### PR TITLE
Fix stalled thumbnail unit tests

### DIFF
--- a/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
@@ -16,7 +16,7 @@
 }
 
 .small-font {
-  font-size: var(--xs-paragraph-size);
+  font-size: var(--s-paragraph-size);
 }
 
 .focused {
@@ -25,7 +25,7 @@
 }
 
 .thumbnail-wrapper {
-  font-size: var(--s-paragraph-size);
+  font-size: var(--l-paragraph-size);
   padding: 4px;
 }
 

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
@@ -66,7 +66,6 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
 
     React.useEffect(() => {
         if (file) {
-            setIsLoading(true);
             file.getPathToThumbnail().then((path) => {
                 setThumbnailPath(path);
                 setIsLoading(false);


### PR DESCRIPTION
The unit tests for `LazilyRenderedThumbnail` were getting stalled. It seems the `.useEffect` was creating an infinite loop, which is apparently a common issue with React/jest. 

I'm still not sure if I fully understand, but my best interpretation is that `useEffect` is dependent on `file` changes, & calling `setThumbnailPath` technically modifies `file`, so the effect runs again. Then toggling `isLoading` back to true triggers a re-render since the `FileThumbnail` component depends on `isLoading`, which calls `useEffect` again, and the loop starts all over... So our unit tests never fully finished rendering the component. 

## Proposed change
Since we already initialize `isLoading` to true and don't set it to false anywhere else, we can remove setting it to true in the effect. This way, `useEffect` only calls twice (once on initialization, and then once to register the change to `file`) and then stops. 

There's also an unrelated .css change; I missed increasing the font size for thumbnail labels in #287.

## Testing/Reviewing
I verified that unit tests run & finish now, but it would be great to double check that the thumbnail loading state still works as expected.