### PR TITLE
Add include/exclude logic for database service

### DIFF
--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/SearchBoxForm.module.css
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/SearchBoxForm.module.css
@@ -2,6 +2,10 @@
     margin-bottom: 6px;
 }
 
+.toggle-hidden {
+    display: none;
+}
+
 .toggle input:disabled + label {
     cursor: not-allowed;
     opacity: 0.5;

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
@@ -19,6 +19,7 @@ interface SearchBoxFormProps {
     onSearch: (filterValue: string, type: FilterType) => void;
     fieldName: string;
     fuzzySearchEnabled?: boolean;
+    hideFuzzyToggle?: boolean;
     defaultValue: FileFilter | undefined;
 }
 
@@ -38,7 +39,9 @@ export default function SearchBoxForm(props: SearchBoxFormProps) {
             <h3 className={styles.title}>{props.title}</h3>
             <Toggle
                 label="Fuzzy search"
-                className={styles.toggle}
+                className={classNames(styles.toggle, {
+                    [styles.toggleHidden]: !!props?.hideFuzzyToggle,
+                })}
                 defaultChecked={isFuzzySearching}
                 onText="On"
                 inlineLabel

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -33,6 +33,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     const dispatch = useDispatch();
     const allFilters = useSelector(selection.selectors.getFileFilters);
     const fuzzyFilters = useSelector(selection.selectors.getFuzzyFilters);
+    const isQueryingAicsFms = useSelector(selection.selectors.isQueryingAicsFms);
     const annotationService = useSelector(interaction.selectors.getAnnotationService);
     const [annotationValues, isLoading, errorMessage] = useAnnotationValues(
         props.annotation.name,
@@ -196,6 +197,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                             fuzzySearchEnabled={fuzzySearchEnabled}
                             fieldName={props.annotation.displayName}
                             defaultValue={filtersForAnnotation?.[0]}
+                            hideFuzzyToggle={!isQueryingAicsFms}
                         />
                     );
                 }

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -33,7 +33,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     const dispatch = useDispatch();
     const allFilters = useSelector(selection.selectors.getFileFilters);
     const fuzzyFilters = useSelector(selection.selectors.getFuzzyFilters);
-    const isQueryingAicsFms = useSelector(selection.selectors.isQueryingAicsFms);
+    const isQueryingSourceWithFuzzy = useSelector(selection.selectors.isQueryingAicsFms);
     const annotationService = useSelector(interaction.selectors.getAnnotationService);
     const [annotationValues, isLoading, errorMessage] = useAnnotationValues(
         props.annotation.name,
@@ -197,7 +197,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                             fuzzySearchEnabled={fuzzySearchEnabled}
                             fieldName={props.annotation.displayName}
                             defaultValue={filtersForAnnotation?.[0]}
-                            hideFuzzyToggle={!isQueryingAicsFms}
+                            hideFuzzyToggle={!isQueryingSourceWithFuzzy}
                         />
                     );
                 }

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -33,7 +33,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     const dispatch = useDispatch();
     const allFilters = useSelector(selection.selectors.getFileFilters);
     const fuzzyFilters = useSelector(selection.selectors.getFuzzyFilters);
-    const isQueryingSourceWithFuzzy = useSelector(selection.selectors.isQueryingAicsFms);
+    const canFuzzySearch = useSelector(selection.selectors.isQueryingAicsFms);
     const annotationService = useSelector(interaction.selectors.getAnnotationService);
     const [annotationValues, isLoading, errorMessage] = useAnnotationValues(
         props.annotation.name,
@@ -197,7 +197,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                             fuzzySearchEnabled={fuzzySearchEnabled}
                             fieldName={props.annotation.displayName}
                             defaultValue={filtersForAnnotation?.[0]}
-                            hideFuzzyToggle={!isQueryingSourceWithFuzzy}
+                            hideFuzzyToggle={!canFuzzySearch}
                         />
                     );
                 }

