### PR TITLE
Feature/update special filter modal ux

### DIFF
--- a/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
+++ b/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
@@ -19,10 +19,6 @@
     padding-bottom: 16px;
 }
 
-.choice-group {
-    margin-bottom: 6px;
-}
-
 .footer {
     background-color: var(--primary-background-color);
     padding: 16px 30px 16px;

--- a/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
+++ b/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
@@ -5,6 +5,27 @@
 .loading-container, .picker {
     background-color: var(--primary-background-color);
     color: var(--primary-text-color);
-    padding: 16px 30px;
+    padding: 0 30px 16px;
     width: 35vw;
+}
+
+.header {
+    background-color: var(--primary-background-color);
+    padding: 16px 30px 0;
+    width: 35vw;
+}
+
+.header > h3 {
+    padding-bottom: 16px;
+}
+
+.choice-group {
+    margin-bottom: 6px;
+}
+
+.footer {
+    background-color: var(--primary-background-color);
+    padding: 16px 30px 16px;
+    width: 35vw;
+    font-style: italic;
 }

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
@@ -1,8 +1,6 @@
-import { ChoiceGroup } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
-import ListPicker from "../../ListPicker";
 import { ListItem } from "../../ListPicker/ListRow";
 import SearchBox from "../../SearchBox";
 import FileFilter from "../../../entity/FileFilter";
@@ -11,11 +9,11 @@ import styles from "./SearchBoxForm.module.css";
 
 interface SearchBoxFormProps {
     className?: string;
-    items: ListItem[];
+    items?: ListItem[];
     title?: string;
-    onDeselect: (item: ListItem) => void;
+    onDeselect?: (item: ListItem) => void;
     onDeselectAll: () => void;
-    onSelect: (item: ListItem) => void;
+    onSelect?: (item: ListItem) => void;
     onSelectAll: () => void;
     onSearch: (filterValue: string) => void;
     fieldName: string;
@@ -24,57 +22,18 @@ interface SearchBoxFormProps {
 
 /**
  * This component renders a simple form for searching on text values
- * or selecting indiviudal items via the ListPicker
  */
 export default function SearchBoxForm(props: SearchBoxFormProps) {
-    const [isListPicking, setIsListPicking] = React.useState(false);
-
     return (
         <div className={classNames(props.className, styles.container)}>
             <h3 className={styles.title}>{props.title}</h3>
-            <ChoiceGroup
-                className={styles.choiceGroup}
-                label="Filter type"
-                defaultSelectedKey={isListPicking ? "list-picker" : "search-box"}
-                options={[
-                    {
-                        key: "search-box",
-                        text: "Search box",
-                    },
-                    {
-                        key: "list-picker",
-                        text: "List picker",
-                        disabled: props.items.length === 0,
-                    },
-                ]}
-                onChange={(_, selection) => {
-                    // Clear the selection if the user switches to the search box
-                    // and the default value is not in the list (i.e. not deselectable)
-                    if (props.defaultValue && !props.items.some((item) => item.selected)) {
-                        props.onDeselectAll();
-                    }
-                    setIsListPicking(selection?.key === "list-picker");
-                }}
+            <SearchBox
+                defaultValue={props.defaultValue}
+                onReset={props.onDeselectAll}
+                onSearch={props.onSearch}
+                placeholder={"Search..."}
+                showSubmitButton={true}
             />
-            {isListPicking ? (
-                <ListPicker
-                    className={styles.listPicker}
-                    items={props.items}
-                    onDeselect={props.onDeselect}
-                    onDeselectAll={props.onDeselectAll}
-                    onSelect={props.onSelect}
-                    onSelectAll={props.onSelectAll}
-                />
-            ) : (
-                <div data-is-focusable="true">
-                    <SearchBox
-                        defaultValue={props.defaultValue}
-                        onReset={props.onDeselectAll}
-                        onSearch={props.onSearch}
-                        placeholder={`Search by ${props.fieldName}`}
-                    />
-                </div>
-            )}
         </div>
     );
 }

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/test/SearchBoxForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/test/SearchBoxForm.test.tsx
@@ -6,7 +6,8 @@ import * as React from "react";
 import SearchBoxForm from "..";
 
 describe("<SearchBoxForm/>", () => {
-    it("renders a list picker when 'List picker' option is selection", () => {
+    // TODO: Update with the fuzzy search toggle when filters are complete
+    it.skip("renders a list picker when 'List picker' option is selection", () => {
         // Act
         const { getByText, getByTestId } = render(
             <SearchBoxForm

--- a/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
@@ -12,6 +12,7 @@ import { initialState, reducer, reduxLogics, interaction, selection } from "../.
 import HttpAnnotationService from "../../../services/AnnotationService/HttpAnnotationService";
 
 describe("<AnnotationFilterForm />", () => {
+    const LISTROW_TESTID_PREFIX = "default-button-";
     describe("Text annotations", () => {
         // setup
         const fooAnnotation = new Annotation({
@@ -93,25 +94,27 @@ describe("<AnnotationFilterForm />", () => {
             });
 
             // act
-            const { getByText } = render(
+            const { getByTestId } = render(
                 <Provider store={store}>
                     <AnnotationFilterForm annotation={fooAnnotation} />
                 </Provider>
             );
-            await waitFor(() => expect(getByText("b")).to.not.be.undefined);
+            await waitFor(
+                () => expect(getByTestId(`${LISTROW_TESTID_PREFIX}b`)).to.not.be.undefined
+            );
 
             // (sanity-check): Check that the "b" input is selected
             expect(selection.selectors.getFileFilters(store.getState())).to.be.lengthOf(1);
 
             // Act: Deselect the "False" input
-            fireEvent.click(getByText("b"));
+            fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}b`));
             await logicMiddleware.whenComplete();
 
             // Assert: Check that the "b" input is deselected
             expect(selection.selectors.getFileFilters(store.getState())).to.be.lengthOf(0);
 
             // Act: Reselect the "b" input
-            fireEvent.click(getByText("b"));
+            fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}b`));
             await logicMiddleware.whenComplete();
 
             // Assert: Check that the "False" input is selected again
@@ -150,10 +153,11 @@ describe("<AnnotationFilterForm />", () => {
             expect(annotationValueListItems.length).to.equal(4);
             const expectedOrder = ["AICS-0", "aICs-2", "AICS-24", "aics-32"];
             annotationValueListItems.forEach((listItem, index) => {
-                const { getByText } = within(listItem);
+                const { getByTestId } = within(listItem);
 
                 // getByLabelText will throw if it can't find a matching node
-                expect(getByText(expectedOrder[index])).to.not.be.undefined;
+                expect(getByTestId(`${LISTROW_TESTID_PREFIX}${expectedOrder[index]}`)).to.not.be
+                    .undefined;
             });
         });
     });
@@ -230,25 +234,27 @@ describe("<AnnotationFilterForm />", () => {
                 responseStubs: responseStub,
             });
             // Act
-            const { getByText } = render(
+            const { getByTestId } = render(
                 <Provider store={store}>
                     <AnnotationFilterForm annotation={fooAnnotation} />
                 </Provider>
             );
-            await waitFor(() => expect(getByText("False")).to.not.be.undefined);
+            await waitFor(
+                () => expect(getByTestId(`${LISTROW_TESTID_PREFIX}False`)).to.not.be.undefined
+            );
 
             // (sanity-check): Check that the "False" input is selected
             expect(selection.selectors.getFileFilters(store.getState())).to.be.lengthOf(1);
 
             // Act: Deselect the "False" input
-            fireEvent.click(getByText("False"));
+            fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}False`));
             await logicMiddleware.whenComplete();
 
             // Assert: Check that the "False" input is deselected
             expect(selection.selectors.getFileFilters(store.getState())).to.be.lengthOf(0);
 
             // Act: Reselect the "False" input
-            fireEvent.click(getByText("False"));
+            fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}False`));
             await logicMiddleware.whenComplete();
 
             // Assert: Check that the "False" input is selected again
@@ -302,10 +308,11 @@ describe("<AnnotationFilterForm />", () => {
             expect(annotationValueListItems.length).to.equal(6);
             const expectedOrder = [-12, 0, 5, 6.3, 8, 10000000000];
             annotationValueListItems.forEach((listItem, index) => {
-                const { getByText } = within(listItem);
+                const { getByTestId } = within(listItem);
 
                 // getByLabelText will throw if it can't find a matching node
-                expect(getByText(String(expectedOrder[index]))).to.not.be.undefined;
+                expect(getByTestId(`${LISTROW_TESTID_PREFIX}${expectedOrder[index]}`)).to.not.be
+                    .undefined;
             });
         });
     });
@@ -354,10 +361,10 @@ describe("<AnnotationFilterForm />", () => {
             const annotationValueListItems = await findAllByRole("listitem");
 
             expect(annotationValueListItems.length).to.equal(4);
-            expect(annotationValueListItems[0].textContent).to.equal("0.125S");
-            expect(annotationValueListItems[1].textContent).to.equal("3H 45S");
-            expect(annotationValueListItems[2].textContent).to.equal("1D");
-            expect(annotationValueListItems[3].textContent).to.equal("5D 4H 3M 2.22S");
+            expect(annotationValueListItems[0].textContent).to.contain("0.125S");
+            expect(annotationValueListItems[1].textContent).to.contain("3H 45S");
+            expect(annotationValueListItems[2].textContent).to.contain("1D");
+            expect(annotationValueListItems[3].textContent).to.contain("5D 4H 3M 2.22S");
         });
     });
 });

--- a/packages/core/components/DataSourcePrompt/FilePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.module.css
@@ -84,3 +84,7 @@
 .url-form > div > div > div {
     background-color: unset;
 }
+
+.url-form > div > div > div::after {
+    border: 1px solid var(--aqua);
+}

--- a/packages/core/components/DateRangePicker/DateRangePicker.module.css
+++ b/packages/core/components/DateRangePicker/DateRangePicker.module.css
@@ -1,35 +1,62 @@
-.clear-button, .clear-button i {
-    background-color: var(--secondary-background-color);
-    border-radius: var(--small-border-radius);
+.clear-button {
+    height: 30px;
+    width: 30px;
+}
+
+.clear-button, .clear-button span, .clear-button i {
     color: var(--secondary-text-color);
-    margin-left: 2px;
+}
+
+.clear-button, .clear-button i {
+    background-color: var(--secondary-background-color) !important;
+    font-size: var(--s-paragraph-size);
+    margin: 2px 5px;
+
 }
 
 .clear-button:hover, .clear-button:hover i {
-    background-color: var(--highlight-background-color);
-    color: var(--highlight-text-color);
+    background-color: var(--highlight-background-color) !important;
+    color: var(--highlight-text-color) !important;
+    cursor: pointer;
 }
 
 .date-range-container {
     display: flex;
-    justify-content: space-between;
 }
 
 .date-range-separator {
     align-items: center;
     display: flex;
     font-size: small;
-    margin: 0 2px;
+    margin: 0 10px 8px;
 }
 
-.filter-input div {
+.date-range-root {
+    flex-grow: 1;
+}
+
+.text-field div {
     background-color: var(--secondary-background-color);
     border: none;
     border-radius: var(--small-border-radius);
-    color: var(--secondary-text-color);
+    color: var(--primary-text-color);
+}
+
+.text-field div::after {    
+    border: 1px solid var(--aqua)
+}
+
+.text-field > div {
+    border: 1px solid var(--border-color)
 }
 
 .title {
     margin: 0;
     padding-bottom: var(--margin);
+}
+
+.read-only-placeholder {
+    margin-right: 20px;
+    font-style: italic;
+    color: var(--primary-text-color);
 }

--- a/packages/core/components/DateRangePicker/index.tsx
+++ b/packages/core/components/DateRangePicker/index.tsx
@@ -70,8 +70,11 @@ export default function DateRangePicker(props: DateRangePickerProps) {
             <h3 className={styles.title}>{props.title}</h3>
             <div className={styles.dateRangeContainer}>
                 <DatePicker
-                    borderless
-                    textField={{ className: styles.filterInput }}
+                    styles={{
+                        root: styles.dateRangeRoot,
+                        readOnlyPlaceholder: styles.readOnlyPlaceholder,
+                        textField: styles.textField,
+                    }}
                     ariaLabel="Select a start date"
                     placeholder={`Start of date range`}
                     onSelectDate={(v) => (v ? onDateRangeSelection(v, null) : onReset())}
@@ -81,8 +84,11 @@ export default function DateRangePicker(props: DateRangePickerProps) {
                     <Icon iconName="Forward" />
                 </div>
                 <DatePicker
-                    borderless
-                    className={styles.filterInput}
+                    styles={{
+                        root: styles.dateRangeRoot,
+                        readOnlyPlaceholder: styles.readOnlyPlaceholder,
+                        textField: styles.textField,
+                    }}
                     ariaLabel="Select an end date"
                     placeholder={`End of date range`}
                     onSelectDate={(v) => (v ? onDateRangeSelection(null, v) : onReset())}

--- a/packages/core/components/ListPicker/ListPicker.module.css
+++ b/packages/core/components/ListPicker/ListPicker.module.css
@@ -45,7 +45,8 @@
     max-width: 100%;
     position: absolute;
     width: 100%;
-    z-index: 10
+    z-index: 10;
+    pointer-events: none;
 }
 
 .footer {

--- a/packages/core/components/ListPicker/ListRow.tsx
+++ b/packages/core/components/ListPicker/ListRow.tsx
@@ -55,6 +55,7 @@ export default function ListRow(props: Props) {
                     iconName: props.subMenuRenderer && !item.isDivider ? "ChevronRight" : undefined,
                 }}
                 menuProps={props.subMenuRenderer ? buttonMenu : undefined}
+                data-testid={`default-button-${item.displayValue}`}
                 disabled={item.disabled}
                 onClick={() => (item.selected ? props.onDeselect(item) : props.onSelect(item))}
             >

--- a/packages/core/components/ListPicker/ListRow.tsx
+++ b/packages/core/components/ListPicker/ListRow.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { useButtonMenu } from "../Buttons";
+import Tooltip from "../Tooltip";
 import { AnnotationValue } from "../../services/AnnotationService";
 
 import styles from "./ListRow.module.css";
@@ -56,13 +57,14 @@ export default function ListRow(props: Props) {
             disabled={item.disabled}
             onClick={() => (item.selected ? props.onDeselect(item) : props.onSelect(item))}
         >
-            <label
-                className={styles.item}
-                title={`${item.displayValue}${item.description ? `: ${item.description}` : ""}`}
+            <Tooltip
+                content={`${item.displayValue}${item.description ? `: ${item.description}` : ""}`}
             >
-                <div>{item.selected && <Icon iconName="CheckMark" />}</div>
-                <p>{item.displayValue}</p>
-            </label>
+                <label className={styles.item}>
+                    <div>{item.selected && <Icon iconName="CheckMark" />}</div>
+                    <p>{item.displayValue}</p>
+                </label>
+            </Tooltip>
             {item.recent && <Icon iconName="Recent" />}
             {item.loading && <Spinner className={styles.spinner} size={SpinnerSize.small} />}
         </DefaultButton>

--- a/packages/core/components/ListPicker/ListRow.tsx
+++ b/packages/core/components/ListPicker/ListRow.tsx
@@ -63,7 +63,7 @@ export default function ListRow(props: Props) {
                 <div>{item.selected && <Icon iconName="CheckMark" />}</div>
                 <p>{item.displayValue}</p>
             </label>
-            {item.recent && <Icon iconName="Redo" />}
+            {item.recent && <Icon iconName="Recent" />}
             {item.loading && <Spinner className={styles.spinner} size={SpinnerSize.small} />}
         </DefaultButton>
     );

--- a/packages/core/components/ListPicker/ListRow.tsx
+++ b/packages/core/components/ListPicker/ListRow.tsx
@@ -44,29 +44,27 @@ export default function ListRow(props: Props) {
     }
 
     return (
-        <DefaultButton
-            className={classNames(styles.itemContainer, {
-                [styles.selected]: item.selected,
-                [styles.disabled]: item.disabled,
-                [styles.divider]: item.isDivider,
-            })}
-            menuIconProps={{
-                iconName: props.subMenuRenderer && !item.isDivider ? "ChevronRight" : undefined,
-            }}
-            menuProps={props.subMenuRenderer ? buttonMenu : undefined}
-            disabled={item.disabled}
-            onClick={() => (item.selected ? props.onDeselect(item) : props.onSelect(item))}
-        >
-            <Tooltip
-                content={`${item.displayValue}${item.description ? `: ${item.description}` : ""}`}
+        <Tooltip content={`${item.displayValue}${item.description ? `: ${item.description}` : ""}`}>
+            <DefaultButton
+                className={classNames(styles.itemContainer, {
+                    [styles.selected]: item.selected,
+                    [styles.disabled]: item.disabled,
+                    [styles.divider]: item.isDivider,
+                })}
+                menuIconProps={{
+                    iconName: props.subMenuRenderer && !item.isDivider ? "ChevronRight" : undefined,
+                }}
+                menuProps={props.subMenuRenderer ? buttonMenu : undefined}
+                disabled={item.disabled}
+                onClick={() => (item.selected ? props.onDeselect(item) : props.onSelect(item))}
             >
                 <label className={styles.item}>
                     <div>{item.selected && <Icon iconName="CheckMark" />}</div>
                     <p>{item.displayValue}</p>
                 </label>
-            </Tooltip>
-            {item.recent && <Icon iconName="Recent" />}
-            {item.loading && <Spinner className={styles.spinner} size={SpinnerSize.small} />}
-        </DefaultButton>
+                {item.recent && <Icon iconName="Recent" />}
+                {item.loading && <Spinner className={styles.spinner} size={SpinnerSize.small} />}
+            </DefaultButton>
+        </Tooltip>
     );
 }

--- a/packages/core/components/ListPicker/index.tsx
+++ b/packages/core/components/ListPicker/index.tsx
@@ -175,8 +175,7 @@ export default function ListPicker(props: ListPickerProps) {
             </div>
             <div className={styles.footer}>
                 <p>
-                    {/* (item.length -1) to account for buffer in item list. */}
-                    Displaying {filteredItems.length - 1} of {items.length - 1} Options
+                    Displaying {filteredItems.length} of {items.length} Options
                 </p>
             </div>
         </div>

--- a/packages/core/components/ListPicker/test/ListPicker.test.tsx
+++ b/packages/core/components/ListPicker/test/ListPicker.test.tsx
@@ -8,6 +8,7 @@ import ListPicker from "..";
 import { ListItem } from "../ListRow";
 
 describe("<ListPicker />", () => {
+    const LISTROW_TESTID_PREFIX = "default-button-";
     it("renders a list of items that are selectable and deselectable", () => {
         // Arrange
         const onSelect = sinon.spy();
@@ -19,7 +20,7 @@ describe("<ListPicker />", () => {
         }));
 
         // Act / Assert
-        const { getAllByRole, getByText } = render(
+        const { getAllByRole, getByTestId } = render(
             <ListPicker
                 items={items}
                 onDeselect={onDeselect}
@@ -32,7 +33,7 @@ describe("<ListPicker />", () => {
         expect(getAllByRole("button")).to.be.lengthOf(3);
 
         // Trigger selection for the item that isn't selected
-        fireEvent.click(getByText("foo"));
+        fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}foo`));
         expect(onDeselect.called).to.be.false;
         expect(onSelect.called).to.be.true;
 
@@ -40,7 +41,7 @@ describe("<ListPicker />", () => {
         // (reset spies first to isolate assertions)
         onDeselect.resetHistory();
         onSelect.resetHistory();
-        fireEvent.click(getByText("bar"));
+        fireEvent.click(getByTestId(`${LISTROW_TESTID_PREFIX}bar`));
         expect(onDeselect.called).to.be.true;
         expect(onSelect.called).to.be.false;
     });
@@ -56,7 +57,7 @@ describe("<ListPicker />", () => {
         }));
 
         // Act / Assert
-        const { getByText, getByRole } = render(
+        const { getByTestId, getByRole } = render(
             <ListPicker
                 items={items}
                 onDeselect={onDeselect}
@@ -66,8 +67,8 @@ describe("<ListPicker />", () => {
         );
 
         // Should render both list items
-        expect(getByText("foo")).to.not.be.undefined;
-        expect(getByText("bar")).to.not.be.undefined;
+        expect(getByTestId(`${LISTROW_TESTID_PREFIX}foo`)).to.not.be.undefined;
+        expect(getByTestId(`${LISTROW_TESTID_PREFIX}bar`)).to.not.be.undefined;
 
         // Trigger a search
         fireEvent.change(getByRole("searchbox"), {
@@ -75,8 +76,8 @@ describe("<ListPicker />", () => {
                 value: "foo",
             },
         });
-        expect(getByText("foo")).to.not.be.undefined;
-        expect(() => getByText("bar")).to.throw();
+        expect(getByTestId(`${LISTROW_TESTID_PREFIX}foo`)).to.not.be.undefined;
+        expect(() => getByTestId(`${LISTROW_TESTID_PREFIX}bar`)).to.throw();
     });
 
     it("Renders a 'Reset' button that deselects entire selection", () => {

--- a/packages/core/components/ListPicker/test/ListPicker.test.tsx
+++ b/packages/core/components/ListPicker/test/ListPicker.test.tsx
@@ -201,6 +201,6 @@ describe("<ListPicker />", () => {
         );
 
         // Act / Assert
-        expect(getByText(`Displaying ${items.length - 1} of ${items.length - 1} Options`)).to.exist;
+        expect(getByText(`Displaying ${items.length} of ${items.length} Options`)).to.exist;
     });
 });

--- a/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
+++ b/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
@@ -1,45 +1,47 @@
-.buttons {
-    clear: both;
-    display: flex;
-    justify-content: center;
-    padding-top: var(--margin);
-}
-
 .footer {
+    display: flex;
     width: 100%;
-}
-
-.footer > h6 {
-    font-size: smaller;
+    font-size: var(--xs-paragraph-size);
     font-weight: normal;
-    margin: var(--margin) 0 0 0;
+    margin: calc(2*var(--margin)) 0 0 0;
+    overflow: hidden;
+    justify-content: space-between; 
 }
 
-.action-button, .reset-button {
-    border-radius: var(--small-border-radius);
+.footer-left {
+    padding-right: 4px;
+    line-height: 1.5;
+    flex-grow: 1;
 }
 
-.action-button, .action-button span, .action-button i {
-    color: var(--highlight-text-color) !important;
+.footer-right {
+    display: flex;
+    justify-content: flex-end;
 }
 
-.action-button, .action-button i {
+.submit-button {
+    width: fit-content;
+}
+
+.submit-button, .submit-button i {
     background-color: var(--highlight-background-color) !important;
+    color: var(--highlight-text-color) !important;
+    font-size: var(--xs-paragraph-size);
 }
 
-.action-button i, .reset-button i {
-    font-size: smaller;
-}
-
-.action-button:hover:not(.disabled), .action-button:hover:not(.disabled) i, .action-button:hover:not(.disabled) span {
+.submit-button:hover:not(.disabled), .submit-button:hover:not(.disabled) i, .submit-button:hover:not(.disabled) span {
     background-color: var(--highlight-hover-background-color) !important;
     color: var(--highlight-hover-text-color) !important;
     cursor: pointer;
 }
 
-.action-button.disabled {
-    cursor: not-allowed;
+.submit-button.disabled {
     opacity: 0.5;
+}
+
+.reset-button {
+    height: 30px;
+    width: 30px;
 }
 
 .reset-button, .reset-button span, .reset-button i {
@@ -48,6 +50,9 @@
 
 .reset-button, .reset-button i {
     background-color: var(--secondary-background-color) !important;
+    font-size: var(--s-paragraph-size);
+    margin: 0 5px;
+
 }
 
 .reset-button:hover, .reset-button:hover i {
@@ -57,13 +62,16 @@
 }
 
 .reset-button-container {
-    margin-top: 2px;
+    align-items: flex-end;
+    display: flex;
 }
 
 .inputs {
     display: flex;
-    justify-content: space-between;
+}
 
+.input-field {
+    flex-grow: 1;
 }
 
 .input-field > input {
@@ -72,13 +80,28 @@
     border: 1px solid var(--border-color);
     color: var(--secondary-text-color);
     outline: none;
+    padding: 6px;
+    font-size: var(--s-paragraph-size);
+    width: 100%;
+    min-width: fit-content;
+}
+
+.input-field:active > input, .input-field > input:active, 
+.input-field:focus > input, .input-field > input:focus,
+.input-field:focus-within > input, .input-field > input:focus-within  {
+    border: 1px solid var(--aqua);
 }
 
 .range-seperator {
-    align-items: center;
+    align-items: flex-end;
     display: flex;
     font-size: small;
-    margin: 0 2px;
+    margin: 0 10px 8px;
+}
+
+.range-seperator > i {
+    font-size: var(--xs-paragraph-size);
+    font-weight: 600;
 }
 
 .title {

--- a/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
+++ b/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
@@ -74,7 +74,7 @@
     flex-grow: 1;
 }
 
-.input-field > input {
+.input-field input {
     background-color: var(--secondary-background-color);
     border-radius: var(--small-border-radius);
     border: 1px solid var(--border-color);

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -109,8 +109,8 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                     <div className={styles.inputField}>
                         <label htmlFor="rangemin">Min (inclusive)</label>
                         <input
+                            aria-label="Input a minimum value (inclusive)"
                             id="rangemin"
-                            title="Min (inclusive)"
                             type="number"
                             value={searchMinValue}
                             step="any"
@@ -125,8 +125,8 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                     <div className={styles.inputField}>
                         <label htmlFor="rangemax">Max (exclusive)</label>
                         <input
+                            aria-label="Input a maximum value (exclusive)"
                             id="rangemax"
-                            title="Max (exclusive)"
                             type="number"
                             value={searchMaxValue}
                             step="any"

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -110,6 +110,7 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                         <label htmlFor="rangemin">Min (inclusive)</label>
                         <input
                             aria-label="Input a minimum value (inclusive)"
+                            data-testid="rangemin"
                             id="rangemin"
                             type="number"
                             value={searchMinValue}
@@ -126,6 +127,7 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                         <label htmlFor="rangemax">Max (exclusive)</label>
                         <input
                             aria-label="Input a maximum value (exclusive)"
+                            data-testid="rangemax"
                             id="rangemax"
                             type="number"
                             value={searchMaxValue}

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -1,8 +1,8 @@
-import { ActionButton, Icon, Spinner, SpinnerSize } from "@fluentui/react";
+import { Icon, Spinner, SpinnerSize } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
-import { TertiaryButton } from "../Buttons";
+import { PrimaryButton, TertiaryButton } from "../Buttons";
 import FileFilter from "../../entity/FileFilter";
 import { extractValuesFromRangeOperatorFilterString } from "../../entity/AnnotationFormatter/number-formatter";
 import { AnnotationValue } from "../../services/AnnotationService";
@@ -22,7 +22,7 @@ interface NumberRangePickerProps {
     items: ListItem[];
     loading?: boolean;
     onSearch: (filterValue: string) => void;
-    onReset: () => void;
+    onReset?: () => void;
     currentRange: FileFilter | undefined;
     units?: string;
 }
@@ -35,7 +35,7 @@ interface NumberRangePickerProps {
  * It is best suited for selecting items that are numbers.
  */
 export default function NumberRangePicker(props: NumberRangePickerProps) {
-    const { errorMessage, items, loading, onSearch, onReset, currentRange, units } = props;
+    const { errorMessage, items, loading, onSearch, currentRange, units } = props;
 
     const overallMin = React.useMemo(() => {
         return items[0]?.displayValue.toString() ?? "";
@@ -51,10 +51,11 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
         extractValuesFromRangeOperatorFilterString(currentRange?.value).maxValue ?? overallMax
     );
 
+    // Instead of removing filter completely, reset to min and max and submit
     function onResetSearch() {
-        onReset();
-        setSearchMinValue("");
-        setSearchMaxValue("");
+        setSearchMinValue(overallMin);
+        setSearchMaxValue(overallMax);
+        onSearch(`RANGE(${overallMin},${overallMax})`);
     }
 
     const onSubmitRange = () => {
@@ -136,37 +137,38 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                     </div>
                     <div className={styles.resetButtonContainer}>
                         <TertiaryButton
-                            className={classNames(styles.resetButton)}
+                            className={styles.resetButton}
                             title="Reset filter"
                             onClick={onResetSearch}
-                            iconName="Delete"
+                            iconName="Clear"
                         />
                     </div>
-                </div>
-                <div className={styles.buttons}>
-                    <ActionButton
-                        ariaLabel="Submit"
-                        className={classNames(
-                            {
-                                [styles.disabled]: !searchMinValue && !searchMaxValue,
-                            },
-                            styles.actionButton
-                        )}
-                        disabled={!searchMinValue && !searchMaxValue}
-                        iconProps={{ iconName: "ReturnKey" }}
-                        title={searchMinValue || searchMaxValue ? undefined : "No options selected"}
-                        onClick={onSubmitRange}
-                    >
-                        Submit Range
-                    </ActionButton>
                 </div>
             </div>
             <div className={styles.footer}>
                 {overallMin && overallMax && (
-                    <h6>
-                        Full range available: {overallMin}, {overallMax}
-                    </h6>
+                    <div className={styles.footerLeft}>
+                        <div> Full range available: </div>
+                        <div>
+                            {overallMin}, {overallMax}
+                        </div>
+                    </div>
                 )}
+                <div className={styles.footerRight}>
+                    <PrimaryButton
+                        disabled={!searchMinValue && !searchMaxValue}
+                        iconName=""
+                        text="Submit"
+                        className={classNames(
+                            {
+                                [styles.disabled]: !searchMinValue && !searchMaxValue,
+                            },
+                            styles.submitButton
+                        )}
+                        title={searchMinValue || searchMaxValue ? "" : "No options selected"}
+                        onClick={onSubmitRange}
+                    />
+                </div>
             </div>
         </div>
     );

--- a/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
+++ b/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
@@ -25,8 +25,8 @@ describe("<NumberRangePicker />", () => {
         expect(getByText("Max (exclusive)")).to.not.be.undefined;
 
         // Should initialize to min and max item provided, respectively
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("20");
+        expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("0");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("20");
     });
 
     it("initializes to values passed through props if provided", () => {
@@ -40,8 +40,8 @@ describe("<NumberRangePicker />", () => {
         render(<NumberRangePicker items={items} onSearch={noop} currentRange={currentRange} />);
 
         // Should initialize to min and max item provided, respectively
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("12.34");
+        expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("0");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("12.34");
     });
 
     it("renders a 'Reset' button if given a callback", () => {
@@ -59,8 +59,8 @@ describe("<NumberRangePicker />", () => {
         );
 
         // Consistency check
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("1");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("12.34");
+        expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("1");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("12.34");
 
         // Hit reset
         expect(onSearch.called).to.equal(false);
@@ -68,8 +68,8 @@ describe("<NumberRangePicker />", () => {
         expect(onSearch.called).to.equal(true);
 
         // Should reset to min and max values
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("20");
+        expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("0");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("20");
     });
 
     it("displays available min and max of items", () => {

--- a/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
+++ b/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
@@ -17,12 +17,7 @@ describe("<NumberRangePicker />", () => {
 
         // Act / Assert
         const { getByText } = render(
-            <NumberRangePicker
-                items={items}
-                onSearch={noop}
-                onReset={noop}
-                currentRange={undefined}
-            />
+            <NumberRangePicker items={items} onSearch={noop} currentRange={undefined} />
         );
 
         // Should render both input fields
@@ -42,14 +37,7 @@ describe("<NumberRangePicker />", () => {
             value: val,
         }));
 
-        render(
-            <NumberRangePicker
-                items={items}
-                onSearch={noop}
-                onReset={noop}
-                currentRange={currentRange}
-            />
-        );
+        render(<NumberRangePicker items={items} onSearch={noop} currentRange={currentRange} />);
 
         // Should initialize to min and max item provided, respectively
         expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
@@ -58,8 +46,8 @@ describe("<NumberRangePicker />", () => {
 
     it("renders a 'Reset' button if given a callback", () => {
         // Arrange
-        const onSearch = noop;
-        const onReset = sinon.spy();
+        const onSearch = sinon.spy();
+        const currentRange = new FileFilter("Test Numerical Annotation", "RANGE(1, 12.34)");
         const items: ListItem[] = ["0", "20"].map((val) => ({
             displayValue: val,
             value: val,
@@ -67,26 +55,21 @@ describe("<NumberRangePicker />", () => {
 
         // Act / Assert
         const { getByTestId } = render(
-            <NumberRangePicker
-                items={items}
-                onSearch={onSearch}
-                onReset={onReset}
-                currentRange={undefined}
-            />
+            <NumberRangePicker items={items} onSearch={onSearch} currentRange={currentRange} />
         );
 
-        // Sanity check
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("20");
+        // Consistency check
+        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("1");
+        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("12.34");
 
         // Hit reset
-        expect(onReset.called).to.equal(false);
+        expect(onSearch.called).to.equal(false);
         fireEvent.click(getByTestId("base-button-Reset filter"));
-        expect(onReset.called).to.equal(true);
+        expect(onSearch.called).to.equal(true);
 
-        // Should clear min and max values
-        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("");
-        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("");
+        // Should reset to min and max values
+        expect(screen.getByTitle<HTMLInputElement>(/^Min/).value).to.equal("0");
+        expect(screen.getByTitle<HTMLInputElement>(/^Max/).value).to.equal("20");
     });
 
     it("displays available min and max of items", () => {
@@ -96,21 +79,12 @@ describe("<NumberRangePicker />", () => {
             value: val,
         }));
         const { getByText } = render(
-            <NumberRangePicker
-                items={items}
-                onReset={noop}
-                onSearch={noop}
-                currentRange={undefined}
-            />
+            <NumberRangePicker items={items} onSearch={noop} currentRange={undefined} />
         );
 
         // Act / Assert
-        expect(
-            getByText(
-                `Full range available: ${items[0].displayValue}, ${
-                    items[items.length - 1].displayValue
-                }`
-            )
-        ).to.exist;
+        expect(getByText("Full range available:")).to.exist;
+        expect(getByText(`${items[0].displayValue}, ${items[items.length - 1].displayValue}`)).to
+            .exist;
     });
 });

--- a/packages/core/components/SearchBox/SearchBox.module.css
+++ b/packages/core/components/SearchBox/SearchBox.module.css
@@ -1,3 +1,12 @@
+.search-box-wrapper {
+    display: flex;
+    width: 100%;
+}
+
+.search-box {
+    flex-grow: 1;
+}
+
 .search-box, .search-box > :is(div, input), .search-box :is(button, i) {
     background-color: var(--secondary-background-color) !important;
     color: var(--secondary-text-color) !important;
@@ -22,5 +31,22 @@
 }
 
 .search-box::after {
-    display: none;
+    border: 1px solid var(--aqua);
+}
+
+.submit-button {
+    height: 31px;
+    min-width: 30px;
+    margin-left: 8px;
+}
+
+.submit-button, .submit-button i {
+    font-weight: 400;
+    background-color: var(--aqua) !important;
+    color: var(--highlight-text-color)
+}
+
+.submit-button:hover, .submit-button:hover i {
+    background-color: var(--bright-aqua) !important;
+    color: var(--highlight-text-color)
 }

--- a/packages/core/components/SearchBox/index.tsx
+++ b/packages/core/components/SearchBox/index.tsx
@@ -2,6 +2,7 @@ import { SearchBox as SearchBoxComponent } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
+import { TertiaryButton } from "../Buttons";
 import FileFilter from "../../entity/FileFilter";
 
 import styles from "./SearchBox.module.css";
@@ -14,6 +15,7 @@ interface Props {
     onSearch?: (value: string) => void;
     onReset: () => void;
     placeholder?: string;
+    showSubmitButton?: boolean;
 }
 
 /**
@@ -21,6 +23,7 @@ interface Props {
  */
 export default function SearchBox(props: Props) {
     const [searchValue, setSearchValue] = React.useState(props.defaultValue?.value ?? "");
+    const showSubmitButton = props?.showSubmitButton || false;
 
     const onSearchBoxChange = (event?: React.ChangeEvent<HTMLInputElement>) => {
         if (event) {
@@ -35,14 +38,24 @@ export default function SearchBox(props: Props) {
     }
 
     return (
-        <SearchBoxComponent
-            className={classNames(props.className, styles.searchBox)}
-            id={props.id}
-            onClear={onClear}
-            onSearch={props.onSearch}
-            onChange={onSearchBoxChange}
-            placeholder={props.placeholder || "Search..."}
-            value={searchValue}
-        />
+        <div className={styles.searchBoxWrapper}>
+            <SearchBoxComponent
+                className={classNames(props.className, styles.searchBox)}
+                id={props.id}
+                onClear={onClear}
+                onSearch={props.onSearch}
+                onChange={onSearchBoxChange}
+                placeholder={props.placeholder || "Search..."}
+                value={searchValue}
+            />
+            {showSubmitButton && (
+                <TertiaryButton
+                    className={styles.submitButton}
+                    title={"Submit"}
+                    onClick={() => props.onSearch?.(searchValue)}
+                    iconName="ReturnKey"
+                />
+            )}
+        </div>
     );
 }

--- a/packages/core/components/SearchBox/test/SearchBox.test.tsx
+++ b/packages/core/components/SearchBox/test/SearchBox.test.tsx
@@ -54,4 +54,30 @@ describe("<SearchBox/>", () => {
 
         expect(screen.getByRole<HTMLInputElement>("searchbox").value).to.equal("");
     });
+
+    it("renders a clickable button when prop is present that triggers search", () => {
+        // Arrange
+        const onSearch = sinon.spy();
+
+        // Act / Assert
+        const { getByRole, getByLabelText } = render(
+            <SearchBox
+                onSearch={onSearch}
+                onReset={noop}
+                defaultValue={undefined}
+                showSubmitButton
+            />
+        );
+        // Enter values
+        fireEvent.change(getByRole("searchbox"), {
+            target: {
+                value: "bar",
+            },
+        });
+
+        // Hit reset
+        expect(onSearch.called).to.equal(false);
+        fireEvent.click(getByLabelText("Submit"));
+        expect(onSearch.called).to.equal(true);
+    });
 });


### PR DESCRIPTION
This ticket separate out the UX parts of #238 so that the final version of that ticket will be easier to review. The only difference between this PR and the original version of the UX part of #238 is that I added in the new tooltips in a couple places.

This new version is ONLY the UX updates for:
- Searchbox 
   - As noted in big PR, removed search box radio option for annotations that can use list picking, since it had been causing some confusion since there's also a separate search box associated with the list picker (prepares for but does NOT include fuzzy search toggle)
- Numerical range form 
- Date range form
- Some refactoring to AnnotationFilterForm, but just as preparation for the ANY/NONE/SOME choice group
- Other minor changes that were also included in #238 

### Screenshots

New "Recent" icon to replace "Redo", plus incorporated new version of tooltip
<img width="587" alt="Screenshot 2024-09-24 at 3 44 26 PM" src="https://github.com/user-attachments/assets/fafb1c0c-4ba2-4176-977f-4af8a151d48c">

Removed list picking toggle. Will be replaced by fuzzy search toggle in #238
<img width="634" alt="Screenshot 2024-09-24 at 3 29 46 PM" src="https://github.com/user-attachments/assets/e827f7db-2284-42db-8bad-e75a8007e540">

Date 
<img width="628" alt="Screenshot 2024-09-24 at 3 29 40 PM" src="https://github.com/user-attachments/assets/b7dc815c-141e-4d6a-87aa-30c634cf07e8">

Numerical
<img width="609" alt="Screenshot 2024-09-24 at 3 29 32 PM" src="https://github.com/user-attachments/assets/8b96b0f4-5df6-4b99-b690-dda3563b62ea">


