### PR TITLE
Eternal load on start

### DIFF
--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -30,8 +30,10 @@ export default function Query(props: QueryProps) {
     const annotations = useSelector(metadata.selectors.getSortedAnnotations);
     const currentQueryParts = useSelector(selection.selectors.getCurrentQueryParts);
 
+    const shouldHaveDataSource = !!window.location.search;
     const hasDataSource = !!props.query.parts.sources.length;
-    const isLoading = !hasDataSource || props.query.name === AICS_FMS_DATA_SOURCE_NAME;
+    const isLoading =
+        (shouldHaveDataSource && !hasDataSource) || props.query.name === AICS_FMS_DATA_SOURCE_NAME;
 
     const [isExpanded, setIsExpanded] = React.useState(false);
     React.useEffect(() => {


### PR DESCRIPTION
The spinner was blocking the data source query panel on start for users that both aren't looking at a specific data source yet and aren't on institute wifi. This adds a qualifier to make it only load when we are expecting there to be a data source and isn't one.

Resolves #285 