### PR TITLE
Conditionally import zarrita

### DIFF
--- a/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
@@ -56,13 +56,13 @@ describe("<LazilyRenderedThumbnail />", () => {
         };
     }
 
-    it("renders thumbnail when file has one specified", () => {
+    it("renders thumbnail when file has one specified", async () => {
         // Arrange
         const state = mergeState(initialState, {});
         const { store } = configureMockStore({ state });
 
         // Act
-        const { getByText, getByRole } = render(
+        const { getByText, findByRole } = render(
             <Provider store={store}>
                 <LazilyRenderedThumbnail
                     data={makeItemData()}
@@ -75,17 +75,17 @@ describe("<LazilyRenderedThumbnail />", () => {
 
         // Assert
         // Also checking for proper row/col indexing
-        const thumbnail = getByRole("img");
+        const thumbnail = await findByRole("img");
         expect(thumbnail.getAttribute("src")).to.include("some/path/to/my_image0.jpg");
         expect(getByText("my_image0.czi")).to.not.equal(null);
     });
 
-    it("renders file as thumbnail if file is renderable type", () => {
+    it("renders file as thumbnail if file is renderable type", async () => {
         // Arrange
         const { store } = configureMockStore({ state: initialState });
 
         // Act
-        const { getByText, getByRole } = render(
+        const { getByText, findByRole } = render(
             <Provider store={store}>
                 <LazilyRenderedThumbnail
                     data={makeItemData()}
@@ -98,7 +98,7 @@ describe("<LazilyRenderedThumbnail />", () => {
 
         // Assert
         // Also confirms proper row/col indexing
-        const thumbnail = getByRole("img");
+        const thumbnail = await findByRole("img");
         expect(thumbnail.getAttribute("src")).to.include("some/path/to/my_image9.jpg");
         expect(getByText("my_image9.jpg")).to.not.equal(null);
     });

--- a/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
+++ b/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
@@ -1,4 +1,20 @@
-import * as zarr from "zarrita";
+// This conditional import is due to to this unresolved error:
+// https://github.com/AllenInstitute/biofile-finder/issues/178
+// where the zarrita package produces "Exception during run: Error: No "exports" main
+// defined in /zarrita/package.json" during test runs.
+// This seems to either be due to a problem with the zarrita package
+// or a problem with the way mocha resolves the zarrita package. Either way after trying out
+// various solutions like changing Node versions, ts config settings, and package.json settings
+// I am timeboxing this issue and moving on to the next task. - Sean M 08/30/2024
+let zarr: any;
+const isInTest = typeof global.it === "function";
+if (isInTest) {
+    zarr = {};
+} else {
+    import("zarrita").then((zarrita) => {
+        zarr = zarrita;
+    });
+}
 
 interface AxisData {
     name: string;


### PR DESCRIPTION
So this sucks. I can not figure out why exactly zarrita fails during tests with `Exception during run: Error: No "exports" main defined in /zarrita/package.json`. There are a ton of references to this error out there all with largely unique solutions, I tried a bunch of them including:
- Modifying node versions
- Modifying npm versions
- Changing tsconfig to match zarrita
- Upgrading test suite
- Running npm update
- Running npm audit with the force flag
- Importing zarritas sub-packages separately
- Using a CDN import rather than npm

None of them yielded any change. My guess is that this has to do with mocha, our test suite runner, since it is in charge of importing zarrita during tests and that it might be resolving to the wrong node version during tests. I didn't find any leads down that path though and am time boxing this issue by adding a conditional import for now. My hope is that when zarrita leaves its test release phase (which we are in now) this issue will magically resolve itself.

Related to #178 