### PR TITLE
Update various links

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -50,7 +50,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             key: "3d-web-viewer",
             text: "3D Web Viewer",
             title: `Open files with 3D Web Viewer`,
-            href: `https://allen-cell-animated.github.io/website-3d-cell-viewer/?url=${fileDetails?.path}/`,
+            href: `https://volumeviewer.allencell.org/viewer?url=${fileDetails?.cloudPath}/`,
             disabled: !fileDetails?.path,
             target: "_blank",
         },


### PR DESCRIPTION
This changeset updates 3 different kinds of links:

* LabKey Plate UI link to use a different host, resolves #108 
* The viewer links for AICS files to use the S3 bucket instead of NGINX (makes useable in 3D Web Viewer), resolves #174
* Use the production volume viewer link not the github dev version, resolves #163 

Unfortunately, we still have to use the NGINX server for downloads until [this](https://github.com/AllenInstitute/biofile-finder/issues/205) is resolved.

[Try it out here]()