### PR TITLE
Feature/hide unique id for data sources

### DIFF
--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -53,6 +53,15 @@
     justify-content: left;
 }
 
+.table-example, .table-example > tr > :is(th, td) {
+    border: 2px solid var(--secondary-background-color);
+    border-collapse: collapse;
+}
+
+.table-example > tr > :is(th, td) {
+    padding: 5px;
+}
+
 .title {
     margin-bottom: 6px;
 }

--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -62,12 +62,21 @@
     padding: 5px;
 }
 
+.light-border.table-example, .light-border.table-example > tr > :is(th, td) {
+    border: 2px solid var(--primary-background-color);
+}
+
+.left-text-align {
+    text-align: left !important;
+}
+
 .title {
     margin-bottom: 6px;
 }
 
 .datasource-subhead {
-    margin-bottom: 26px !important;
+    margin-bottom: 13px !important;
+    text-align: left;
     font-weight: 600;
 }
 

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -19,8 +19,8 @@ interface Props {
 const ADDITIONAL_COLUMN_DETAILS = [
     'If a "Thumbnail" column is present it should contain a web URL to a thumbnail image for the file. ',
     'If a "File Name" column is present it should be the file\'s name (this will replace the "File Name" created by default from the path). ',
-    'If a "File Size" column is present it should contain the size of the file in bytes. ',
-    'If an "Uploaded" column is present it should contain the date the file was uploaded to the cloud storage and be formatted as YYYY-MM-DD HH:MM:SS.Z where Z is a timezone offset. ',
+    'If a "File Size" column is present it should contain the size of the file in bytes. This is used for showing feedback to the user during downloads. ',
+    'If an "Uploaded" column is present it should contain the date the file was uploaded to the storage and be formatted as YYYY-MM-DD HH:MM:SS.Z where Z is a timezone offset. ',
 ];
 
 /**
@@ -81,10 +81,8 @@ export default function DataSourcePrompt(props: Props) {
                 <>
                     <ul className={styles.detailsList}>
                         <li className={styles.details}>
-                            The file must contain a &quot;File Path&quot; column & must be unique by
-                            the &quot;File Path&quot; column or have a unique &quot;File ID&quot;
-                            column. Any other columns are optional and will be available as
-                            annotations to query by.
+                            The file must contain a &quot;File Path&quot; column. Any other columns
+                            are optional and will be available as metadata to query by.
                         </li>
                     </ul>
                     <h4 className={styles.details}>Advanced:</h4>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -99,21 +99,25 @@ export default function DataSourcePrompt(props: Props) {
                     [styles.lightBorder]: !props?.hideTitle,
                 })}
             >
-                <tr>
-                    <th>File Path</th>
-                    <th>Gene (Just an example)</th>
-                    <th>Color (Also an example)</th>
-                </tr>
-                <tr>
-                    <td>/some/path/to/storage/somewhere.zarr</td>
-                    <td>CDH2</td>
-                    <td>Blue</td>
-                </tr>
-                <tr>
-                    <td>/another/path/to/another/file.txt</td>
-                    <td>VIM</td>
-                    <td>Green</td>
-                </tr>
+                <thead>
+                    <tr>
+                        <th>File Path</th>
+                        <th>Gene (Just an example)</th>
+                        <th>Color (Also an example)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>/some/path/to/storage/somewhere.zarr</td>
+                        <td>CDH2</td>
+                        <td>Blue</td>
+                    </tr>
+                    <tr>
+                        <td>/another/path/to/another/file.txt</td>
+                        <td>VIM</td>
+                        <td>Green</td>
+                    </tr>
+                </tbody>
             </table>
             {isDataSourceDetailExpanded ? (
                 <>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -82,9 +82,9 @@ export default function DataSourcePrompt(props: Props) {
                     [styles.datasourceSubhead]: !props?.hideTitle,
                 })}
             >
-                The first row should contain metadata tags, and each subsequent row includes
-                metadata for a file, with &quot;File Path&quot; being the only required column.
-                Other columns are optional and can be used for querying additional file metadata.
+                The first row should contain metadata tags, and each subsequent row include metadata
+                for a file, with &quot;File Path&quot; being the only required column. Other columns
+                are optional and can be used for querying additional file metadata.
             </p>
             <p
                 className={classNames(styles.text, {

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -82,19 +82,23 @@ export default function DataSourcePrompt(props: Props) {
                     [styles.datasourceSubhead]: !props?.hideTitle,
                 })}
             >
-                The first row should be the metadata tags and each row proceeding it should be
-                metadata about a file. The only required column is &quot;File Path&quot; which is
-                intended to represent the path to a file in storage. Any other columns are optional
-                and will be available as metadata to query by.
+                The first row should contain metadata tags, and each subsequent row includes
+                metadata for a file, with &quot;File Path&quot; being the only required column.
+                Other columns are optional and can be used for querying additional file metadata.
             </p>
             <p
                 className={classNames(styles.text, {
                     [styles.datasourceSubhead]: !props?.hideTitle,
+                    [styles.leftTextAlign]: !props?.hideTitle,
                 })}
             >
                 Example CSV:
             </p>
-            <table className={styles.tableExample}>
+            <table
+                className={classNames(styles.tableExample, {
+                    [styles.lightBorder]: !props?.hideTitle,
+                })}
+            >
                 <tr>
                     <th>File Path</th>
                     <th>Gene (Just an example)</th>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -77,14 +77,42 @@ export default function DataSourcePrompt(props: Props) {
                 To get started, load a CSV, Parquet, or JSON file containing metadata (annotations)
                 about your files to view them.
             </p>
+            <p
+                className={classNames(styles.text, {
+                    [styles.datasourceSubhead]: !props?.hideTitle,
+                })}
+            >
+                The first row should be the metadata tags and each row proceeding it should be
+                metadata about a file. The only required column is &quot;File Path&quot; which is
+                intended to represent the path to a file in storage. Any other columns are optional
+                and will be available as metadata to query by.
+            </p>
+            <p
+                className={classNames(styles.text, {
+                    [styles.datasourceSubhead]: !props?.hideTitle,
+                })}
+            >
+                Example CSV:
+            </p>
+            <table className={styles.tableExample}>
+                <tr>
+                    <th>File Path</th>
+                    <th>Gene (Just an example)</th>
+                    <th>Color (Also an example)</th>
+                </tr>
+                <tr>
+                    <td>/some/path/to/storage/somewhere.zarr</td>
+                    <td>CDH2</td>
+                    <td>Blue</td>
+                </tr>
+                <tr>
+                    <td>/another/path/to/another/file.txt</td>
+                    <td>VIM</td>
+                    <td>Green</td>
+                </tr>
+            </table>
             {isDataSourceDetailExpanded ? (
                 <>
-                    <ul className={styles.detailsList}>
-                        <li className={styles.details}>
-                            The file must contain a &quot;File Path&quot; column. Any other columns
-                            are optional and will be available as metadata to query by.
-                        </li>
-                    </ul>
                     <h4 className={styles.details}>Advanced:</h4>
                     <ul className={styles.detailsList}>
                         <li className={styles.details}>

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -99,7 +99,7 @@ export default function FileDetails(props: Props) {
             dispatch(
                 interaction.actions.downloadFiles([
                     {
-                        id: fileDetails.id,
+                        id: fileDetails.uid,
                         name: fileDetails.name,
                         size: fileDetails.size,
                         path: fileDetails.downloadPath,
@@ -145,7 +145,7 @@ export default function FileDetails(props: Props) {
                                     <PrimaryButton
                                         className={styles.primaryButton}
                                         disabled={processStatuses.some((status) =>
-                                            status.data.fileId?.includes(fileDetails.id)
+                                            status.data.fileId?.includes(fileDetails.uid)
                                         )}
                                         iconName="Download"
                                         text="Download"

--- a/packages/core/components/FileList/LazilyRenderedRow.tsx
+++ b/packages/core/components/FileList/LazilyRenderedRow.tsx
@@ -67,7 +67,7 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
                     displayValue: annotation.extractFromFile(file),
                     width: columnWidths[annotation.name] || 1 / annotations.length,
                 }))}
-                rowIdentifier={{ index, id: file.id }}
+                rowIdentifier={{ index, id: file.uid }}
                 onSelect={onSelect}
             />
         );

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
@@ -79,7 +79,7 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
 
         if (onSelect && file !== undefined) {
             onSelect(
-                { index: overallIndex, id: file.id },
+                { index: overallIndex, id: file.uid },
                 {
                     // Details on different OS keybindings
                     // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#Properties

--- a/packages/core/components/FileRow/index.tsx
+++ b/packages/core/components/FileRow/index.tsx
@@ -19,7 +19,7 @@ export interface CellConfig {
 interface FileRowProps {
     cells: CellConfig[];
     className?: string;
-    rowIdentifier?: any;
+    rowIdentifier?: { index: number; id: string };
     onContextMenu?: (evt: React.MouseEvent) => void;
     onResize?: (columnKey: string, nextWidth?: number) => void;
     onSelect?: OnSelect;

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -15,18 +15,17 @@ export const TOP_LEVEL_FILE_ANNOTATIONS = [
     new Annotation({
         annotationDisplayName: "File ID",
         annotationName: AnnotationName.FILE_ID,
-        description:
-            "Auto or manually generated unique ID for file. Should not be used for collaboration or sharing as it may change.",
+        description: "ID for file.",
         type: AnnotationType.STRING,
     }),
     new Annotation({
         annotationDisplayName: "File Name",
         annotationName: AnnotationName.FILE_NAME,
-        description: "Name of file",
+        description: "Name of file.",
         type: AnnotationType.STRING,
     }),
     new Annotation({
-        annotationDisplayName: "File Path (Canonical)",
+        annotationDisplayName: "File Path",
         annotationName: AnnotationName.FILE_PATH,
         description: "Path to file in storage.",
         type: AnnotationType.STRING,

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -25,7 +25,7 @@ export const TOP_LEVEL_FILE_ANNOTATIONS = [
         type: AnnotationType.STRING,
     }),
     new Annotation({
-        annotationDisplayName: "File Path",
+        annotationDisplayName: "File Path (Canonical)",
         annotationName: AnnotationName.FILE_PATH,
         description: "Path to file in storage.",
         type: AnnotationType.STRING,

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -73,7 +73,8 @@ export interface FmsFile {
  * Facade for a FileDetailResponse.
  */
 export default class FileDetail {
-    private fileDetail: FmsFile;
+    private readonly fileDetail: FmsFile;
+    private readonly uniqueId?: string;
 
     private static convertAicsDrivePathToAicsS3Path(path: string): string {
         const pathWithoutDrive = path.replace("/allen/programs/allencell/data/proj0", "");
@@ -82,12 +83,17 @@ export default class FileDetail {
         return `https://s3.us-west-2.amazonaws.com/production.files.allencell.org${pathWithoutDrive}`;
     }
 
-    constructor(fileDetail: FmsFile) {
+    constructor(fileDetail: FmsFile, uniqueId?: string) {
         this.fileDetail = fileDetail;
+        this.uniqueId = uniqueId;
     }
 
     public get details() {
         return this.fileDetail;
+    }
+
+    public get uid(): string {
+        return this.uniqueId || this.id;
     }
 
     public get id(): string {

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -343,7 +343,7 @@ export default abstract class DatabaseService {
 
                 if (matches.length === 1) {
                     // Rename matching column name to new pre-defined column
-                    this.execute(`
+                    await this.execute(`
                         ALTER TABLE "${dataSourceName}"
                         RENAME COLUMN "${matches[0]}" TO '${preDefinedColumn}'
                     `);

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -326,11 +326,8 @@ export default abstract class DatabaseService {
                 // Grab near matches to the pre-defined columns like "file_name" for "File Name"
                 const matches = [...columnsOnDataSource].filter((column) => {
                     const simplifiedColumn = column
-                        .trim()
                         .toLowerCase() // File Name -> file name
-                        .replace("_", "") // file_path -> filepath
-                        .replace(" ", "") // file path -> filepath
-                        .replace("-", ""); // file-path -> filepath
+                        .replaceAll(/\s|-|_/g, ""); // Matches any whitespace, hyphen, or underscore
                     return simplifiedColumn === preDefinedColumnSimplified;
                 });
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -22,8 +22,8 @@ const PRE_DEFINED_COLUMNS = Object.values(PreDefinedColumn);
  */
 export default abstract class DatabaseService {
     public static readonly LIST_DELIMITER = ",";
-    public static readonly HIDDEN_UID_ANNOTATION = "hidden_bff_uid";
     // Name of the hidden column BFF uses to uniquely identify rows
+    public static readonly HIDDEN_UID_ANNOTATION = "hidden_bff_uid";
     protected readonly SOURCE_METADATA_TABLE = "source_metadata";
     // "Open file link" as a datatype must be hardcoded, and CAN NOT change
     // without BREAKING visibility in the dataset released in 2024 as part

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import DatabaseService from "../../../DatabaseService";
 import FileSelection from "../../../../entity/FileSelection";
 import FileSet from "../../../../entity/FileSet";
 import NumericRange from "../../../../entity/NumericRange";
@@ -12,7 +13,7 @@ describe("DatabaseFileService", () => {
     const totalFileSize = 864452;
     const fileIds = ["abc123", "def456"];
     const files = fileIds.map((file_id) => ({
-        "File ID": file_id,
+        [DatabaseService.HIDDEN_UID_ANNOTATION]: file_id,
         "File Size": `${totalFileSize / 2}`,
         "File Path": "path/to/file",
         "File Name": "file",

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -45,10 +45,6 @@ describe("DatabaseFileService", () => {
             expect(data[0].details).to.deep.equal({
                 annotations: [
                     {
-                        name: "File ID",
-                        values: ["abc123"],
-                    },
-                    {
                         name: "File Size",
                         values: ["432226"],
                     },

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -213,7 +213,7 @@ const downloadFilesLogic = createLogic({
         } else {
             const selectedFilesDetails = await fileSelection.fetchAllDetails();
             filesToDownload = selectedFilesDetails.map((file) => ({
-                id: file.id,
+                id: file.uid,
                 name: file.name,
                 size: file.size,
                 path: file.downloadPath,


### PR DESCRIPTION
## Context
In the last changeset related to this I added validation at ingestion time of a data source that would check for errors and automatically add some columns. This was largely because users were having a difficult time telling what the issue with their data was in the event of a failure.

## Description
This changeset removes the previously auto-generated "File ID" in favor of creating a hidden UID that the app only uses internally to track a row. This makes it so the user doesn't have to see the "File ID." While I was reviewing this code I noticed I could combine some alter commands that hit the database and see a performance improvement so I adjusted those and add a constant `PreDefinedColumn` to track the pre-defined columns like "File ID." FWIW the reason for a unique ID is because we need some unique identifier for a row and if we can't assume "File Path" is unique (because of a request from AIBS) then we need to find or generate one so now we generate one secretly.

## Testing
[This is available on staging.](https://staging.biofile-finder.allencell.org/app)