### PR TITLE
Feature/default cloudpath zarrs

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -128,6 +128,7 @@ export default class FileDetail {
         // For AICS files we don't have permission to the bucket nor do we expect to have the /allen
         // drive mounted on the client machine. So we use the NGINX server to serve the file.
 
+        // Always try to use cloudpath for zarrs.
         if (this.path.endsWith(".zarr")) {
             return this.cloudPath;
         }

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -127,6 +127,11 @@ export default class FileDetail {
     public get downloadPath(): string {
         // For AICS files we don't have permission to the bucket nor do we expect to have the /allen
         // drive mounted on the client machine. So we use the NGINX server to serve the file.
+
+        if (this.path.endsWith(".zarr")) {
+            return this.cloudPath;
+        }
+
         if (this.path.startsWith("/allen")) {
             return `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${this.path}`;
         }


### PR DESCRIPTION
## Description 
 This PR defaults to using the cloudpath for zarr files. If the cloudpath does not exist it will fall back to path.

### Related Issues
Resolves #244. 