### PR TITLE
Supply path as url arg to agave

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -110,7 +110,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                 className: styles.agaveLink,
                 text: "AGAVE",
                 title: `Open files with AGAVE`,
-                href: `agave://${fileDetails?.path}`,
+                href: `agave://?url=${fileDetails?.path}`,
                 disabled: !fileDetails?.path,
                 target: "_blank",
                 onRenderContent(props, defaultRenders) {


### PR DESCRIPTION
Dan updated AGAVE to fix/add support for opening from BFF. This change makes the file path a "url" argument to the protocol handler (necessary for AGAVE).

Resolves #231 

Corresponding AGAVE build:
https://github.com/allen-cell-animated/agave/actions/runs/10739707159