### PR TITLE
Fix evergreen CI

### DIFF
--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: "16"
+          node-version: 16
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on: pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - name: Check out Git repository
         uses: actions/checkout@main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Check out Git repository
         uses: actions/checkout@main
@@ -21,6 +22,8 @@ jobs:
         run: npm run lint
 
   test-core:
+    runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Check out Git repository
         uses: actions/checkout@main
@@ -38,6 +41,7 @@ jobs:
 
   test-web:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Check out Git repository
         uses: actions/checkout@main
@@ -55,6 +59,7 @@ jobs:
 
   test-desktop:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Check out Git repository
         uses: actions/checkout@main
@@ -72,6 +77,7 @@ jobs:
 
   build-desktop:
     runs-on: ${{ matrix.os }}
+    needs: test-desktop, test-web, test-core
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,7 @@ jobs:
 
   build-desktop:
     runs-on: ${{ matrix.os }}
-    needs: test-desktop, test-web, test-core
+    needs: [test-desktop, test-web, test-core]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,58 @@ name: integration
 on: pull_request
 
 jobs:
-  build-fms-file-explorer-electron:
+  test-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@main
+
+      - name: Install Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run test:core
+
+  test-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@main
+
+      - name: Install Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run test:web
+
+  test-desktop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@main
+
+      - name: Install Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run test:desktop
+
+  build-desktop:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -13,12 +64,12 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@main
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js
         uses: actions/setup-node@main
         with:
           node-version: 16
 
-      - name: Build/release Electron app
+      - name: Build Electron app
         uses: AllenCellSoftware/action-electron-builder@fms-file-explorer
         with:
           # GitHub token, automatically provided to the action

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: integration
 on: pull_request
 
 jobs:
-  test-core:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
@@ -17,7 +17,23 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build
+      - name: Lint
+        run: npm run lint
+
+  test-core:
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@main
+
+      - name: Install Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Unit Test
         run: npm run test:core
 
   test-web:
@@ -34,7 +50,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build
+      - name: Unit Test
         run: npm run test:web
 
   test-desktop:
@@ -51,7 +67,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build
+      - name: Unit Test
         run: npm run test:desktop
 
   build-desktop:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - v*
 
 jobs:
-  release-fms-file-explorer-desktop:
+  release-desktop:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.ref }}
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js
         uses: actions/setup-node@main
         with:
           node-version: 16


### PR DESCRIPTION
The CI is evergreen. I think this happened when we upgraded the build deploy method since it seems the desktop build action no longer does a unit test run. This should make it not evergreen and split up the tests and build stuff to make the errors we hit more apparent. Resolves #261 

see oooo a dependency graph 🌟 
<img width="1011" alt="Screen Shot 2024-10-24 at 3 12 33 PM" src="https://github.com/user-attachments/assets/d816771a-068d-4930-aaae-f6f48583174d">
