### PR TITLE
Simplify open with options

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -329,7 +329,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             {
                 key: "other-apps",
                 text: "Other apps",
-                title: "Other applications that are not expected to support this file type",
+                title: "Other applications that are not recommended for this file",
                 subMenuProps: {
                     items: subMenuItems,
                 },

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -131,7 +131,7 @@ function getPrioritySupportedApps(fileDetails?: FileDetail): IContextualMenuItem
     const isLikelyLocalFile =
         !fileDetails.path.startsWith("http") && !fileDetails.path.startsWith("s3");
 
-    const fileExt = fileDetails.name.slice(fileDetails.name.lastIndexOf(".") + 1).toLowerCase();
+    const fileExt = fileDetails.path.slice(fileDetails.path.lastIndexOf(".") + 1).toLowerCase();
     const apps = APPS(fileDetails);
     switch (fileExt) {
         case "simularium":
@@ -204,7 +204,6 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     const priorityApps = authorDefinedApps.length
         ? authorDefinedApps
         : getPrioritySupportedApps(fileDetails);
-    console.log(authorDefinedApps, priorityApps);
 
     const plateLink = fileDetails?.getLinkToPlateUI(fileExplorerServiceBaseUrl);
     if (plateLink && isAicsEmployee) {

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -13,7 +13,19 @@
 }
 
 .desktop-menu-item .info-button {
-    transform: translateY(-2px);
+    color: var(--white);
+    opacity: 0.5;
+}
+
+.desktop-menu-item .info-button:hover {
+    opacity: 1;
+}
+
+.secondary-text {
+    color: var(--white);
+    font-size: 12px !important;
+    opacity: 0.5;
+    padding-left: 10px;
 }
 
 .desktop-menu-item .info-button > span {
@@ -34,6 +46,5 @@
 }
 
 .desktop-menu-item a {
-    padding-left: 57.5px;
-    width: 25px;
+    padding-left: 0;
 }

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -21,6 +21,11 @@
     opacity: 1;
 }
 
+.divider {
+    display: inherit !important;
+    opacity: 0.25;
+}
+
 .secondary-text {
     color: var(--white);
     font-size: 12px !important;


### PR DESCRIPTION
This intends to make it simpler for users to tell which viewer to use when opening a file. This is what happens:

If the data source tells us there are specific links to use for the file we show those in the primary menu and everything else in the sub-menu.
If not, we show the viewers that support the file extension in the primary menu and everything else in the sub-menu (could be none!).

I am triple-checking the design of this around with users and UX rn.

Resolves #307 

Before
<img width="1594" alt="old" src="https://github.com/user-attachments/assets/b717c04c-ecac-46c1-8950-7a8cd42b976c">

After with "user defined links"
![Screen Shot 2024-11-14 at 2 16 24 PM](https://github.com/user-attachments/assets/4a078525-4241-4185-b1fc-68230034382e)

After without "user defined links"
<img width="1014" alt="new-use-case-2" src="https://github.com/user-attachments/assets/dcca3a46-46f3-46e1-88bf-3090d24b4618">
