### PR TITLE
Fix first file in file list click events

### DIFF
--- a/packages/core/components/FileList/Header.module.css
+++ b/packages/core/components/FileList/Header.module.css
@@ -10,6 +10,13 @@
   (in ./index.tsx). */
   height: calc(var(--inner-header-size) + 10px);
   z-index: 1000;
+
+  /* Makes the gradient not prevent clicking the first file */
+  pointer-events: none;
+}
+
+.header-wrapper > * {
+  pointer-events: auto;
 }
 
 .header {


### PR DESCRIPTION
## Description
The first file in the file list wasn't clickable due to the header gradient

## Related Issue
Resolves #166