### PR TITLE
Bugfix/add loading state to on csv load

### DIFF
--- a/dev-docs/02-setup-and-workflow.md
+++ b/dev-docs/02-setup-and-workflow.md
@@ -39,7 +39,7 @@ $ npm ci
 In many cases, you'll need to make changes to the `core` package, and you'll want to see how those changes play out in the context of a
 rendered application, like `desktop` or `web`.
 To make that happen:
-1. Navigate to either `packages/desktop` or `packages/web` and run `npm run start`.
+1. To start the desktop version, run `npm --prefix packages/desktop run start`. Otherwise to start the web version, run `npm --prefix packages/web run start`.
 
 ### Testing
 Most components in the project have associated unit tests; to run the full suite, run `npm run test`.

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -105,7 +105,7 @@ export default function App(props: AppProps) {
                 <div className={styles.querySidebarAndCenter}>
                     <QuerySidebar className={styles.querySidebar} />
                     <div className={styles.center}>
-                        {hasQuerySelected ? (
+                        {hasQuerySelected || window.location.search ? (
                             <>
                                 <GlobalActionButtonRow className={styles.globalButtonRow} />
                                 <DirectoryTree className={styles.fileList} />

--- a/packages/core/components/AggregateInfoBox/AggregateInfoBox.module.css
+++ b/packages/core/components/AggregateInfoBox/AggregateInfoBox.module.css
@@ -24,6 +24,10 @@
     margin-bottom: 5px;
 }
 
+.column-data > div > div {
+    border-color: var(--primary-text-color) var(--primary-background-color) var(--primary-background-color);
+}
+
 .label {
     font-weight: lighter;
     margin: 0;

--- a/packages/core/components/DirectoryTree/RootLoadingIndicator.module.css
+++ b/packages/core/components/DirectoryTree/RootLoadingIndicator.module.css
@@ -17,6 +17,14 @@
     flex: 1 1 auto;
 }
 
+.indeterminate-progress-bar > div > div:first-child {
+    background: var(--primary-text-color);
+}
+
+.indeterminate-progress-bar > div > div:last-child {
+    background: linear-gradient(to right, var(--primary-text-color) 0%, var(--secondary-background-color) 25%, var(--secondary-background-color) 75%, var(--primary-text-color) 100%);
+}
+
 .hidden {
     display: none;
 }

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -2,12 +2,13 @@ import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { interaction, selection } from "../../state";
-import AggregateInfoBox from "../AggregateInfoBox";
-import FileSet from "../../entity/FileSet";
-import Tutorial from "../../entity/Tutorial";
 import RootLoadingIndicator from "./RootLoadingIndicator";
 import useDirectoryHierarchy from "./useDirectoryHierarchy";
+import AggregateInfoBox from "../AggregateInfoBox";
+import EmptyFileListMessage from "../EmptyFileListMessage";
+import FileSet from "../../entity/FileSet";
+import Tutorial from "../../entity/Tutorial";
+import { interaction, selection } from "../../state";
 
 import styles from "./DirectoryTree.module.css";
 
@@ -80,9 +81,9 @@ export default function DirectoryTree(props: FileListProps) {
                 aria-multiselectable="true"
                 id={Tutorial.FILE_LIST_ID}
             >
-                {!error ? (
-                    content
-                ) : (
+                {!error && Array.isArray(content) && !content.length && <EmptyFileListMessage />}
+                {!error && content}
+                {error && (
                     <aside className={styles.errorMessage}>
                         <p>Whoops! Something went wrong:</p>
                         <p>{error.message}</p>

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -8,7 +8,6 @@ import FileSet from "../../entity/FileSet";
 import Tutorial from "../../entity/Tutorial";
 import RootLoadingIndicator from "./RootLoadingIndicator";
 import useDirectoryHierarchy from "./useDirectoryHierarchy";
-import EmptyFileListMessage from "../EmptyFileListMessage";
 
 import styles from "./DirectoryTree.module.css";
 
@@ -81,11 +80,9 @@ export default function DirectoryTree(props: FileListProps) {
                 aria-multiselectable="true"
                 id={Tutorial.FILE_LIST_ID}
             >
-                {!error && (!content || (Array.isArray(content) && !content.length)) && (
-                    <EmptyFileListMessage />
-                )}
-                {!error && content}
-                {error && (
+                {!error ? (
+                    content
+                ) : (
                     <aside className={styles.errorMessage}>
                         <p>Whoops! Something went wrong:</p>
                         <p>{error.message}</p>

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -480,30 +480,4 @@ describe("<DirectoryTree />", () => {
         header = await findByTestId(directoryTreeNodes[0], "treeitemheader"); // refresh node
         expect(header.classList.contains(styles.focused)).to.be.true;
     });
-
-    it("displays 'No files found' when no files found", async () => {
-        sandbox.restore();
-        const emptyFileService = new HttpFileService();
-        sandbox.stub(interaction.selectors, "getFileService").returns(emptyFileService);
-
-        const { store } = configureMockStore({
-            state,
-            responseStubs,
-            reducer,
-            logics: reduxLogics,
-        });
-
-        const { queryAllByRole, findByText } = render(
-            <Provider store={store}>
-                <DirectoryTree />
-            </Provider>
-        );
-
-        // No tree items should load
-        const directoryTreeNodes = queryAllByRole("treeitem");
-        expect(directoryTreeNodes.length).to.equal(0);
-
-        // Wait for the fileService call to return, then check for empty list message
-        await findByText("Sorry! No files found");
-    });
 });

--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -106,7 +106,10 @@ const useDirectoryHierarchy = (
     const fileService = useSelector(interaction.selectors.getFileService);
     const selectedFileFilters = useSelector(selection.selectors.getFileFilters);
     const sortColumn = useSelector(selection.selectors.getSortColumn);
-    const [state, dispatch] = React.useReducer(reducer, INITIAL_STATE);
+    const [state, dispatch] = React.useReducer(reducer, {
+        ...INITIAL_STATE,
+        isLoading: !collapsed,
+    });
 
     const isRoot = currentNode === ROOT_NODE;
     const isLeaf = !isRoot && !!hierarchy.length && ancestorNodes.length === hierarchy.length - 1;
@@ -128,7 +131,8 @@ const useDirectoryHierarchy = (
         async function getContent() {
             if (isLeaf || hierarchy.length === 0) {
                 // if we're at the top or bottom of the hierarchy, render a FileList
-                if (!cancel) {
+                // unless we have cancelled or there is nothing to query against
+                if (!cancel && !isEmpty(fileSet.toJSON().queryString)) {
                     dispatch(
                         receiveContent(
                             <FileList fileSet={fileSet} isRoot={isRoot} sortOrder={sortOrder} />

--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -132,7 +132,7 @@ const useDirectoryHierarchy = (
             if (isLeaf || hierarchy.length === 0) {
                 // if we're at the top or bottom of the hierarchy, render a FileList
                 // unless we have cancelled or there is nothing to query against
-                if (!cancel && !isEmpty(fileSet.toJSON().queryString)) {
+                if (!cancel) {
                     dispatch(
                         receiveContent(
                             <FileList fileSet={fileSet} isRoot={isRoot} sortOrder={sortOrder} />

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -120,11 +120,21 @@ export default function FileList(props: FileListProps) {
     // Get a count of all files in the FileList, but don't wait on it
     React.useEffect(() => {
         let cancel = false;
-        fileSet.fetchTotalCount().then((count) => {
-            if (!cancel) {
-                setTotalCount(count);
-            }
-        });
+        fileSet
+            .fetchTotalCount()
+            .then((count) => {
+                if (!cancel) {
+                    setTotalCount(count);
+                }
+            })
+            .catch((err) => {
+                // Data source may not be prepared if the data source is taking longer to load
+                // than the component does to render. In this case, we can ignore the error.
+                // The component will re-render when the data source is prepared.
+                if (!err?.message.includes("Data source is not prepared")) {
+                    throw err;
+                }
+            });
         return () => {
             cancel = true;
         };

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -130,7 +130,7 @@ export default function FileList(props: FileListProps) {
         };
     }, [fileSet]);
 
-    let content: React.ReactNode | undefined;
+    let content: React.ReactNode;
     if (totalCount === null || totalCount > 0) {
         if (height > 0) {
             // When this component isRoot the height is measured. It takes

--- a/packages/core/components/Modal/MetadataManifest/test/MetadataManifest.test.tsx
+++ b/packages/core/components/Modal/MetadataManifest/test/MetadataManifest.test.tsx
@@ -98,7 +98,7 @@ describe("<MetadataManifest />", () => {
         );
 
         // Act
-        const downloadButton = await findByText("Download");
+        const downloadButton = await findByText("DOWNLOAD");
         fireEvent.click(downloadButton);
         await logicMiddleware.whenComplete();
 

--- a/packages/core/components/QueryPart/QueryPartRow.module.css
+++ b/packages/core/components/QueryPart/QueryPartRow.module.css
@@ -79,7 +79,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    height: min-content;
+    padding-top: 1px;
+    height: calc(var(--s-paragraph-size) + 4px);
 }
 
 .dynamic-row-title {

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -49,6 +49,18 @@
     white-space: nowrap;
 }
 
+.loading-container {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    height: 250px;
+    width: 100%;
+}
+
+.loading-container > div > div {
+    border-color: var(--primary-text-color) var(--primary-background-color) var(--primary-background-color);
+}
+
 .title-container {
     display: flex;
     width: 100%;

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -1,4 +1,4 @@
-import { IContextualMenuItem, IconButton, TextField } from "@fluentui/react";
+import { IContextualMenuItem, IconButton, Spinner, SpinnerSize, TextField } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -13,6 +13,7 @@ import { interaction, metadata, selection } from "../../state";
 import { Query as QueryType } from "../../state/selection/actions";
 
 import styles from "./Query.module.css";
+import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
 
 interface QueryProps {
     isSelected: boolean;
@@ -30,6 +31,7 @@ export default function Query(props: QueryProps) {
     const currentQueryParts = useSelector(selection.selectors.getCurrentQueryParts);
 
     const hasDataSource = !!props.query.parts.sources.length;
+    const isLoading = !hasDataSource || props.query.name === AICS_FMS_DATA_SOURCE_NAME;
 
     const [isExpanded, setIsExpanded] = React.useState(false);
     React.useEffect(() => {
@@ -37,7 +39,10 @@ export default function Query(props: QueryProps) {
     }, [props.isSelected]);
 
     const queryComponents = React.useMemo(
-        () => (props.isSelected ? currentQueryParts : props.query?.parts),
+        () =>
+            props.isSelected && !!currentQueryParts.sources.length
+                ? currentQueryParts
+                : props.query?.parts,
         [props.query?.parts, currentQueryParts, props.isSelected]
     );
 
@@ -65,6 +70,16 @@ export default function Query(props: QueryProps) {
         ];
         dispatch(interaction.actions.showContextMenu(items, evt.nativeEvent));
     };
+
+    if (isLoading) {
+        return (
+            <div className={styles.container}>
+                <div className={styles.loadingContainer}>
+                    <Spinner size={SpinnerSize.medium} data-testid="query-spinner" />
+                </div>
+            </div>
+        );
+    }
 
     if (!isExpanded) {
         return (

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -103,6 +103,7 @@ export default function Query(props: QueryProps) {
                             className={styles.collapseButton}
                             onClick={() => setIsExpanded(!isExpanded)}
                             iconProps={{ iconName: "ChevronUp" }}
+                            data-testid="expand-button"
                         />
                     )}
                 </div>
@@ -158,11 +159,12 @@ export default function Query(props: QueryProps) {
                     />
                 </div>
                 <IconButton
-                    ariaDescription="Expand view details"
-                    ariaLabel="Expand"
+                    ariaDescription="Collapse view details"
+                    ariaLabel="Collapse"
                     className={styles.collapseButton}
                     onClick={() => setIsExpanded(!isExpanded)}
                     iconProps={{ iconName: "ChevronDown" }}
+                    data-testid="collapse-button"
                 />
             </div>
             <QueryDataSource

--- a/packages/core/components/QuerySidebar/QuerySidebar.module.css
+++ b/packages/core/components/QuerySidebar/QuerySidebar.module.css
@@ -62,7 +62,7 @@
 
 .queries-container {
     height: calc(100% - var(--header-height) - var(--footer-height));
-    overflow-y: scroll;
+    overflow-y: auto;
     padding-bottom: 40px;
 }
 

--- a/packages/core/components/QuerySidebar/index.tsx
+++ b/packages/core/components/QuerySidebar/index.tsx
@@ -125,7 +125,7 @@ export default function QuerySidebar(props: QuerySidebarProps) {
                     queries.map((query) => (
                         <Query
                             key={query.name}
-                            isSelected={query.name === selectedQuery}
+                            isSelected={query.name === selectedQuery || queries.length === 1}
                             query={query}
                         />
                     ))

--- a/packages/core/components/QuerySidebar/test/Query.test.tsx
+++ b/packages/core/components/QuerySidebar/test/Query.test.tsx
@@ -1,0 +1,101 @@
+import { configureMockStore } from "@aics/redux-utils";
+import { render, fireEvent } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+
+import Query from "../Query";
+import { initialState } from "../../../state";
+
+describe("<Query />", () => {
+    it("expands and collapses when clicked", async () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: initialState,
+        });
+        const sourceName = "Test Source";
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <Query
+                    isSelected
+                    query={{
+                        name: "Test Random Query",
+                        parts: {
+                            filters: [],
+                            hierarchy: [],
+                            sources: [{ name: sourceName }],
+                            openFolders: [],
+                        },
+                    }}
+                />
+            </Provider>
+        );
+
+        // (sanity-check) is collapsed
+        expect(getByTestId("expand-button")).to.exist;
+        expect(() => getByTestId("collapse-button")).to.throw();
+
+        // Act
+        fireEvent.click(getByTestId("expand-button"));
+
+        // Assert
+        expect(getByTestId("collapse-button")).to.exist;
+        expect(() => getByTestId("expand-button")).to.throw();
+    });
+
+    it("renders spinner when loading", () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: initialState,
+        });
+
+        // Act
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <Query
+                    isSelected
+                    query={{
+                        name: "Test Random Query",
+                        parts: {
+                            filters: [],
+                            hierarchy: [],
+                            sources: [],
+                            openFolders: [],
+                        },
+                    }}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(getByTestId("query-spinner")).to.exist;
+    });
+
+    it("does not render spinner when not loading", () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: initialState,
+        });
+
+        // Act
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <Query
+                    isSelected
+                    query={{
+                        name: "Test Random Query",
+                        parts: {
+                            filters: [],
+                            hierarchy: [],
+                            sources: [{ name: "Test Source" }],
+                            openFolders: [],
+                        },
+                    }}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(() => getByTestId("query-spinner")).to.throw();
+    });
+});

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -197,6 +197,11 @@ export default abstract class DatabaseService {
     }
 
     private async fetchAnnotationDescriptions(): Promise<Record<string, string>> {
+        // Unless we have actually added the source metadata table we can't fetch the descriptions
+        if (!this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+            return {};
+        }
+
         const sql = new SQLBuilder()
             .select('"Column Name", "Description"')
             .from(this.SOURCE_METADATA_TABLE)
@@ -219,6 +224,11 @@ export default abstract class DatabaseService {
     }
 
     private async fetchAnnotationTypes(): Promise<Record<string, string>> {
+        // Unless we have actually added the source metadata table we can't fetch the types
+        if (!this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+            return {};
+        }
+
         const sql = new SQLBuilder()
             .select('"Column Name", "Type"')
             .from(this.SOURCE_METADATA_TABLE)

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -81,7 +81,7 @@ export default class DatabaseFileService implements FileService {
 
     public async getCountOfMatchingFiles(fileSet: FileSet): Promise<number> {
         if (!this.dataSourceNames.length) {
-            return 0;
+            throw new Error("Data source is not prepared");
         }
 
         const select_key = "num_files";

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -48,42 +48,40 @@ import NumericRange from "../../entity/NumericRange";
 import FileExplorerURL, { DEFAULT_AICS_FMS_QUERY } from "../../entity/FileExplorerURL";
 import { ModalType } from "../../components/Modal";
 
+export const DEFAULT_QUERY_NAME = "New Query";
+
 /**
  * Interceptor responsible for checking if the user is able to access the AICS network
  */
-const checkAicsEmployee = createLogic({
+const initializeApp = createLogic({
     type: INITIALIZE_APP,
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const queries = selection.selectors.getQueries(deps.getState());
         const isOnWeb = interactionSelectors.isOnWeb(deps.getState());
-        const selectedQuery = selection.selectors.getSelectedQuery(deps.getState());
         const fileService = interactionSelectors.getHttpFileService(deps.getState());
 
         // Redimentary check to see if the user is an AICS Employee by
         // checking if the AICS network is accessible
         const isAicsEmployee = await fileService.isNetworkAccessible();
 
-        // If no query is currently selected attempt to choose one for the user
-        if (!selectedQuery) {
-            // If there are query args representing a query we can extract that
-            // into the query to render (ex. when refreshing a page)
-            if (isOnWeb && window.location.search) {
-                dispatch(
-                    selection.actions.addQuery({
-                        name: "New Query",
-                        parts: FileExplorerURL.decode(window.location.search),
-                    })
-                );
-            } else if (queries.length) {
-                dispatch(selection.actions.changeQuery(queries[0]));
-            } else if (isAicsEmployee) {
-                dispatch(
-                    selection.actions.addQuery({
-                        name: "New AICS FMS Query",
-                        parts: DEFAULT_AICS_FMS_QUERY,
-                    })
-                );
-            }
+        // If there are query args representing a query we can extract that
+        // into the query to render (ex. when refreshing a page)
+        if (isOnWeb && window.location.search) {
+            dispatch(
+                selection.actions.addQuery({
+                    name: DEFAULT_QUERY_NAME,
+                    parts: FileExplorerURL.decode(window.location.search),
+                })
+            );
+        } else if (queries.length) {
+            dispatch(selection.actions.changeQuery(queries[0]));
+        } else if (isAicsEmployee) {
+            dispatch(
+                selection.actions.addQuery({
+                    name: "New AICS FMS Query",
+                    parts: DEFAULT_AICS_FMS_QUERY,
+                })
+            );
         }
 
         dispatch(setIsAicsEmployee(isAicsEmployee) as AnyAction);
@@ -577,7 +575,7 @@ const setIsSmallScreen = createLogic({
 });
 
 export default [
-    checkAicsEmployee,
+    initializeApp,
     downloadManifest,
     cancelFileDownloadLogic,
     promptForNewExecutable,


### PR DESCRIPTION
# Description
Currently when you load a query from a link ([like so](https://staging.biofile-finder.allencell.org/app?group=Glass+Coating&openFolder=%5B%22PLF+%288.33ug%2FmL+Fibronectin+and+8.33ug%2FmL+rhLaminin-521++and+0.08mg%2FmL+Poly-D-Lysine%29%22%5D&source=%7B%22name%22%3A%22imaging_and_segmentation_data.csv+%288%2F15%2F2024+4%3A26%3A03+PM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Femt_timelapse_dataset%2Fmanifests%2Fimaging_and_segmentation_data.csv%3FversionId%3DWmTjARBNL4rNJhV4N7YFYr2dKHWlCHwc%22%7D&sourceMetadata=%7B%22name%22%3A%22Imaging_and_segmentation_data_column_description.csv+%288%2F15%2F2024+4%3A26%3A02+PM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Femt_timelapse_dataset%2Fmanifests%2FImaging_and_segmentation_data_column_description.csv%3FversionId%3D.bmbr.UUT06F9nupeuwxVBYuTMyKyYu6%22%7D)) there isn't much feedback immediately that BFF has detected a query. This has been worrying the scientists so this changeset makes the feedback appear much faster by enabling the loading states of the query & the file list ASAP.

## Testing
Tested locally & added unit tests

