### PR TITLE
Bugfix/fix broken font

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
         <meta name="author" content="AICS Software">
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..700;1,300..600&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Raleway:wght@100..600&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="styles.css?v=1.0">
     </head>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,8 +7,9 @@
         <title>BioFile Finder</title>
         <meta name="description" content="BioFile Finder">
         <meta name="author" content="AICS Software">
-
-        <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Raleway:wght@0..600&display=swap" rel="stylesheet">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..700;1,300..600&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="styles.css?v=1.0">
     </head>
 

--- a/packages/core/components/Buttons/BaseButton.module.css
+++ b/packages/core/components/Buttons/BaseButton.module.css
@@ -25,7 +25,7 @@
 
 .button-text {
     font-weight: 600;
-    overflow-x: hidden;
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }

--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -54,7 +54,6 @@
 }
 
 .title {
-    font-weight: 100;
     margin-bottom: 30px;
 }
 

--- a/packages/core/components/Modal/BaseModal/BaseModal.module.css
+++ b/packages/core/components/Modal/BaseModal/BaseModal.module.css
@@ -33,7 +33,6 @@
 
 .title {
     display: inline-block;
-    font-weight: bold;
     margin: 0;
 
     /* flex child */

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -38,9 +38,9 @@ export default function BaseModal(props: BaseModalProps) {
         >
             <div className={styles.header}>
                 {title ? (
-                    <h3 className={styles.title} id={titleId}>
+                    <h2 className={styles.title} id={titleId}>
                         {title}
-                    </h3>
+                    </h2>
                 ) : null}
                 <TertiaryButton iconName="Cancel" onClick={onDismiss} title="Close" />
             </div>

--- a/packages/core/styles/global.css
+++ b/packages/core/styles/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0..800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..700;1,300..600&display=swap');
 
 html {
     box-sizing: border-box;

--- a/packages/desktop/webpack/index.html
+++ b/packages/desktop/webpack/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/packages/web/src/components/Home/Home.module.css
+++ b/packages/web/src/components/Home/Home.module.css
@@ -89,6 +89,10 @@
     padding: var(--margin);
 }
 
+.option-header {
+    min-height: 56px;
+}
+
 .option-button {
     margin: auto;
     width: 166px

--- a/packages/web/src/components/Home/index.tsx
+++ b/packages/web/src/components/Home/index.tsx
@@ -110,7 +110,7 @@ export default function Home() {
                                 )}
                             >
                                 <div className={styles.option} key={`option_${index}`}>
-                                    <div className={styles.optionHeader}>{option.header}</div>
+                                    <h3 className={styles.optionHeader}>{option.header}</h3>
                                     <div className={styles.optionBody}>{option.body}</div>
                                     {option.action}
                                 </div>

--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
@@ -20,6 +20,7 @@
 }
 
 .button-wrapper {
+  pointer-events: none;
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/web/webpack/index.html
+++ b/packages/web/webpack/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
### Context
Even though we had Open Sans listed in our stylesheet, Chrome and other browsers were actually rendering their default sans fonts (in my case, Helvetica). We were apparently using a broken stylesheet link in `global.css`, so network call was failing. 

closes #235 

### Changes
- Replaced current .css import link with one recommended by the [Google Font API](https://fonts.google.com/selection/embed). 
- Also updated the embed in `docs/index.html` to match Google API rec for good measure. We use fewer styling options in docs, so don't need the full `ital` etc link used in `global.css`
- Updated a couple minor font styling issues, and added the lang tag to our html files.

### Screenshots
Before & after (ignore weird cropping, margins are the same)
<img width="1180" alt="Home page before font changes" src="https://github.com/user-attachments/assets/7c9b2582-36bf-4916-971e-1e59f4a13bb0">
<img width="1226" alt="Home page after font changes" src="https://github.com/user-attachments/assets/afaf5822-cc9f-4eac-85f4-69d74714b815">