### PR TITLE
Enable clicking through gradient

### DIFF
--- a/packages/core/components/DirectoryTree/DirectoryTree.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTree.module.css
@@ -11,6 +11,7 @@
     height: 100%;
     right: 0;
     position: absolute;
+    pointer-events: none;
     width: 60px;
     z-index: 11;
 }


### PR DESCRIPTION
Simple change to make the gradient seen below not prevent clicking on the scrollbar or the file rows beneath it. Resolves #169 
<img width="232" alt="Screen Shot 2024-09-23 at 4 14 07 PM" src="https://github.com/user-attachments/assets/57ba9003-aff5-4e50-ac61-acd51b000ab2">
