### PR TITLE
Upgrade data source validation

### DIFF
--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -165,7 +165,7 @@ const requestDatasetManifest = createLogic({
 
         try {
             if (uri) {
-                await databaseService.prepareDataSources([{ name, type: "csv", uri }]);
+                await databaseService.prepareDataSources([{ name, type: "csv", uri }], true);
                 dispatch(receiveDatasetManifest(name, uri));
             }
         } catch (err) {

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -720,13 +720,22 @@ export const ADD_DATASOURCE_RELOAD_ERROR = makeConstant(
 );
 
 export interface AddDataSourceReloadError {
-    payload: string;
+    payload: {
+        dataSourceName: string;
+        error: string;
+    };
     type: string;
 }
 
-export function addDataSourceReloadError(dataSourceName: string): AddDataSourceReloadError {
+export function addDataSourceReloadError(
+    dataSourceName: string,
+    error: string
+): AddDataSourceReloadError {
     return {
-        payload: dataSourceName,
+        payload: {
+            dataSourceName,
+            error,
+        },
         type: ADD_DATASOURCE_RELOAD_ERROR,
     };
 }

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -45,6 +45,7 @@ import {
     ADD_DATASOURCE_RELOAD_ERROR,
     REMOVE_DATASOURCE_RELOAD_ERROR,
     CHANGE_FILE_FILTER_TYPE,
+    AddDataSourceReloadError,
 } from "./actions";
 import { interaction, metadata, ReduxLogicDeps, selection } from "../";
 import * as selectionSelectors from "./selectors";
@@ -520,12 +521,10 @@ const changeDataSourceLogic = createLogic({
             // Hide warning pop-up if present and remove datasource error from state
             dispatch(removeDataSourceReloadError());
         } catch (err) {
-            const errMsg = `Error encountered while preparing data sources (Full error: ${
-                (err as Error).message
-            })`;
+            const errMsg = (err as Error).message || "Unknown error while changing data source";
             console.error(errMsg);
             if (err instanceof DataSourcePreparationError) {
-                dispatch(addDataSourceReloadError(err.sourceName) as AnyAction);
+                dispatch(addDataSourceReloadError(err.sourceName, errMsg) as AnyAction);
             } else {
                 dispatch(interaction.actions.processError("dataSourcePreparationError", errMsg));
             }
@@ -575,12 +574,10 @@ const addQueryLogic = createLogic({
             // Hide warning pop-up if present and remove datasource error from state
             dispatch(removeDataSourceReloadError());
         } catch (err) {
-            const errMsg = `Error encountered while preparing data sources (Full error: ${
-                (err as Error).message
-            })`;
+            const errMsg = (err as Error).message || "Unknown error while adding query";
             console.error(errMsg);
             if (err instanceof DataSourcePreparationError) {
-                dispatch(addDataSourceReloadError(err.sourceName) as AnyAction);
+                dispatch(addDataSourceReloadError(err.sourceName, errMsg) as AnyAction);
             } else {
                 dispatch(interaction.actions.processError("dataSourcePreparationError", errMsg));
             }
@@ -669,12 +666,10 @@ const replaceDataSourceLogic = createLogic({
             // Hide warning pop-up if present and remove datasource error from state
             dispatch(removeDataSourceReloadError());
         } catch (err) {
-            const errMsg = `Error encountered while replacing data sources (Full error: ${
-                (err as Error).message
-            })`;
+            const errMsg = (err as Error).message || "Unknown error while replacing data source";
             console.error(errMsg);
             if (err instanceof DataSourcePreparationError) {
-                dispatch(addDataSourceReloadError(err.sourceName) as AnyAction);
+                dispatch(addDataSourceReloadError(err.sourceName, errMsg) as AnyAction);
             } else {
                 dispatch(interaction.actions.processError("dataSourcePreparationError", errMsg));
             }
@@ -709,15 +704,21 @@ const replaceDataSourceLogic = createLogic({
 // If removing, hides pop-up (if there is one) and unsets bool
 const setDataSourceReloadErrorLogic = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
-        const { payload: dataSourceName, type } = deps.action;
-        const datasourceErrorDefaultMessage = `There was an error loading the data source file
-                        '${dataSourceName}'. Please re-select the data source file or a replacement.
-                    </br>
-                        If this is a local file, the browser&apos;s permissions to access the file
-                        may have expired since last time. If so, consider putting the file in a
-                        cloud storage and providing the URL to avoid this issue in the future.`;
-
-        if (type === ADD_DATASOURCE_RELOAD_ERROR) {
+        const isNewError = deps.action.type === ADD_DATASOURCE_RELOAD_ERROR;
+        if (isNewError) {
+            const {
+                payload: { dataSourceName, error },
+            } = deps.action as AddDataSourceReloadError;
+            const datasourceErrorDefaultMessage = `
+                The following error occurred while loading the data source
+                &quot;${dataSourceName}&quot;:
+                </br>
+                </br>
+                ${error}
+                </br>
+                </br>
+                Please re-select the data source or a replacement.
+            `;
             dispatch(
                 interaction.actions.processError(
                     "dataSourceReloadError",
@@ -725,7 +726,7 @@ const setDataSourceReloadErrorLogic = createLogic({
                 )
             );
         } else dispatch(interaction.actions.removeStatus("dataSourceReloadError"));
-        dispatch(setRequiresDataSourceReload(type === ADD_DATASOURCE_RELOAD_ERROR) as AnyAction);
+        dispatch(setRequiresDataSourceReload(isNewError) as AnyAction);
         done();
     },
     type: [ADD_DATASOURCE_RELOAD_ERROR, REMOVE_DATASOURCE_RELOAD_ERROR],

--- a/packages/desktop/src/services/DatabaseServiceElectron.ts
+++ b/packages/desktop/src/services/DatabaseServiceElectron.ts
@@ -77,7 +77,7 @@ export default class DatabaseServiceElectron extends DatabaseService {
         });
     }
 
-    protected async addDataSource(dataSource: Source): Promise<void> {
+    protected async addDataSource(dataSource: Source, skipValidation = false): Promise<void> {
         const { name, type, uri } = dataSource;
         if (this.existingDataSources.has(name)) {
             return; // no-op
@@ -138,6 +138,13 @@ export default class DatabaseServiceElectron extends DatabaseService {
                     );
                 }
             });
+
+            if (!skipValidation) {
+                const errors = await this.checkDataSourceForErrors(name);
+                if (errors.length) {
+                    throw new Error(errors.join("</br></br>"));
+                }
+            }
         } catch (err) {
             await this.deleteDataSource(name);
             throw new DataSourcePreparationError((err as Error).message, name);


### PR DESCRIPTION
## Description
We got some reports from users that they were having trouble troubleshooting getting their data into BFF. Specifically that it wasn't clear what was happening when "File Path" exact casing wasn't present, when there were duplicate values, and when there were missing values. This changeset makes it so that when a data source is added a validation step runs from which errors will be reported in the UI if relevant.

## Error Examples

Duplicate & blank values (will also be shown separately when relevant)
<img width="748" alt="Screen Shot 2024-10-30 at 5 55 02 PM" src="https://github.com/user-attachments/assets/574db0f8-2b2b-459d-8399-67ce6dd80d25">

Unable to access data source (like on refresh)
<img width="690" alt="Screen Shot 2024-10-30 at 5 49 50 PM" src="https://github.com/user-attachments/assets/30f6f161-1c47-4a74-92c4-c49be61f7ebb">

No "File Path" column detected
<img width="674" alt="Screen Shot 2024-10-30 at 5 28 51 PM" src="https://github.com/user-attachments/assets/29930b97-2ada-44d6-b52b-136c781d674b">

## Related Issue
Resolves #272
