### PR TITLE
Update view info button style

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -56,7 +56,7 @@ const DESKTOP_APPS = (fileDetails?: FileDetail): { agave: IContextualMenuItem } 
         key: "agave",
         className: styles.desktopMenuItem,
         text: "AGAVE",
-        title: `Open files with AGAVE v1.7.2+`,
+        title: "Open files with AGAVE v1.7.2+",
         href: `agave://?url=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
         target: "_blank",

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -1,4 +1,4 @@
-import { ContextualMenuItemType, IContextualMenuItem, Icon } from "@fluentui/react";
+import { ContextualMenuItemType, DefaultButton, Icon, IContextualMenuItem } from "@fluentui/react";
 import { isEmpty } from "lodash";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -54,9 +54,9 @@ const WEB_APPS = (fileDetails?: FileDetail): WebApps => ({
 const DESKTOP_APPS = (fileDetails?: FileDetail): { agave: IContextualMenuItem } => ({
     agave: {
         key: "agave",
-        className: styles.agaveLink,
+        className: styles.desktopMenuItem,
         text: "AGAVE",
-        title: `Open files with AGAVE`,
+        title: `Open files with AGAVE v1.7.2+`,
         href: `agave://?url=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
         target: "_blank",
@@ -70,8 +70,13 @@ const DESKTOP_APPS = (fileDetails?: FileDetail): { agave: IContextualMenuItem } 
                         rel="noreferrer"
                         target="_blank"
                     >
-                        | View info
-                        <Icon iconName="Link" />
+                        <DefaultButton
+                            className={styles.infoButton}
+                            title="Get info or download to enable use"
+                        >
+                            Info
+                            <Icon iconName="OpenInNewWindow" />
+                        </DefaultButton>
                     </a>
                 </>
             );

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -1,30 +1,32 @@
-.agave-link {
-    color: var(--secondary-text-color);
+.desktop-menu-item .info-button {
+    background-color: var(--primary-background-color);
+    border-radius: var(--large-border-radius);
+    border: none;
+    color: var(--primary-text-color);
+    font-size: 12px;
+    height: 20px;
+    padding: 0;
+
+     /* TODO: The below is a bit funky */
+    max-width: 40px;
+    overflow: hidden;
+    width: 40px;
 }
 
-.agave-link:hover a > i, .agave-link:hover a > div > span {
-    color: var(--secondary-text-color) !important;
-}
-
-.agave-link:hover a > i, .agave-link a > div > span:hover {
-    color: var(--highlight-text-color) !important;
-}
-
-.view-link {
-    align-items: center;
-    color: var(--secondary-text-color);
-    display: flex;
-    font-size: var(--xs-paragraph-size);
-    height: 34px;
-}
-
-.view-link > i {
-    color: var(--secondary-text-color) !important;
-    height: 34px;
-    padding-left: 4px;
-    transform: translateY(-1px);
-}
-
-.view-link:hover, .view-link:hover > i {
+.desktop-menu-item:hover .info-button {
+    background-color: var(--highlight-background-color);
     color: var(--highlight-text-color);
+}
+
+.desktop-menu-item .info-button:hover {
+    background-color: var(--dark-aqua);
+}
+
+.desktop-menu-item .info-button i {
+    padding-left: 4px;
+}
+
+.desktop-menu-item a {
+    padding-left: 35px;
+    width: 25px;
 }

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -5,20 +5,27 @@
     color: var(--primary-text-color);
     font-size: 12px;
     height: 20px;
-    padding: 0;
-
-     /* TODO: The below is a bit funky */
-    max-width: 40px;
+    max-width: 50px;
+    min-width: 50px;
     overflow: hidden;
-    width: 40px;
+    padding: 0;
+    width: 50px;
 }
 
-.desktop-menu-item:hover .info-button {
+.desktop-menu-item .info-button {
+    transform: translateY(-2px);
+}
+
+.desktop-menu-item .info-button {
+    font-size: 10px;
+}
+
+.desktop-menu-item:hover > div, .desktop-menu-item:hover .info-button {
     background-color: var(--highlight-background-color);
     color: var(--highlight-text-color);
 }
 
-.desktop-menu-item .info-button:hover {
+.desktop-menu-item .info-button:hover, .desktop-menu-item .info-button:hover i {
     background-color: var(--dark-aqua);
 }
 
@@ -27,6 +34,6 @@
 }
 
 .desktop-menu-item a {
-    padding-left: 35px;
+    padding-left: 57.5px;
     width: 25px;
 }

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -20,7 +20,7 @@
     font-size: 10px;
 }
 
-.desktop-menu-item:hover > div, .desktop-menu-item:hover .info-button {
+.desktop-menu-item:hover > div, .desktop-menu-item:hover .info-button, .desktop-menu-item:hover .info-button i {
     background-color: var(--highlight-background-color);
     color: var(--highlight-text-color);
 }


### PR DESCRIPTION
## Description
AGAVE is a desktop application which means it requires a download so we want to make it easy for people to find and download it. This changeset upgrades the styling of the button that links to the download page for AGAVE (and in the future for other desktop apps). Resolves #284

### Before
<img width="317" alt="Screen Shot 2024-10-23 at 12 34 28 PM" src="https://github.com/user-attachments/assets/c41de980-5eb7-4b0a-8f2e-df022c31ac18">

### After
<img width="517" alt="Screen Shot 2024-10-23 at 12 34 06 PM" src="https://github.com/user-attachments/assets/21fed8e8-4fae-48e2-a847-73ac0bccead2">
