### PR TITLE
feature/tracked-zarr-download-web

### DIFF
--- a/packages/core/services/FileDownloadService/index.ts
+++ b/packages/core/services/FileDownloadService/index.ts
@@ -1,7 +1,4 @@
 import axios from "axios";
-import * as http from "http";
-import * as https from "https";
-
 import HttpServiceBase from "../HttpServiceBase";
 
 export enum DownloadResolution {
@@ -138,19 +135,14 @@ export default abstract class FileDownloadService extends HttpServiceBase {
      * Retrieve file metadata (specifically, file size) from an S3 object using a HEAD request.
      */
     public async headS3Object(url: string): Promise<{ size: number }> {
-        return new Promise((resolve, reject) => {
-            const requestor = new URL(url).protocol === "http:" ? http : https;
-            const req = requestor.request(url, { method: "HEAD" }, (res) => {
-                if (res.statusCode !== 200) {
-                    return reject(new Error(`Failed to get file metadata: ${res.statusCode}`));
-                }
-                const fileSize = parseInt(res.headers["content-length"] || "0", 10);
-                resolve({ size: fileSize });
-            });
-
-            req.on("error", reject);
-            req.end();
-        });
+        try {
+            const response = await axios.head(url);
+            const fileSize = parseInt(response.headers["content-length"] || "0", 10);
+            return { size: fileSize };
+        } catch (err) {
+            console.error(`Failed to get file metadata: ${err}`);
+            throw err;
+        }
     }
 }
 

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -309,7 +309,12 @@ const downloadFilesLogic = createLogic({
                         if (result.resolution === DownloadResolution.CANCELLED) {
                             dispatch(removeStatus(downloadRequestId));
                         } else {
-                            dispatch(processSuccess(downloadRequestId, result.msg || ""));
+                            dispatch(
+                                processSuccess(
+                                    downloadRequestId,
+                                    result.msg || "Download completed successfully."
+                                )
+                            );
                         }
                     }
                 } catch (err) {

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { Canceler } from "axios";
 import JSZip from "jszip";
 import {
     FileDownloadService,
@@ -7,20 +7,42 @@ import {
     DownloadResolution,
 } from "../../../core/services";
 
+interface ActiveRequestMap {
+    [id: string]: {
+        cancel: () => void;
+    };
+}
+
 export default class FileDownloadServiceWeb extends FileDownloadService {
     isFileSystemAccessible = false;
+    private readonly activeRequestMap: ActiveRequestMap = {};
 
-    public async download(fileInfo: FileInfo): Promise<DownloadResult> {
+    public async download(
+        fileInfo: FileInfo,
+        downloadRequestId: string,
+        onProgress?: (transferredBytes: number) => void,
+        destination?: string
+    ): Promise<DownloadResult> {
         if (fileInfo.path.endsWith(".zarr")) {
-            return await this.handleZarrFile(fileInfo);
+            return await this.handleZarrFile(fileInfo, downloadRequestId, onProgress, destination);
         } else {
             return await this.downloadFile(fileInfo);
         }
     }
 
-    private async handleZarrFile(fileInfo: FileInfo): Promise<DownloadResult> {
+    private async handleZarrFile(
+        fileInfo: FileInfo,
+        downloadRequestId: string,
+        onProgress?: (transferredBytes: number) => void,
+        destination?: string
+    ): Promise<DownloadResult> {
         if (this.isS3Url(fileInfo.path)) {
-            return await this.downloadS3Directory(fileInfo);
+            return await this.downloadS3Directory(
+                fileInfo,
+                downloadRequestId,
+                onProgress,
+                destination
+            );
         }
 
         if (this.isLocalPath(fileInfo.path)) {
@@ -48,11 +70,17 @@ Please navigate to this directory manually, or upload files to a remote address 
 
         return {
             downloadRequestId: fileInfo.id,
+            msg: `Download cancelled: the Zarr file is located locally at ${directoryPath}.`,
             resolution: DownloadResolution.CANCELLED,
         };
     }
 
-    private async downloadS3Directory(fileInfo: FileInfo): Promise<DownloadResult> {
+    private async downloadS3Directory(
+        fileInfo: FileInfo,
+        downloadRequestId: string,
+        onProgress?: (transferredBytes: number) => void,
+        destination?: string
+    ): Promise<DownloadResult> {
         const { hostname, key } = this.parseS3Url(fileInfo.path);
         const keys = await this.listS3Objects(hostname, key);
 
@@ -61,27 +89,70 @@ Please navigate to this directory manually, or upload files to a remote address 
         }
 
         const zip = new JSZip();
+        let totalSize = 0;
 
+        // Fetch the size of each file to calculate total download size
         for (const fileKey of keys) {
             const fileUrl = `https://${hostname}/${encodeURIComponent(fileKey)}`;
-            const response = await axios.get(fileUrl, { responseType: "blob" });
-            const fileData = response.data;
-            const fileName = fileKey.replace(`${key}/`, "");
-
-            zip.file(fileName, fileData);
+            const response = await axios.head(fileUrl);
+            const fileSize = parseInt(response.headers["content-length"] || "0", 10);
+            totalSize += fileSize; // Calculate total size for all files
         }
 
-        // Generate the ZIP file as a Blob and trigger the download
+        // Register cancellation token for this request
+        let cancelToken: Canceler;
+        this.activeRequestMap[downloadRequestId] = {
+            cancel: () => cancelToken && cancelToken(),
+        };
+
+        // Download each file and add it to the ZIP archive
+        for (const fileKey of keys) {
+            const fileUrl = `https://${hostname}/${encodeURIComponent(fileKey)}`;
+            const fileName = fileKey.replace(`${key}/`, ""); // Local file name in zip
+
+            let fileBytesDownloaded = 0; // Track the bytes for the current file
+
+            const response = await axios.get(fileUrl, {
+                responseType: "blob",
+                onDownloadProgress: (progressEvent) => {
+                    const { loaded } = progressEvent;
+
+                    // Calculate the number of new bytes downloaded since the last progress event
+                    const newBytes = loaded - fileBytesDownloaded;
+                    fileBytesDownloaded = loaded;
+
+                    // Pass only the new bytes downloaded to onProgress
+                    if (onProgress && totalSize > 0) {
+                        onProgress(newBytes);
+                    }
+                },
+                cancelToken: new axios.CancelToken((c) => {
+                    cancelToken = c;
+                }),
+            });
+
+            zip.file(fileName, response.data);
+        }
+
+        // Cleanup after download finishes
+        delete this.activeRequestMap[downloadRequestId];
+
+        // Generate ZIP Blob and trigger download
         const zipBlob = await zip.generateAsync({ type: "blob" });
         const downloadUrl = URL.createObjectURL(zipBlob);
         const a = document.createElement("a");
+
+        // Use destination or default name if destination is passed
         a.href = downloadUrl;
-        a.download = `${fileInfo.name}.zip`;
+        a.download = destination || `${fileInfo.name}.zip`;
         a.click();
         URL.revokeObjectURL(downloadUrl);
 
         return {
             downloadRequestId: fileInfo.id,
+            msg: `Successfully downloaded ${fileInfo.name} and saved it as a ZIP file to ${
+                destination || "your default downloads folder"
+            }.`,
             resolution: DownloadResolution.SUCCESS,
         };
     }
@@ -120,13 +191,16 @@ Please navigate to this directory manually, or upload files to a remote address 
         }
     }
 
+    public cancelActiveRequest(downloadRequestId: string): void {
+        if (this.activeRequestMap[downloadRequestId]) {
+            this.activeRequestMap[downloadRequestId].cancel();
+            delete this.activeRequestMap[downloadRequestId];
+        }
+    }
+
     public getDefaultDownloadDirectory(): Promise<string> {
         throw new Error(
             "FileDownloadServiceWeb:getDefaultDownloadDirectory not implemented for web"
         );
-    }
-
-    public cancelActiveRequest(): void {
-        /** noop: Browser will handle cancellation */
     }
 }


### PR DESCRIPTION
## Description 

This PR was originally supposed to add a spinner for when the download was in progress, However in writing that element it became apparent that we could track the download via onProgress and use the in-place infrastructure for progress reporting rather than designing a new feature.

This PR also resolves an issue in FileDownloadService/index.ts where we were using http and https to retrieve file size. These are not available to web so I replaced it with a pure axios call.

Also cancelable zarr downloads for web!

## Relevant Issues
resolves #240 