### PR TITLE
Fix datasets link

### DIFF
--- a/packages/web/src/components/Learn/index.tsx
+++ b/packages/web/src/components/Learn/index.tsx
@@ -145,7 +145,7 @@ export default function Learn() {
                 </p>
                 <p className={styles.sectionFooter}>
                     Check out our{" "}
-                    <Link className={styles.link} to="datasets">
+                    <Link className={styles.link} to="/datasets">
                         Open-source datasets
                     </Link>{" "}
                     for inspiration and examples of datasets.


### PR DESCRIPTION
Datasets link is broken, this makes it so it redirects to `/datasets` not `/learn/datasets`