### PR TITLE
Join url like values into single link

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -216,7 +216,7 @@ export default class FileDetail {
             .reduce(
                 (mapThusFar, annotation) => ({
                     ...mapThusFar,
-                    [annotation.name]: annotation.values[0] as string,
+                    [annotation.name]: annotation.values.join(",") as string,
                 }),
                 {} as { [annotationName: string]: string }
             );


### PR DESCRIPTION
Antoine pointed out that URLs were being truncated sometimes, this is due to URL like annotations potentially containing the list delimiter in them; this assumes that link like annotations need to be combined which relies on the existing expectation that link like annotations can only ever have 1 value AKA shouldn't be lists anyway.