### PR TITLE
Remove automatic link detection and force users to specify manually

### DIFF
--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -24,7 +24,7 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
         metadata.selectors.getAnnotationNameToAnnotationMap
     );
 
-    const isValueLinkLike = props.value.startsWith("http");
+    const isLink = annotationNameToAnnotationMap[props.name]?.isLink;
 
     const onContextMenuHandlerFactory = (clipboardText: string) => {
         return (evt: React.MouseEvent) => {
@@ -70,7 +70,7 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                 columnKey="value"
                 width={1}
             >
-                {isValueLinkLike ? (
+                {isLink ? (
                     <a
                         className={styles.link}
                         onContextMenu={onContextMenuHandlerFactory(props.value.trim())}

--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -24,7 +24,7 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
         metadata.selectors.getAnnotationNameToAnnotationMap
     );
 
-    const isLink = annotationNameToAnnotationMap[props.name]?.isLink;
+    const isOpenFileLink = annotationNameToAnnotationMap[props.name]?.isOpenFileLink;
 
     const onContextMenuHandlerFactory = (clipboardText: string) => {
         return (evt: React.MouseEvent) => {
@@ -70,7 +70,7 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                 columnKey="value"
                 width={1}
             >
-                {isLink ? (
+                {isOpenFileLink ? (
                     <a
                         className={styles.link}
                         onContextMenu={onContextMenuHandlerFactory(props.value.trim())}

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -13,6 +13,7 @@ export interface AnnotationResponse {
     annotationName: string;
     description: string;
     type: string;
+    isLink?: boolean;
     units?: string;
 }
 
@@ -59,6 +60,10 @@ export default class Annotation {
 
     public get type(): string {
         return this.annotation.type;
+    }
+
+    public get isLink(): boolean {
+        return this.annotation.isLink || false;
     }
 
     public get units(): string | undefined {

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -13,7 +13,7 @@ export interface AnnotationResponse {
     annotationName: string;
     description: string;
     type: string;
-    isLink?: boolean;
+    isOpenFileLink?: boolean;
     units?: string;
 }
 
@@ -62,8 +62,8 @@ export default class Annotation {
         return this.annotation.type;
     }
 
-    public get isLink(): boolean {
-        return this.annotation.isLink || false;
+    public get isOpenFileLink(): boolean {
+        return this.annotation.isOpenFileLink || false;
     }
 
     public get units(): string | undefined {

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import FileDetail from "../../entity/FileDetail";
 import FileFilter from "../../entity/FileFilter";
-import { interaction } from "../../state";
+import { interaction, metadata } from "../../state";
 
 import styles from "./useOpenWithMenuItems.module.css";
 
@@ -15,12 +15,27 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     const isAicsEmployee = useSelector(interaction.selectors.isAicsEmployee);
     const userSelectedApplications = useSelector(interaction.selectors.getUserSelectedApplications);
     const { executionEnvService } = useSelector(interaction.selectors.getPlatformDependentServices);
+    const annotationNameToAnnotationMap = useSelector(
+        metadata.selectors.getAnnotationNameToAnnotationMap
+    );
     const fileExplorerServiceBaseUrl = useSelector(
         interaction.selectors.getFileExplorerServiceBaseUrl
     );
 
     const plateLink = fileDetails?.getLinkToPlateUI(fileExplorerServiceBaseUrl);
-    const annotationNameToLinkMap = fileDetails?.getAnnotationNameToLinkMap() || {};
+    const annotationNameToLinkMap = React.useMemo(
+        () =>
+            fileDetails?.annotations
+                .filter((annotation) => annotationNameToAnnotationMap[annotation.name]?.isLink)
+                .reduce(
+                    (mapThusFar, annotation) => ({
+                        ...mapThusFar,
+                        [annotation.name]: annotation.values.join(",") as string,
+                    }),
+                    {} as { [annotationName: string]: string }
+                ) || {},
+        [fileDetails, annotationNameToAnnotationMap]
+    );
 
     return [
         ...(isEmpty(annotationNameToLinkMap)

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -26,7 +26,9 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     const annotationNameToLinkMap = React.useMemo(
         () =>
             fileDetails?.annotations
-                .filter((annotation) => annotationNameToAnnotationMap[annotation.name]?.isLink)
+                .filter(
+                    (annotation) => annotationNameToAnnotationMap[annotation.name]?.isOpenFileLink
+                )
                 .reduce(
                     (mapThusFar, annotation) => ({
                         ...mapThusFar,

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -14,10 +14,10 @@ export default abstract class DatabaseService {
     public static readonly LIST_DELIMITER = ",";
     // THIS CAN NEVER CHANGE, THIS VALUE IS INCLUDED IN THE EMT DATA RELEASE
     // AS A MARKER FOR WHAT IS AN ACTUAL LINK
-    private static readonly LINK_TYPE = "Link";
+    private static readonly OPEN_FILE_LINK_TYPE = "Open file link";
     private static readonly ANNOTATION_TYPE_SET = new Set([
         ...Object.values(AnnotationType),
-        DatabaseService.LINK_TYPE,
+        DatabaseService.OPEN_FILE_LINK_TYPE,
     ]);
     private currentAggregateSource?: string;
     // Initialize with AICS FMS data source name to pretend it always exists
@@ -178,12 +178,12 @@ export default abstract class DatabaseService {
                         annotationName: row["column_name"],
                         annotationDisplayName: row["column_name"],
                         description: annotationNameToDescriptionMap[row["column_name"]] || "",
-                        isLink:
+                        isOpenFileLink:
                             annotationNameToTypeMap[row["column_name"]] ===
-                            DatabaseService.LINK_TYPE,
+                            DatabaseService.OPEN_FILE_LINK_TYPE,
                         type:
                             annotationNameToTypeMap[row["column_name"]] ===
-                            DatabaseService.LINK_TYPE
+                            DatabaseService.OPEN_FILE_LINK_TYPE
                                 ? AnnotationType.STRING
                                 : annotationNameToTypeMap[row["column_name"]] ||
                                   DatabaseService.columnTypeToAnnotationType(row["data_type"]),

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -12,8 +12,9 @@ import SQLBuilder from "../../entity/SQLBuilder";
 export default abstract class DatabaseService {
     protected readonly SOURCE_METADATA_TABLE = "source_metadata";
     public static readonly LIST_DELIMITER = ",";
-    // THIS CAN NEVER CHANGE, THIS VALUE IS INCLUDED IN THE EMT DATA RELEASE
-    // AS A MARKER FOR WHAT IS AN ACTUAL LINK
+    // "Open file link" as a datatype must be hardcoded, and CAN NOT change
+    // without BREAKING visibility in the dataset released in 2024 as part
+    // of the EMT Data Release paper
     private static readonly OPEN_FILE_LINK_TYPE = "Open file link";
     private static readonly ANNOTATION_TYPE_SET = new Set([
         ...Object.values(AnnotationType),


### PR DESCRIPTION
## Backstory
Antoine requested that some "link-like" annotation values not be displayed as links and not be provided in the open-with menu. We were just assuming any value starting with "http" was a link, but that wasn't specific enough for this use case since these are download links that are just for programmatic use.

## Description
This forces users to supply the data type in the additional metadata CSV alongside the optional descriptions rather than assuming any "http" value is a link

## Testing Data
Here is his image data CSV and the related description CSV:
[image_data.csv](https://github.com/user-attachments/files/16619804/imaging_and_segmentation_data_FOR_Matheus_test.csv)
[description.csv](https://github.com/user-attachments/files/16627513/Imaging_and_segmentation_data_column_definition.csv)



## Open questions
* ~Does this cause us to miss out on an easy opportunity to render links for people~ _**After some more thinking, we could always go back to treating everything as a link, this new way of doing things is actually more conservative so it would be compatible**_
* ~Should we be even more specific like "Open link" and "Download link" as the types or is that an over-complication?~ **_Had another meeting where this was dubbed to be the more future-proof decision._** see https://github.com/AllenInstitute/biofile-finder/pull/218/commits/d083aa20a15876c6a69dc0d9aaa5ceada05790bf
