### PR TITLE
Fix splitting on non-strings as annotations

### DIFF
--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -109,7 +109,9 @@ export default class DatabaseAnnotationService implements AnnotationService {
         const rows = await this.databaseService.query(sqlBuilder.toSQL());
         const rowsSplitByDelimiter = rows
             .flatMap((row) =>
-                isNil(row[annotation]) ? [] : row[annotation].split(DatabaseService.LIST_DELIMITER)
+                isNil(row[annotation])
+                    ? []
+                    : `${row[annotation]}`.split(DatabaseService.LIST_DELIMITER)
             )
             .map((value) => value.trim());
         return uniq(rowsSplitByDelimiter);


### PR DESCRIPTION
Antoine noticed a bug where the attached dataset wouldn't display values when grouped by "Used for" + "Gene" + "Pixel Size X". Turns out this is because a spot where we were checking to see if a value was a list we didn't cast the value from the DB into a string first and numbers can't be split like that. I didn't see any other spots where we were doing this so its just the one line changed.

Test it out on staging with the attached CSV
[Dataset_1_V14_V3.csv](https://github.com/user-attachments/files/16590927/Dataset_1_V14_V3.csv)
