### PR TITLE
Descriptions missing on initial load

### DIFF
--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -63,7 +63,9 @@ export default abstract class DatabaseService {
     }
 
     public async prepareSourceMetadata(sourceMetadata: Source): Promise<void> {
-        await this.deleteSourceMetadata();
+        if (sourceMetadata.type && sourceMetadata.uri) {
+            await this.deleteSourceMetadata();
+        }
 
         await this.addDataSource({
             ...sourceMetadata,

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -524,6 +524,9 @@ const addQueryLogic = createLogic({
         // Prepare the data sources ahead of querying against them below
         try {
             await databaseService.prepareDataSources(newQuery.parts.sources);
+            if (newQuery.parts.sourceMetadata) {
+                await databaseService.prepareSourceMetadata(newQuery.parts.sourceMetadata);
+            }
         } catch (err) {
             const errMsg = `Error encountered while preparing data sources (Full error: ${
                 (err as Error).message

--- a/packages/web/src/services/DatabaseServiceWeb.ts
+++ b/packages/web/src/services/DatabaseServiceWeb.ts
@@ -83,7 +83,7 @@ export default class DatabaseServiceWeb extends DatabaseService {
         }
         if (!type || !uri) {
             throw new DataSourcePreparationError(
-                "Data source type and URI are missing",
+                `Data source type and URI are missing for ${dataSource.name}`,
                 dataSource.name
             );
         }


### PR DESCRIPTION
In certain scenarios like when loading a description for the first time the source metadata would fail to load before the actual data sources. This adds some insurance that the metadata source will load first by preparing it whenever the data sources are prepared.

[Try it out here](https://staging.biofile-finder.allencell.org/app)