### PR TITLE
Remove footer from app and update styling

### DIFF
--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -80,6 +80,7 @@ export default class DatabaseFileService implements FileService {
     }
 
     public async getCountOfMatchingFiles(fileSet: FileSet): Promise<number> {
+        if (!this.dataSourceNames.length) return 0;
         const select_key = "num_files";
         const sql = fileSet
             .toQuerySQLBuilder()
@@ -110,6 +111,7 @@ export default class DatabaseFileService implements FileService {
      * and potentially starting from a particular file_id and limited to a set number of files.
      */
     public async getFiles(request: GetFilesRequest): Promise<FileDetail[]> {
+        if (!this.dataSourceNames.length) return [];
         const sql = request.fileSet
             .toQuerySQLBuilder()
             .from(this.dataSourceNames)

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -80,7 +80,6 @@ export default class DatabaseFileService implements FileService {
     }
 
     public async getCountOfMatchingFiles(fileSet: FileSet): Promise<number> {
-        if (!this.dataSourceNames.length) return 0;
         const select_key = "num_files";
         const sql = fileSet
             .toQuerySQLBuilder()
@@ -111,7 +110,6 @@ export default class DatabaseFileService implements FileService {
      * and potentially starting from a particular file_id and limited to a set number of files.
      */
     public async getFiles(request: GetFilesRequest): Promise<FileDetail[]> {
-        if (!this.dataSourceNames.length) return [];
         const sql = request.fileSet
             .toQuerySQLBuilder()
             .from(this.dataSourceNames)

--- a/packages/web/src/components/Layout/Layout.module.css
+++ b/packages/web/src/components/Layout/Layout.module.css
@@ -13,3 +13,8 @@
   height: calc(100% - 60px);
   overflow-y: auto;
 }
+
+/* App. -15 so row count is included */
+.fill-screen {
+  height: calc(100% - 15px); 
+}

--- a/packages/web/src/components/Layout/index.tsx
+++ b/packages/web/src/components/Layout/index.tsx
@@ -1,5 +1,6 @@
+import classNames from "classnames";
 import * as React from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import Header from "../Header";
 import Footer from "../Footer";
@@ -8,12 +9,14 @@ import styles from "./Layout.module.css";
 
 // Basic wrapper to maintain global header
 export default function Layout() {
+    const currentPath = useLocation().pathname;
+    const isApp: boolean = currentPath == "/app";
     return (
         <div className={styles.root}>
             <Header />
-            <div className={styles.scrollable}>
+            <div className={classNames(isApp ? styles.fillScreen : styles.scrollable)}>
                 <Outlet />
-                <Footer />
+                {!isApp && <Footer />}
             </div>
         </div>
     );


### PR DESCRIPTION
### Context
We only need the cookie settings button available on the web pages, not on the app itself, so removing the footer from /app per recent UX discussions since it's visually annoying

### Changes
Because of the way react router works, /app is tied up with the `Outlet` component that's also used for webpages, so the easiest way to conditionally hide footer is to check the route.

To do: The footer will eventually need some styling updates but leaving as is for now to prioritize other tasks