### PR TITLE
Bugfix/fix csv import format

### DIFF
--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -58,7 +58,7 @@
     content: " ";
     height: 50px;
     right: 0;
-    max-width: 100%;
+    max-width: var(--file-details-width);
     position: absolute;
     width: 100%;
     z-index: 11;

--- a/packages/core/components/QueryPart/QueryPartRow.module.css
+++ b/packages/core/components/QueryPart/QueryPartRow.module.css
@@ -72,10 +72,10 @@
     margin: 0;
     display: block;
     padding: 0;
-    overflow-x: hidden;
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    height: unset;
+    height: min-content;
 }
 
 .dynamic-row-title {

--- a/packages/desktop/src/services/DatabaseServiceElectron.ts
+++ b/packages/desktop/src/services/DatabaseServiceElectron.ts
@@ -133,7 +133,7 @@ export default class DatabaseServiceElectron extends DatabaseService {
                 } else {
                     // Default to CSV
                     this.database.exec(
-                        `CREATE TABLE "${name}" AS FROM read_csv_auto('${source}', header=true);`,
+                        `CREATE TABLE "${name}" AS FROM read_csv_auto('${source}', header=true, all_varchar=true);`,
                         callback
                     );
                 }

--- a/packages/web/src/services/DatabaseServiceWeb.ts
+++ b/packages/web/src/services/DatabaseServiceWeb.ts
@@ -116,7 +116,7 @@ export default class DatabaseServiceWeb extends DatabaseService {
             } else {
                 // Default to CSV
                 await this.execute(
-                    `CREATE TABLE "${name}" AS FROM read_csv_auto('${name}', header=true);`
+                    `CREATE TABLE "${name}" AS FROM read_csv_auto('${name}', header=true, all_varchar=true);`
                 );
             }
         } catch (err) {


### PR DESCRIPTION
This bugfix came from Antoine where he was noticing `Clone` could not be grouped by, it seems it was failing bc we don't support querying by numbers very well with the newest regex. We should be importing everything as a varchar anyway since we don't support actually filtering by types outside of AICS data yet; so this changes the import strategy to make everything a varchar by default.

The two styling changes are not relevant but they have been _bugging_ me, they fix the gradient at the bottom of the UI to be back to its original shape (constrained to the file details pane) and make it so Windows users don't see a scrollbar in the query group rows