--- a/packages/core/entity/FileFilter/index.ts
+++ b/packages/core/entity/FileFilter/index.ts
@@ -1,3 +1,5 @@
+import SQLBuilder from "../SQLBuilder";
+
 export interface FileFilterJson {
     name: string;
     value: any;
@@ -69,6 +71,20 @@ export default class FileFilter {
                 return `${this.annotationName}=${this.annotationValue}&fuzzy=${this.annotationName}`;
         }
         return `${this.annotationName}=${this.annotationValue}`;
+    }
+
+    // Unlike with sort, we shouldn't generate a full SQLBuilder
+    // Instead, just generate the string that will be passed into .where() clause
+    public toSQLWhereString(): string {
+        switch (this.type) {
+            case FilterType.ANY:
+                return `"${this.annotationName}" IS NOT NULL`;
+            case FilterType.EXCLUDE:
+                return `"${this.annotationName}" IS NULL`;
+            case FilterType.FUZZY:
+            default:
+                return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
+        }
     }
 
     public toJSON(): FileFilterJson {

--- a/packages/core/entity/FileFilter/index.ts
+++ b/packages/core/entity/FileFilter/index.ts
@@ -73,8 +73,10 @@ export default class FileFilter {
         return `${this.annotationName}=${this.annotationValue}`;
     }
 
-    // Unlike with sort, we shouldn't generate a full SQLBuilder
-    // Instead, just generate the string that will be passed into .where() clause
+    /** Unlike with FileSort, we shouldn't construct a new SQLBuilder since these will
+     * be applied to a pre-existing SQLBuilder.
+     * Instead, generate the string that can be passed into the .where() clause.
+     */
     public toSQLWhereString(): string {
         switch (this.type) {
             case FilterType.ANY:

--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -198,15 +198,10 @@ export default class FileSet {
         // Transform the map above into SQL comparison clauses
         const sqlBuilder = this.sort ? this.sort.toQuerySQLBuilder() : new SQLBuilder();
 
-        Object.entries(filtersGroupedByAnnotation).forEach(([annotation, appliedFilters]) => {
-            // If an annotation has no filtered values applied, we assume it's a hierarchy or include filter
-            if (appliedFilters.length === 0) {
-                sqlBuilder.where(`"${annotation}" IS NOT NULL`);
-            } else {
-                sqlBuilder.where(
-                    appliedFilters.map((filter) => filter.toSQLWhereString()).join(") OR (")
-                );
-            }
+        Object.entries(filtersGroupedByAnnotation).forEach(([_, appliedFilters]) => {
+            sqlBuilder.where(
+                appliedFilters.map((filter) => filter.toSQLWhereString()).join(") OR (")
+            );
         });
 
         return sqlBuilder;

--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -202,7 +202,12 @@ export default class FileSet {
         Object.entries(filterValuesByAnnotation).forEach(([annotation, filterValues]) => {
             // If a filter value is `null` then we need to modify the way we approach filtering
             // it in SQL
-            if (filterValues.length === 0) {
+            if (!!this.excludeFilters?.some((filter) => filter.name === annotation)) {
+                sqlBuilder.where(`"${annotation}" IS NULL`);
+            } else if (
+                !!this.includeFilters?.some((filter) => filter.name === annotation) ||
+                filterValues.length === 0
+            ) {
                 sqlBuilder.where(`"${annotation}" IS NOT NULL`);
             } else {
                 sqlBuilder.where(

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -14,6 +14,7 @@ import FileDownloadServiceNoop from "../../../services/FileDownloadService/FileD
 
 describe("FileSet", () => {
     const scientistEqualsJane = new FileFilter("scientist", "jane");
+    const scientistEqualsJohn = new FileFilter("scientist", "john");
     const matrigelIsHard = new FileFilter("matrigel_is_hardened", true);
     const dateCreatedDescending = new FileSort("date_created", SortOrder.DESC);
     const fuzzyFileName = new FuzzyFilter("file_name");
@@ -92,7 +93,7 @@ describe("FileSet", () => {
         it("builds SQL queries with include filters", () => {
             const fileSet = new FileSet({ filters: [anyGene] });
             expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
-                "NOT NULL"
+                'WHERE ("gene" IS NOT NULL'
             );
             expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).not.to.contain(
                 "IS NULL"
@@ -102,10 +103,30 @@ describe("FileSet", () => {
         it("builds SQL queries with exclude filters", () => {
             const fileSet = new FileSet({ filters: [noCellBatch] });
             expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
-                "IS NULL"
+                'WHERE ("cell_batch" IS NULL'
             );
             expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).not.to.contain(
                 "NOT NULL"
+            );
+        });
+
+        it("builds SQL queries with regular filters for different annotations", () => {
+            const fileSet = new FileSet({ filters: [scientistEqualsJane, matrigelIsHard] });
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                'WHERE (REGEXP_MATCHES("scientist"'
+            );
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                'AND (REGEXP_MATCHES("matrigel_is_hardened"'
+            );
+        });
+
+        it("builds SQL queries with regular filters for same annotation with different values", () => {
+            const fileSet = new FileSet({ filters: [scientistEqualsJane, scientistEqualsJohn] });
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                'WHERE (REGEXP_MATCHES("scientist"'
+            );
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                'OR (REGEXP_MATCHES("scientist"'
             );
         });
     });

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -86,6 +86,30 @@ describe("FileSet", () => {
         });
     });
 
+    describe("toQuerySQLBuilder", () => {
+        const mockDatasource = "testSource";
+
+        it("builds SQL queries with include filters", () => {
+            const fileSet = new FileSet({ filters: [anyGene] });
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                "NOT NULL"
+            );
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).not.to.contain(
+                "IS NULL"
+            );
+        });
+
+        it("builds SQL queries with exclude filters", () => {
+            const fileSet = new FileSet({ filters: [noCellBatch] });
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
+                "IS NULL"
+            );
+            expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).not.to.contain(
+                "NOT NULL"
+            );
+        });
+    });
+
     describe("fetchFileRange", () => {
         const sandbox = createSandbox();
         const fileIds = ["abc123", "def456", "ghi789", "jkl012", "mno345"];

--- a/packages/core/entity/SQLBuilder/index.ts
+++ b/packages/core/entity/SQLBuilder/index.ts
@@ -91,7 +91,7 @@ export default class SQLBuilder {
 
     public toSQL(): string {
         if (!this.fromStatement) {
-            throw new Error("Unable to build SLQ without a FROM statement");
+            throw new Error("Unable to build SQL without a FROM statement");
         }
         return `
             ${this.isSummarizing ? "SUMMARIZE" : ""}

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/test/DatabaseAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/test/DatabaseAnnotationService.test.ts
@@ -28,9 +28,9 @@ describe("DatabaseAnnotationService", () => {
     });
 
     describe("fetchRootHierarchyValues", () => {
-        const annotationNames = ["Cell Line", "Is Split Scene", "Whatever"];
+        const annotationNames = ["Cell Line", "Is Split Scene", "Gene"];
         const annotations = annotationNames.map((name, index) => ({
-            foo: name + index,
+            mock_annotation: name + index,
             column_name: name,
             column_type: "VARCHAR",
         }));
@@ -40,37 +40,52 @@ describe("DatabaseAnnotationService", () => {
             }
         }
         const databaseService = new MockDatabaseService();
+        const mockDataSourceName = "mockDataSourceName";
+        const mockAnnotationName = "mock_annotation"; // snake case to match annotation properties in annotation map
 
+        // This test suite does not test the implementation or return values of fetchRootHierarchyValues
+        // It simply checks that a DatabaseService query is successfully issued
         it("issues a request for annotation values for the first level of the annotation hierarchy", async () => {
             const annotationService = new DatabaseAnnotationService({
-                dataSourceNames: ["d"],
+                dataSourceNames: [mockDataSourceName],
                 databaseService,
             });
-            const values = await annotationService.fetchRootHierarchyValues(["foo"], []);
-            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Whatever2"]);
+            const values = await annotationService.fetchRootHierarchyValues(
+                [mockAnnotationName],
+                []
+            );
+            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Gene2"]);
         });
 
         it("issues a request for annotation values for the first level of the annotation hierarchy with filters", async () => {
             const annotationService = new DatabaseAnnotationService({
-                dataSourceNames: ["e"],
+                dataSourceNames: [mockDataSourceName],
                 databaseService,
             });
-            const filter = new FileFilter("bar", "barValue");
-            const values = await annotationService.fetchRootHierarchyValues(["foo"], [filter]);
-            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Whatever2"]);
+            const filter = new FileFilter("annotationName", "annotationValue");
+            const values = await annotationService.fetchRootHierarchyValues(
+                [mockAnnotationName],
+                [filter]
+            );
+            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Gene2"]);
         });
 
         it("issues a request for annotation values for the first level of the annotation hierarchy with typed filters", async () => {
             const annotationService = new DatabaseAnnotationService({
-                dataSourceNames: ["e"],
+                dataSourceNames: [mockDataSourceName],
                 databaseService,
             });
-            const filter = new FileFilter("bar", "barValue", FilterType.ANY);
-            const values = await annotationService.fetchRootHierarchyValues(["foo"], [filter]);
-            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Whatever2"]);
+            const filter = new FileFilter("annotationName", "annotationValue", FilterType.ANY);
+            const values = await annotationService.fetchRootHierarchyValues(
+                [mockAnnotationName],
+                [filter]
+            );
+            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Gene2"]);
         });
     });
 
+    // This test suite does not test the implementation or return values of fetchHierarchyValuesUnderPath
+    // It simply checks that a DatabaseService query is successfully issued
     describe("fetchHierarchyValuesUnderPath", () => {
         const annotations = ["A", "B", "Cc", "dD"].map((name, index) => ({
             foo: name + index,
@@ -99,8 +114,6 @@ describe("DatabaseAnnotationService", () => {
         });
 
         it("issues request for hierarchy values under a specific path within the hierarchy with filters", async () => {
-            const expectedValues = ["A0", "B1", "Cc2", "dD3"];
-
             const annotationService = new DatabaseAnnotationService({
                 dataSourceNames: ["mock1"],
                 databaseService,
@@ -111,14 +124,12 @@ describe("DatabaseAnnotationService", () => {
                 ["baz"],
                 [filter]
             );
-            expect(values).to.deep.equal(expectedValues);
+            expect(values).to.deep.equal(["A0", "B1", "Cc2", "dD3"]);
         });
 
         it("issues request for hierarchy values under a specific path within the hierarchy with typed filters", async () => {
-            const expectedValues = ["A0", "B1", "Cc2", "dD3"];
-
             const annotationService = new DatabaseAnnotationService({
-                dataSourceNames: ["mock1"],
+                dataSourceNames: ["mockDataSource"],
                 databaseService,
             });
             const filter = new FileFilter("bar", "barValue", FilterType.FUZZY);
@@ -127,7 +138,7 @@ describe("DatabaseAnnotationService", () => {
                 ["baz"],
                 [filter]
             );
-            expect(values).to.deep.equal(expectedValues);
+            expect(values).to.deep.equal(["A0", "B1", "Cc2", "dD3"]);
         });
     });
 

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/test/DatabaseAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/test/DatabaseAnnotationService.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import FileFilter from "../../../../entity/FileFilter";
+import FileFilter, { FilterType } from "../../../../entity/FileFilter";
 import DatabaseServiceNoop from "../../../DatabaseService/DatabaseServiceNoop";
 
 import DatabaseAnnotationService from "..";
@@ -59,6 +59,16 @@ describe("DatabaseAnnotationService", () => {
             const values = await annotationService.fetchRootHierarchyValues(["foo"], [filter]);
             expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Whatever2"]);
         });
+
+        it("issues a request for annotation values for the first level of the annotation hierarchy with typed filters", async () => {
+            const annotationService = new DatabaseAnnotationService({
+                dataSourceNames: ["e"],
+                databaseService,
+            });
+            const filter = new FileFilter("bar", "barValue", FilterType.ANY);
+            const values = await annotationService.fetchRootHierarchyValues(["foo"], [filter]);
+            expect(values).to.deep.equal(["Cell Line0", "Is Split Scene1", "Whatever2"]);
+        });
     });
 
     describe("fetchHierarchyValuesUnderPath", () => {
@@ -96,6 +106,22 @@ describe("DatabaseAnnotationService", () => {
                 databaseService,
             });
             const filter = new FileFilter("bar", "barValue");
+            const values = await annotationService.fetchHierarchyValuesUnderPath(
+                ["foo", "bar"],
+                ["baz"],
+                [filter]
+            );
+            expect(values).to.deep.equal(expectedValues);
+        });
+
+        it("issues request for hierarchy values under a specific path within the hierarchy with typed filters", async () => {
+            const expectedValues = ["A0", "B1", "Cc2", "dD3"];
+
+            const annotationService = new DatabaseAnnotationService({
+                dataSourceNames: ["mock1"],
+                databaseService,
+            });
+            const filter = new FileFilter("bar", "barValue", FilterType.FUZZY);
             const values = await annotationService.fetchHierarchyValuesUnderPath(
                 ["foo", "bar"],
                 ["baz"],


### PR DESCRIPTION
This adds include/exclude logic for external files that DON'T use FES (e.g., use database service with SQL queries). 
Edit for context: the logic for FES has already been merged via #238 

This does NOT implement fuzzy vs. exact search toggling yet for non-FES sources -- our current logic for the database file service still does fuzzy matching by default. Because of this, I'm conditionally hiding/disabling the fuzzy toggle in the UI element for non-AICS data sources.

### Testing
Tested manually for `any value` filters and `no value` filters using a test csv that contains null values.
There's also some very simple unit tests to make sure things still run with typed filters