### PR TITLE
feature/web-download-threshold

### DIFF
--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -14,7 +14,7 @@ import FileThumbnail from "../../components/FileThumbnail";
 import { interaction } from "../../state";
 
 import styles from "./FileDetails.module.css";
-import { MaximumDownloadSizeBrowser } from "../../services/FileDownloadService";
+import { MAX_DOWNLOAD_SIZE_WEB } from "../../services/FileDownloadService";
 
 interface Props {
     className?: string;
@@ -120,7 +120,7 @@ export default function FileDetails(props: Props) {
               isZarr &&
               // The Zarr size is calculated using the same traversal method as downloads
               // meaning that if the size cannot be determined, the download is also not possible.
-              (calculatedSize === null || calculatedSize > MaximumDownloadSizeBrowser))
+              (calculatedSize === null || calculatedSize > MAX_DOWNLOAD_SIZE_WEB))
         : true;
 
     // Prevent triggering multiple downloads accidentally -- throttle with a 1s wait

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -118,6 +118,8 @@ export default function FileDetails(props: Props) {
         ? processStatuses.some((status) => status.data.fileId?.includes(fileDetails.id)) ||
           (isOnWeb &&
               isZarr &&
+              // The Zarr size is calculated using the same traversal method as downloads
+              // meaning that if the size cannot be determined, the download is also not possible.
               (calculatedSize === null || calculatedSize > MaximumDownloadSizeBrowser))
         : true;
 

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -14,6 +14,7 @@ import FileThumbnail from "../../components/FileThumbnail";
 import { interaction } from "../../state";
 
 import styles from "./FileDetails.module.css";
+import { MaximumDownloadSizeBrowser } from "../../services/FileDownloadService";
 
 interface Props {
     className?: string;
@@ -117,7 +118,7 @@ export default function FileDetails(props: Props) {
         ? processStatuses.some((status) => status.data.fileId?.includes(fileDetails.id)) ||
           (isOnWeb &&
               isZarr &&
-              (calculatedSize === null || calculatedSize > 2 * 1024 * 1024 * 1024))
+              (calculatedSize === null || calculatedSize > MaximumDownloadSizeBrowser))
         : true;
 
     // Prevent triggering multiple downloads accidentally -- throttle with a 1s wait

--- a/packages/core/services/FileDownloadService/index.ts
+++ b/packages/core/services/FileDownloadService/index.ts
@@ -155,4 +155,4 @@ export const FileDownloadCancellationToken =
 /**
  * Maximum size of multifile cloud files that can be downloaded from a browser ~2GB
  */
-export const MaximumDownloadSizeBrowser = 2 * 1024 * 1024 * 1024;
+export const MAX_DOWNLOAD_SIZE_WEB = 2 * 1024 * 1024 * 1024;

--- a/packages/core/services/FileDownloadService/index.ts
+++ b/packages/core/services/FileDownloadService/index.ts
@@ -151,3 +151,8 @@ export default abstract class FileDownloadService extends HttpServiceBase {
  */
 export const FileDownloadCancellationToken =
     "FMS_EXPLORER_EXECUTABLE_FILE_DOWNLOAD_CANCELLATION_TOKEN";
+
+/**
+ * Maximum size of multifile cloud files that can be downloaded from a browser ~2GB
+ */
+export const MaximumDownloadSizeBrowser = 2 * 1024 * 1024 * 1024;

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -84,6 +84,8 @@ Please navigate to this directory manually, or upload files to a remote address 
         // Most modern web browsers have memory constraints that limit them to using approximately 2 GB of RAM.
         // Exceeding this limit can cause memory issues, crashes, or download failures due to insufficient memory.
         // This check ensures that the total download size does not surpass the supported 2 GB threshold.
+        // Additionally, zarr size is calculated using the same traversal method as downloads,
+        // meaning that if the size cannot be determined, the download is also not possible.
         if (totalSize > MaximumDownloadSizeBrowser) {
             throw new Error(
                 `The total download size of the requested zarr file exceeds the 2 GB RAM limit supported by web browsers. ` +

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -6,7 +6,7 @@ import {
     FileInfo,
     DownloadResolution,
 } from "../../../core/services";
-import { MaximumDownloadSizeBrowser } from "../../../core/services/FileDownloadService";
+import { MAX_DOWNLOAD_SIZE_WEB } from "../../../core/services/FileDownloadService";
 
 interface ActiveRequestMap {
     [id: string]: {
@@ -86,7 +86,7 @@ Please navigate to this directory manually, or upload files to a remote address 
         // This check ensures that the total download size does not surpass the supported 2 GB threshold.
         // Additionally, zarr size is calculated using the same traversal method as downloads,
         // meaning that if the size cannot be determined, the download is also not possible.
-        if (totalSize > MaximumDownloadSizeBrowser) {
+        if (totalSize > MAX_DOWNLOAD_SIZE_WEB) {
             throw new Error(
                 `The total download size of the requested zarr file exceeds the 2 GB RAM limit supported by web browsers. ` +
                     `Attempting to download a total size of ${(

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -6,6 +6,7 @@ import {
     FileInfo,
     DownloadResolution,
 } from "../../../core/services";
+import { MaximumDownloadSizeBrowser } from "../../../core/services/FileDownloadService";
 
 interface ActiveRequestMap {
     [id: string]: {
@@ -79,11 +80,11 @@ Please navigate to this directory manually, or upload files to a remote address 
         // Calculate the total size of the S3 directory
         const totalSize = await this.calculateS3DirectorySize(hostname, key);
 
-        // Check if the total size exceeds 2 GB (2 * 1024 * 1024 * 1024 bytes)
+        // Check if the total size exceeds 2 GB.
         // Most modern web browsers have memory constraints that limit them to using approximately 2 GB of RAM.
         // Exceeding this limit can cause memory issues, crashes, or download failures due to insufficient memory.
         // This check ensures that the total download size does not surpass the supported 2 GB threshold.
-        if (totalSize > 2 * 1024 * 1024 * 1024) {
+        if (totalSize > MaximumDownloadSizeBrowser) {
             throw new Error(
                 `The total download size of the requested zarr file exceeds the 2 GB RAM limit supported by web browsers. ` +
                     `Attempting to download a total size of ${(


### PR DESCRIPTION
The purpose of this PR is to resolve #283. In web browsers we have to read the entire zarr image into memory and cannot stream files as zarrs are a full directory. As a result of this we are bound to the browsers inherent memory limit of about 2GB. We should notify users if they are trying to download a file larger than this threshold.