### PR TITLE
Address remaining minor styling issues from old list

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -45,6 +45,8 @@
 
 .data-source-prompt {
     padding: 10%;
+    overflow: scroll;
+    height: 100%;
 }
 
 .query-sidebar-and-center {

--- a/packages/core/components/Buttons/useButtonMenu.module.css
+++ b/packages/core/components/Buttons/useButtonMenu.module.css
@@ -35,6 +35,11 @@
 
 .button-menu-callout > div {
     border-radius: var(--small-border-radius);
+    background-color: unset;
+}
+
+.button-menu-callout span {
+    font-size: var(--l-paragraph-size);
 }
 
 .button-menu li:empty {

--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -60,10 +60,12 @@
 .text {
     margin: 0;
     padding: 2px 0.5em 2px 0;
+    line-height: 1.5;
 }
 
 .title, .details, .warning > p {
     padding: 2px 0;
+    line-height: 1.5;
 }
 
 .details, .details-list {

--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -54,7 +54,12 @@
 }
 
 .title {
-    margin-bottom: 30px;
+    margin-bottom: 6px;
+}
+
+.datasource-subhead {
+    margin-bottom: 26px !important;
+    font-weight: 600;
 }
 
 .text {

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -69,7 +69,11 @@ export default function DataSourcePrompt(props: Props) {
     return (
         <div className={props.className}>
             {!props.hideTitle && <h2 className={styles.title}>Choose a data source</h2>}
-            <p className={styles.text}>
+            <p
+                className={classNames(styles.text, {
+                    [styles.datasourceSubhead]: !props?.hideTitle,
+                })}
+            >
                 To get started, load a CSV, Parquet, or JSON file containing metadata (annotations)
                 about your files to view them.
             </p>

--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -41,8 +41,8 @@
 }
 
 .pagination-and-content {
-    padding: 12px 12px 0 12px;
-    width: 100%
+    padding: 12px 12px 0 16px;
+    width: 100%;
 }
 
 .overflow-container {
@@ -105,7 +105,7 @@
 
 
 .resize-handle {
-    --resize-handle-width: 10px;
+    --resize-handle-width: 15px;
 
     align-items: center;
     background: none;
@@ -124,7 +124,7 @@
 
 .resize-handle:hover {
     border-left: 2px solid var(--bright-aqua);
-    width: 10px;
+    width: var(--resize-handle-width);
     z-index: 9999;
 }
 

--- a/packages/core/components/FileList/Header.module.css
+++ b/packages/core/components/FileList/Header.module.css
@@ -61,6 +61,6 @@
   transform: translateY(0px);
 }
 
-.list-parent > div > div:nth-child(even) > div {
+.list-parent > div > div:nth-child(even) div {
   background-color: var(--primary-background-color);
 }

--- a/packages/core/components/FileList/LazilyRenderedRow.module.css
+++ b/packages/core/components/FileList/LazilyRenderedRow.module.css
@@ -1,14 +1,13 @@
-.row.selected > div {
+.row.selected div {
     background-color: var(--highlight-background-color) !important;
     border-bottom: 1px solid var(--secondary-background-color);
     color: var(--highlight-text-color);
 }
 
-.row.focused > div {
+.row.focused div {
     background-color: var(--highlight-hover-background-color) !important;
     border-bottom: 1px solid var(--secondary-background-color);
     color: var(--highlight-hover-text-color);
-    /* padding-bottom: 0; */
 }
 
 .row.small-font {

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
@@ -12,6 +12,7 @@
 
 .selected {
   background-color: var(--highlight-background-color);
+  color: var(--highlight-text-color);
 }
 
 .small-font {
@@ -20,6 +21,7 @@
 
 .focused {
   background-color: var(--highlight-hover-background-color);
+  color: var(--highlight-text-color);
 }
 
 .thumbnail-wrapper {
@@ -40,10 +42,15 @@
 }
 
 .thumbnail-wrapper > div > div {
+  border-radius: var(--small-border-radius);
   overflow-wrap: unset;
   text-overflow: ellipsis;
   word-break: keep-all;
   margin: auto;
   text-align: center;
   width: 100%;
+}
+
+.thumbnail-label {
+  padding-bottom: 5px;
 }

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
@@ -119,9 +119,10 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
                         width={thumbnailSize}
                         uri={thumbnailPath}
                         loading={isLoading}
+                        selected={isSelected}
                     />
                     <div
-                        className={classNames({
+                        className={classNames(styles.thumbnailLabel, {
                             [styles.smallFont]:
                                 shouldDisplaySmallFont ||
                                 fileGridColCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL,

--- a/packages/core/components/FileThumbnail/FileThumbnail.module.css
+++ b/packages/core/components/FileThumbnail/FileThumbnail.module.css
@@ -6,7 +6,13 @@
 }
 
 .no-thumbnail {
-    fill: var(--border-color);
+    fill: var(--medium-grey);
+    position: relative;
+    left: -4px;
+}
+
+.no-thumbnail-selected {
+    fill: var(--primary-dark);
 }
 
 .thumbnailPlaceholder {

--- a/packages/core/components/FileThumbnail/index.tsx
+++ b/packages/core/components/FileThumbnail/index.tsx
@@ -13,6 +13,7 @@ interface Props {
     height?: number | string;
     width?: number | string;
     loading?: boolean;
+    selected?: boolean;
 }
 
 /**
@@ -43,7 +44,9 @@ export default function FileThumbnail(props: Props) {
                 pathData={NO_IMAGE_ICON_PATH_DATA}
                 viewBox="0,1,22,22"
                 width={props.width}
-                className={classNames(styles.noThumbnail)}
+                className={classNames(styles.noThumbnail, {
+                    [styles.noThumbnailSelected]: props?.selected,
+                })}
             />
         );
     }

--- a/packages/core/components/QueryPart/QueryPart.module.css
+++ b/packages/core/components/QueryPart/QueryPart.module.css
@@ -17,7 +17,7 @@
 
 .add-button i {
     font-weight: 600;
-    font-size: 12px;
+    font-size: 13px;
 }
 
 .add-button:hover {

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -41,12 +41,19 @@
     overflow: hidden;
     padding: 8px 10px;
     text-overflow: ellipsis;
+    box-shadow: 2px 2px 4px rgb(0 0 0 / 0.8);
+    width: calc(100% - 5px);
 }
 
 .container:hover:not(.selected) {
     background-color: var(--highlight-background-color);
     color: var(--highlight-text-color);
     cursor: pointer;
+}
+
+.container:hover:not(.selected) .expand-button {
+    color: var(--highlight-text-color);
+    background: none;
 }
 
 .header {

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -8,6 +8,20 @@
     background-color: var(--highlight-background-color);
 }
 
+.expand-button {
+    color: var(--primary-sidebar-text-color);
+    background: none;
+}
+
+.expand-button:hover {
+    color: var(--highlight-text-color);
+    background: none;
+}
+
+.collapse-button i, .expand-button i {
+    font-weight: 600;
+}
+
 .display-row {
     margin: 8px 0;
 }
@@ -84,6 +98,12 @@
 
 .title:hover {
     border: 1px solid var(--border-color);
+    border-radius: var(--small-border-radius);
+    padding: 0 6px;
+}
+
+.title:active, .title:focus {
+    border: 1px solid var(--bright-aqua);
     border-radius: var(--small-border-radius);
     padding: 0 6px;
 }

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -101,7 +101,7 @@ export default function Query(props: QueryProps) {
                         ariaLabel="Expand"
                         className={styles.expandButton}
                         onClick={() => setIsExpanded(!isExpanded)}
-                        iconProps={{ iconName: "ChevronDown" }}
+                        iconProps={{ iconName: "ChevronDownMed" }}
                         data-testid="expand-button"
                     />
                 </div>
@@ -161,7 +161,7 @@ export default function Query(props: QueryProps) {
                     ariaLabel="Collapse"
                     className={styles.collapseButton}
                     onClick={() => setIsExpanded(!isExpanded)}
-                    iconProps={{ iconName: "ChevronUp" }}
+                    iconProps={{ iconName: "ChevronUpMed" }}
                     data-testid="collapse-button"
                 />
             </div>

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -96,16 +96,14 @@ export default function Query(props: QueryProps) {
                     <Tooltip content={props.query.name}>
                         <h4>{props.query.name}</h4>
                     </Tooltip>
-                    {props.isSelected && (
-                        <IconButton
-                            ariaDescription="Expand view details"
-                            ariaLabel="Expand"
-                            className={styles.collapseButton}
-                            onClick={() => setIsExpanded(!isExpanded)}
-                            iconProps={{ iconName: "ChevronUp" }}
-                            data-testid="expand-button"
-                        />
-                    )}
+                    <IconButton
+                        ariaDescription="Expand view details"
+                        ariaLabel="Expand"
+                        className={styles.expandButton}
+                        onClick={() => setIsExpanded(!isExpanded)}
+                        iconProps={{ iconName: "ChevronDown" }}
+                        data-testid="expand-button"
+                    />
                 </div>
                 <p className={styles.displayRow}>
                     <strong>Data source:</strong>{" "}
@@ -163,7 +161,7 @@ export default function Query(props: QueryProps) {
                     ariaLabel="Collapse"
                     className={styles.collapseButton}
                     onClick={() => setIsExpanded(!isExpanded)}
-                    iconProps={{ iconName: "ChevronDown" }}
+                    iconProps={{ iconName: "ChevronUp" }}
                     data-testid="collapse-button"
                 />
             </div>

--- a/packages/core/components/QuerySidebar/QuerySidebar.module.css
+++ b/packages/core/components/QuerySidebar/QuerySidebar.module.css
@@ -64,6 +64,7 @@
     height: calc(100% - var(--header-height) - var(--footer-height));
     overflow-y: auto;
     padding-bottom: 40px;
+    padding-right: 8px;
 }
 
 .queries-container::after {
@@ -99,14 +100,15 @@
     z-index: 9999;
 }
 
-.minimize-bar > div {
-    height: 15px;
-    width: 2px;
-    background-color: var(--highlight-background-color);
+.minimize-bar > i {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--highlight-background-color);
+    padding-right: 4px;
 }
 
-.minimize-bar:hover > div {
-    background-color: var(--highlight-hover-background-color);
+.minimize-bar:hover > i {
+    color: var(--highlight-hover-background-color);
     transform: translateX(0.5px);
 }
 

--- a/packages/core/components/QuerySidebar/QuerySidebar.module.css
+++ b/packages/core/components/QuerySidebar/QuerySidebar.module.css
@@ -48,7 +48,9 @@
 }
 
 .minimized-container:hover {
-    box-shadow: 5px 0 5px -2px var(--highlight-background-color)
+    box-shadow: 5px 0 5px -2px var(--highlight-background-color);
+    background-color: var(--accent-dark);
+    color: var(--highlight-text-color);
 }
 
 .minimized-container > p {
@@ -58,6 +60,8 @@
     text-align: center;
     transform: rotate(180deg);
     white-space: nowrap;
+    font-weight: 600;
+    padding-left: 3px;
 }
 
 .queries-container {
@@ -100,16 +104,29 @@
     z-index: 9999;
 }
 
-.minimize-bar > i {
+.minimize-bar > i, .minimized-container i {
     font-size: 10px;
     font-weight: 700;
     color: var(--highlight-background-color);
-    padding-right: 4px;
+}
+
+.minimize-bar > i {
+    padding-right: 5px;
+}
+
+.minimized-container i {
+    padding: 10px 0;
+    position: relative;
+    right: 2px;
 }
 
 .minimize-bar:hover > i {
     color: var(--highlight-hover-background-color);
     transform: translateX(0.5px);
+}
+
+.minimized-container:hover i {
+    color: var(--highlight-hover-background-color);
 }
 
 .header {

--- a/packages/core/components/QuerySidebar/QuerySidebar.module.css
+++ b/packages/core/components/QuerySidebar/QuerySidebar.module.css
@@ -101,7 +101,7 @@
 }
 
 .minimize-bar > i {
-    font-size: 13px;
+    font-size: 10px;
     font-weight: 700;
     color: var(--highlight-background-color);
     padding-right: 4px;

--- a/packages/core/components/QuerySidebar/index.tsx
+++ b/packages/core/components/QuerySidebar/index.tsx
@@ -157,7 +157,7 @@ export default function QuerySidebar(props: QuerySidebarProps) {
                 </Tooltip>
             </div>
             <div className={styles.minimizeBar} onClick={() => setIsExpanded(false)}>
-                <Icon iconName={"ChevronLeft"} />
+                <Icon iconName={"ChevronLeftSmall"} />
             </div>
         </div>
     );

--- a/packages/core/components/QuerySidebar/index.tsx
+++ b/packages/core/components/QuerySidebar/index.tsx
@@ -2,6 +2,7 @@ import {
     ContextualMenuItemType,
     DirectionalHint,
     IContextualMenuItem,
+    Icon,
     IconButton,
 } from "@fluentui/react";
 import classNames from "classnames";
@@ -156,7 +157,7 @@ export default function QuerySidebar(props: QuerySidebarProps) {
                 </Tooltip>
             </div>
             <div className={styles.minimizeBar} onClick={() => setIsExpanded(false)}>
-                <div />
+                <Icon iconName={"ChevronLeft"} />
             </div>
         </div>
     );

--- a/packages/core/components/QuerySidebar/index.tsx
+++ b/packages/core/components/QuerySidebar/index.tsx
@@ -100,7 +100,11 @@ export default function QuerySidebar(props: QuerySidebarProps) {
         return (
             <div className={styles.minimizedContainer} onClick={() => setIsExpanded(true)}>
                 <p>
-                    <strong>{selectedQuery}</strong>
+                    Query Panel
+                    <Icon
+                        iconName={"ChevronLeftSmall"}
+                        className={styles.minimizedContainerExpand}
+                    />
                 </p>
             </div>
         );

--- a/packages/core/hooks/useFileAccessContextMenu.ts
+++ b/packages/core/hooks/useFileAccessContextMenu.ts
@@ -86,9 +86,6 @@ export default (filters?: FileFilter[], onDismiss?: () => void) => {
                             {
                                 key: "csv",
                                 text: "CSV",
-                                iconProps: {
-                                    iconName: "Folder",
-                                },
                                 disabled: !filters && fileSelection.count() === 0,
                                 title: "Download a CSV of the metadata of the selected files",
                                 onClick() {
@@ -107,9 +104,6 @@ export default (filters?: FileFilter[], onDismiss?: () => void) => {
                                       {
                                           key: "json",
                                           text: "JSON",
-                                          iconProps: {
-                                              iconName: "Folder",
-                                          },
                                           disabled: !filters && fileSelection.count() === 0,
                                           title:
                                               "Download a JSON file of the metadata of the selected files",
@@ -125,9 +119,6 @@ export default (filters?: FileFilter[], onDismiss?: () => void) => {
                                       {
                                           key: "parquet",
                                           text: "Parquet",
-                                          iconProps: {
-                                              iconName: "Folder",
-                                          },
                                           disabled: !filters && fileSelection.count() === 0,
                                           title:
                                               "Download a Parquet file of the metadata of the selected files",

--- a/packages/web/src/components/Home/index.tsx
+++ b/packages/web/src/components/Home/index.tsx
@@ -40,7 +40,7 @@ export default function Home() {
                 <Link to="datasets">
                     <PrimaryButton
                         className={styles.optionButton}
-                        iconName="BulletedList"
+                        iconName="List"
                         title="View datasets"
                         text="VIEW DATASETS"
                     />

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
@@ -77,7 +77,12 @@ export default function DatasetTable(props: DatasetTableProps) {
         if (!fieldContent) return <>--</>;
         if (column?.fieldName === DatasetAnnotations.RELATED_PUBLICATON.name && item?.doi) {
             return (
-                <a className={classNames(styles.link, styles.doubleLine)} href={item.doi}>
+                <a
+                    className={classNames(styles.link, styles.doubleLine)}
+                    href={item.doi}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     {fieldContent}
                 </a>
             );

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -68,19 +68,19 @@ export default function OpenSourceDatasets() {
                             target="_blank"
                             rel="noreferrer"
                         >
-                            &nbsp;our GitHub page here&nbsp;
+                            &nbsp;our GitHub page&nbsp;
                         </a>
-                        and we can see about including your data. Please note, your image data would
-                        need to be stored in a public location like
+                        and we can see about including your data. Please note that your image data
+                        would need to be stored in a public location like
                         <a
                             className={styles.link}
                             href="https://idr.openmicroscopy.org/"
                             target="_blank"
                             rel="noreferrer"
                         >
-                            &nbsp;on Image Data Registry&nbsp;
+                            &nbsp;the Image Data Resource&nbsp;
                         </a>{" "}
-                        or AWS for example.
+                        or AWS.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This resolves (almost) all of the remaining requested UX changes from [this doc](https://docs.google.com/document/d/1QP_xT7IZOuLjgaHyK2gletNUK1ybCt7B_ayOG34H0zU/edit?tab=t.0). The full list of changes addressed in this PR is available in #287; details and screenshots of requests are in the doc. 

This touches a lot of files, but the main changes are to the query sidebar, datasource modal and the file list. 
Mostly css changes, so reviewing might be tedious (sorry). 

NOT covered by this PR: (would overlap with other tickets)
- Adding left/right buttons to carousel of features on home page
- Agave menu styling

closes #287