### PR TITLE
Feature/comma sep count

### DIFF
--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -7,7 +7,7 @@
 }
 
 .list {
-    height: 100%;
+    height: calc(100% - 3px);
 }
 
 .row-count-display {

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -271,7 +271,7 @@ export default function FileList(props: FileListProps) {
                 {content}
             </div>
             <p className={styles.rowCountDisplay}>
-                {totalCount !== null ? `${totalCount} files` : "Counting files..."}
+                {totalCount !== null ? `${totalCount.toLocaleString()} files` : "Counting files..."}
             </p>
         </div>
     );


### PR DESCRIPTION
## Description
Simple change to make the file list display show as comma-separated (or dot-separated) depending on the browser locale.

## Related Issue
Resolves #270 & fixes weird issue on main where the file list is shown as a scroll even when not due to space including the text

## Before
<img width="180" alt="Screen Shot 2024-10-14 at 3 55 56 PM" src="https://github.com/user-attachments/assets/b91de78d-6034-4079-bcb0-598402266021">

## After 

<img width="139" alt="Screen Shot 2024-10-14 at 3 55 40 PM" src="https://github.com/user-attachments/assets/0e38b86f-0403-4ed2-bd09-06064ca178df">