### PR TITLE
Add neuroglancer and volview

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -38,6 +38,7 @@ const WEB_APPS = (fileDetails?: FileDetail): WebApps => ({
         text: "Simularium",
         title: `Open files with Simularium`,
         href: `https://simularium.allencell.org/viewer?trajUrl=${fileDetails?.cloudPath}`,
+        disabled: !fileDetails?.path,
         target: "_blank",
     },
     volview: {


### PR DESCRIPTION
## Description
Yesterday during the data summit there was a lot of interest in getting Neuroglancer support in BFF so this adds Neuroglancer & VolView (just for fun). This also makes it so that apps that aren't expected to support the file get brought into an "Other" category at the bottom. I did not make the 3D Web Viewer, AGAVE, or Neuroglancer file type specific because .zarr files often don't have an extension and so these kind of act like defaults - we might want to consider changing that up later.

## Related Issue
Resolves #264