### PR TITLE
Switch to new download button

### DIFF
--- a/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
+++ b/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
@@ -1,15 +1,3 @@
 .download-button {
-    border: none;
-    background-color: var(--secondary-background-color);
-    color: var(--secondary-text-color);
-}
-
-.disabled {
-    opacity: 0.5;
-}
-
-.download-button:hover:not(.disabled), .download-button:active:not(.disabled), .download-button:focus:not(.disabled)  {
-    border: none;
-    background-color: var(--highlight-background-color);
-    color: var(--highlight-text-color);
+    width: 135px;
 }

--- a/packages/core/components/Modal/MetadataManifest/index.tsx
+++ b/packages/core/components/Modal/MetadataManifest/index.tsx
@@ -1,11 +1,10 @@
-import { PrimaryButton } from "@fluentui/react";
-import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { ModalProps } from "..";
 import BaseModal from "../BaseModal";
 import AnnotationPicker from "../../AnnotationPicker";
+import { PrimaryButton } from "../../Buttons";
 import { interaction, metadata } from "../../../state";
 
 import styles from "./MetadataManifest.module.css";
@@ -58,13 +57,12 @@ export default function MetadataManifest({ onDismiss }: ModalProps) {
             body={body}
             footer={
                 <PrimaryButton
-                    className={classNames(styles.downloadButton, {
-                        [styles.disabled]: !selectedAnnotations.length,
-                    })}
-                    iconProps={{ iconName: "Download" }}
+                    className={styles.downloadButton}
                     disabled={!selectedAnnotations.length}
+                    iconName="Download"
                     onClick={onDownload}
-                    text="Download"
+                    text="DOWNLOAD"
+                    title="Download"
                 />
             }
             onDismiss={onDismiss}


### PR DESCRIPTION
This button never got updated to the new button styling, resolves #175 

Old
<img width="595" alt="Screen Shot 2024-09-23 at 4 34 21 PM" src="https://github.com/user-attachments/assets/dc35124a-8780-4045-9653-ae06d9905666">

New
<img width="620" alt="Screen Shot 2024-09-23 at 4 34 37 PM" src="https://github.com/user-attachments/assets/09ce99e9-0e48-4146-89fa-5eed7f697d89">

