### PR TITLE
LOAD button on dataset page bug

### DIFF
--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
@@ -20,7 +20,6 @@
 }
 
 .button-wrapper {
-  pointer-events: none;
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
@@ -22,12 +22,15 @@
 .button-wrapper {
   position: absolute;
   top: 0;
-  left: 0;
-  width: 100%;
+  right: 0;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+}
+
+.button-wrapper:hover {
+  width: 100%;
 }
 
 .button-wrapper-hidden {

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
@@ -62,6 +62,7 @@
     background-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9));
     position: absolute;
     height: calc(100% - calc(4*var(--margin)));
+    pointer-events: none;
     width: 86px;
   }
 }


### PR DESCRIPTION
The "LOAD" button on the open-source datasets page doesn't actually load the dataset. This is because the pointer-events property here is preventing that. Resolves #300 