### PR TITLE
Add description meta tag

### DIFF
--- a/packages/web/webpack/index.html
+++ b/packages/web/webpack/index.html
@@ -3,7 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>BioFile Finder</title>
+    <meta name="description" content="Open-use web application created for easy access, collaboration, and sharing of datasets through rich metadata search, filter, sort, and direct viewing.">
+    <meta name="author" content="Allen Institute for Cell Science">
     <link rel="icon" type="image/x-icon"href="logo.ico" />
+
     <!-- Google Tag Manager -->
     <script>(function (w, d, s, l, i) {
             w[l] = w[l] || []; w[l].push({
@@ -14,7 +19,6 @@
                     'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-KCCN6L4X');</script>
     <!-- End Google Tag Manager -->
-    <title>BioFile Finder</title>
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
## Description
In search engines we don't appear to have a description, this is due to a missing description tag. This should add the description.

## Related Issue
Resolves #267 