### PR TITLE
Prevent button from refocusing on menu close

### DIFF
--- a/packages/core/components/Buttons/BaseButton.tsx
+++ b/packages/core/components/Buttons/BaseButton.tsx
@@ -1,6 +1,5 @@
 import { DefaultButton, DirectionalHint, IContextualMenuItem, Icon } from "@fluentui/react";
 import classNames from "classnames";
-import { noop } from "lodash";
 import * as React from "react";
 
 import useButtonMenu from "./useButtonMenu";
@@ -29,7 +28,6 @@ export default function BaseButton(props: Props) {
     const styledMenu = useButtonMenu({
         items: props.menuItems,
         directionalHint: props.menuDirection,
-        onRestoreFocus: noop, // Prevent button from refocusing on menu close
     });
 
     const content = (

--- a/packages/core/components/Buttons/BaseButton.tsx
+++ b/packages/core/components/Buttons/BaseButton.tsx
@@ -1,5 +1,6 @@
 import { DefaultButton, DirectionalHint, IContextualMenuItem, Icon } from "@fluentui/react";
 import classNames from "classnames";
+import { noop } from "lodash";
 import * as React from "react";
 
 import useButtonMenu from "./useButtonMenu";
@@ -28,6 +29,7 @@ export default function BaseButton(props: Props) {
     const styledMenu = useButtonMenu({
         items: props.menuItems,
         directionalHint: props.menuDirection,
+        onRestoreFocus: noop, // Prevent button from refocusing on menu close
     });
 
     const content = (

--- a/packages/core/components/Buttons/useButtonMenu.ts
+++ b/packages/core/components/Buttons/useButtonMenu.ts
@@ -1,4 +1,5 @@
 import { ContextualMenuItemType, IContextualMenuItem, IContextualMenuProps } from "@fluentui/react";
+import { noop } from "lodash";
 import * as React from "react";
 
 import styles from "./useButtonMenu.module.css";
@@ -30,6 +31,7 @@ function normalizeButtonMenu(menu: IContextualMenuProps): IContextualMenuProps {
         className: styles.buttonMenu,
         calloutProps: { className: styles.buttonMenuCallout },
         items: menu.items.map((item) => normalizeButtonMenuItem(item)),
+        onRestoreFocus: noop, // Prevent button from refocusing on menu close
     };
 }
 


### PR DESCRIPTION
### Description
The tooltip was reappearing on buttons with menus after the menu was closed because the dom was refocusing on the original button. This prevents refocusing on menu close via [a FluentUI Callout property](https://developer.microsoft.com/en-us/fluentui#/controls/web/callout)

### Testing
Tested manually 

closes #301 