### PR TITLE
[small] Fix scrollbar for Safari and Chromium

### DIFF
--- a/packages/core/styles/global.css
+++ b/packages/core/styles/global.css
@@ -20,8 +20,30 @@ main {
     padding: 0;
     border: 0;
     overflow: hidden;
-    /* Unavailable on some versions of some browsers */
-    scrollbar-color:  var(--medium-grey) var(--accent-dark);
+}
+
+/* For browsers that support `scrollbar-*` properties */
+@supports (scrollbar-color: auto) {
+    html,
+    body,
+    main {
+        scrollbar-color: var(--medium-grey) var(--accent-dark);
+    }
+}
+/* Otherwise, use `::-webkit-scrollbar-*` pseudo-elements */
+@supports selector(::-webkit-scrollbar) {
+    body *::-webkit-scrollbar {
+        background-color: var(--accent-dark);
+        width: 12px;
+        height: 12px;
+    }
+    body *::-webkit-scrollbar-corner {
+        background-color: var(--accent-dark);
+    }
+    body *::-webkit-scrollbar-thumb {
+        background-color: var(--medium-grey);
+        border-radius: 8px
+    }
 }
 
 body {


### PR DESCRIPTION
### Description
Scrollbar was not styled in Safari and Chromium. Added webkit pseudo-element in global styles for everything under the `body` element. 

### Screenshots
Before: 
<img width="331" alt="image" src="https://github.com/user-attachments/assets/f3148bd8-2262-47ff-8882-66681ec2d40c">
<img width="336" alt="image" src="https://github.com/user-attachments/assets/cbcfbf76-6f86-4af3-8a08-722088440e11">

After:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/fcf5ec8b-dc7b-442f-98f3-2bbccf7e25e2">
<img width="359" alt="image" src="https://github.com/user-attachments/assets/d3a7a8e2-4185-465b-bed6-47ddda64d813">
