### PR TITLE
Add simularium for .simularium files

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -71,6 +71,17 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             disabled: !fileDetails?.path,
             target: "_blank",
         },
+        ...(!fileDetails?.name.includes(".simularium")
+            ? []
+            : [
+                  {
+                      key: "simularium",
+                      text: "Simularium",
+                      title: `Open files with Simularium`,
+                      href: `https://simularium.allencell.org/viewer?trajUrl=${fileDetails?.cloudPath}`,
+                      target: "_blank",
+                  },
+              ]),
         ...(plateLink && isAicsEmployee
             ? [
                   {


### PR DESCRIPTION
This adds Simularium as an option to view a file in if the file is a `.simularium` file. We may switch to conditionally rendering all the "Open with" apps or just disable the ones we think will work but this gets this added for an external user to test it out for now.

Resolves #247 