### PR TITLE
Prevent duplicate loading of same description source

### DIFF
--- a/packages/core/services/DatabaseService/DatabaseServiceNoop.ts
+++ b/packages/core/services/DatabaseService/DatabaseServiceNoop.ts
@@ -1,6 +1,10 @@
 import DatabaseService from ".";
 
 export default class DatabaseServiceNoop extends DatabaseService {
+    public deleteSourceMetadata(): Promise<void> {
+        return Promise.reject("DatabaseServiceNoop:deleteSourceMetadata");
+    }
+
     public execute(): Promise<void> {
         return Promise.reject("DatabaseServiceNoop:execute");
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -141,8 +141,8 @@ export default abstract class DatabaseService {
     }
 
     public async prepareSourceMetadata(sourceMetadata: Source): Promise<void> {
-        const isOldSource = sourceMetadata.name === this.sourceMetadataName;
-        if (isOldSource) {
+        const isPreviousSource = sourceMetadata.name === this.sourceMetadataName;
+        if (isPreviousSource) {
             return;
         }
 

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -555,6 +555,8 @@ const changeSourceMetadataLogic = createLogic({
         );
         if (selectedSourceMetadata) {
             await databaseService.prepareSourceMetadata(selectedSourceMetadata);
+        } else {
+            await databaseService.deleteSourceMetadata();
         }
 
         dispatch(metadata.actions.requestAnnotations());
@@ -577,6 +579,8 @@ const addQueryLogic = createLogic({
             await databaseService.prepareDataSources(newQuery.parts.sources);
             if (newQuery.parts.sourceMetadata) {
                 await databaseService.prepareSourceMetadata(newQuery.parts.sourceMetadata);
+            } else {
+                await databaseService.deleteSourceMetadata();
             }
             // Hide warning pop-up if present and remove datasource error from state
             dispatch(removeDataSourceReloadError());

--- a/packages/core/state/selection/test/logics.test.ts
+++ b/packages/core/state/selection/test/logics.test.ts
@@ -24,6 +24,7 @@ import {
     selectNearbyFile,
     SET_SORT_COLUMN,
     changeDataSources,
+    changeSourceMetadata,
 } from "../actions";
 import { initialState, interaction } from "../../";
 import Annotation from "../../../entity/Annotation";
@@ -40,6 +41,7 @@ import FileSort, { SortOrder } from "../../../entity/FileSort";
 import { DatasetService } from "../../../services";
 import { DataSource } from "../../../services/DataSourceService";
 import HttpFileService from "../../../services/FileService/HttpFileService";
+import DatabaseServiceNoop from "../../../services/DatabaseService/DatabaseServiceNoop";
 import FileDownloadServiceNoop from "../../../services/FileDownloadService/FileDownloadServiceNoop";
 
 describe("Selection logics", () => {
@@ -947,7 +949,17 @@ describe("Selection logics", () => {
         it("dispatches new hierarchy, filters, sort, source, & opened folders from given URL", async () => {
             // Arrange
             const annotations = annotationsJson.map((annotation) => new Annotation(annotation));
+            class MockDatabaseService extends DatabaseServiceNoop {
+                public deleteSourceMetadata(): Promise<void> {
+                    return Promise.resolve();
+                }
+            }
             const state = mergeState(initialState, {
+                interaction: {
+                    platformDependentServices: {
+                        databaseService: new MockDatabaseService(),
+                    },
+                },
                 metadata: {
                     annotations,
                     dataSources: mockDataSources,
@@ -998,6 +1010,7 @@ describe("Selection logics", () => {
                     payload: sortColumn,
                 })
             ).to.be.true;
+            expect(actions.includesMatch(changeSourceMetadata())).to.be.true;
             expect(actions.includesMatch(changeDataSources(mockDataSources))).to.be.true;
         });
     });


### PR DESCRIPTION
Currently there is a bug where description sources for data sources are being loaded in duplicate causing the queries against them to fail. This prevents that by improving our check to see if we have loaded this file before similar to how we do the actual data sources.