### PR TITLE
Feature/add better column control

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -1,8 +1,3 @@
-.light-theme {
-    /* placeholder for until / if we do a light theme for the app */
-    color: orange;
-}
-
 .absolute {
     position: absolute;
 }

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -48,7 +48,6 @@ export default function App(props: AppProps) {
     const dispatch = useDispatch();
     const hasQuerySelected = useSelector(selection.selectors.hasQuerySelected);
     const requiresDataSourceReload = useSelector(selection.selectors.getRequiresDataSourceReload);
-    const isDarkTheme = useSelector(selection.selectors.getIsDarkTheme);
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const platformDependentServices = useSelector(
         interaction.selectors.getPlatformDependentServices
@@ -97,7 +96,6 @@ export default function App(props: AppProps) {
         <div
             id={ROOT_ELEMENT_ID}
             className={classNames(styles.root, props.className, {
-                [styles.lightTheme]: !isDarkTheme,
                 [styles.smallFont]: shouldDisplaySmallFont,
             })}
             ref={measuredNodeRef}

--- a/packages/core/components/DirectoryTree/DirectoryTree.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTree.module.css
@@ -4,18 +4,6 @@
     position: relative;
 }
 
-.container::after {
-    background-image: linear-gradient(to right, transparent, var(--secondary-background-color));
-    bottom: 0;
-    content: " ";
-    height: 100%;
-    right: 0;
-    position: absolute;
-    pointer-events: none;
-    width: 60px;
-    z-index: 11;
-}
-
 .filter-display-bar {
     flex-shrink: 0;
     width: 100%;

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -58,6 +58,9 @@ describe("<DirectoryTree />", () => {
         (a) => a.name === AnnotationName.FILE_NAME
     );
     const state = mergeState(initialState, {
+        metadata: {
+            annotations: [...baseDisplayAnnotations, fooAnnotation, barAnnotation],
+        },
         interaction: {
             fileExplorerServiceBaseUrl: baseUrl,
         },
@@ -356,6 +359,9 @@ describe("<DirectoryTree />", () => {
 
     it("only includes one filter value per annotation for an annotation within the hierarchy", async () => {
         const oneAnnotationDeepState = mergeState(initialState, {
+            metadata: {
+                annotations: [...baseDisplayAnnotations, fooAnnotation, barAnnotation],
+            },
             interaction: {
                 fileExplorerServiceBaseUrl: baseUrl,
             },

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -63,7 +63,10 @@ describe("<DirectoryTree />", () => {
         },
         selection: {
             annotationHierarchy: [fooAnnotation.name, barAnnotation.name],
-            displayAnnotations: [...baseDisplayAnnotations, fooAnnotation, barAnnotation],
+            columns: [...baseDisplayAnnotations, fooAnnotation, barAnnotation].map((a) => ({
+                name: a.name,
+                width: 0.1,
+            })),
         },
     });
 
@@ -358,7 +361,10 @@ describe("<DirectoryTree />", () => {
             },
             selection: {
                 annotationHierarchy: [fooAnnotation.name],
-                displayAnnotations: [...baseDisplayAnnotations, fooAnnotation, barAnnotation],
+                columns: [...baseDisplayAnnotations, fooAnnotation, barAnnotation].map((a) => ({
+                    name: a.name,
+                    width: 0.1,
+                })),
             },
         });
 

--- a/packages/core/components/EmptyFileListMessage/index.tsx
+++ b/packages/core/components/EmptyFileListMessage/index.tsx
@@ -8,12 +8,12 @@ export default function EmptyFileListMessage() {
         <div className={styles.emptyFileListContainer}>
             <div className={styles.emptyFileListMessage}>
                 <Icon className={styles.emptySearchIcon} iconName="SearchIssue" />
-                <h2>Sorry! No files found</h2>
+                <h2>No files match your query</h2>
                 <br />
-                <div>We couldn&apos;t find any files matching your request.</div>
+                <div>Double check your filters for any issues.</div>
                 <br />
                 <div>
-                    Double check your filters for any issues and then contact the software team via
+                    Contact us via
                     <a
                         className={styles.link}
                         href="https://github.com/AllenInstitute/biofile-finder/issues"
@@ -22,7 +22,7 @@ export default function EmptyFileListMessage() {
                     >
                         &nbsp;GitHub&nbsp;
                     </a>
-                    if you still expect there to be matches present.
+                    if you expect there should be matches present for query.
                 </div>
             </div>
         </div>

--- a/packages/core/components/EmptyFileListMessage/index.tsx
+++ b/packages/core/components/EmptyFileListMessage/index.tsx
@@ -22,7 +22,7 @@ export default function EmptyFileListMessage() {
                     >
                         &nbsp;GitHub&nbsp;
                     </a>
-                    if you expect there should be matches present for query.
+                    if you expect there should be matches present for this query.
                 </div>
             </div>
         </div>

--- a/packages/core/components/FileList/ColumnPicker.tsx
+++ b/packages/core/components/FileList/ColumnPicker.tsx
@@ -2,31 +2,33 @@ import * as React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import AnnotationPicker from "../AnnotationPicker";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 
 /**
  * Picker for selecting which columns to display in the file list.
  */
 export default function ColumnPicker() {
     const dispatch = useDispatch();
-    const annotations = useSelector(metadata.selectors.getAnnotations);
-    const columnAnnotations = useSelector(selection.selectors.getAnnotationsToDisplay);
+    const columns = useSelector(selection.selectors.getColumns);
+    const columnNames = useSelector(selection.selectors.getColumnNames);
 
     return (
         <AnnotationPicker
             title="Select metadata to display as columns"
-            selections={columnAnnotations.map((c) => c.name)}
-            setSelections={(selectedAnnotations) => {
-                // Prevent de-selecting all columns
-                if (!selectedAnnotations.length) {
-                    dispatch(selection.actions.setDisplayAnnotations([columnAnnotations[0]]));
-                } else {
-                    dispatch(
-                        selection.actions.setDisplayAnnotations(
-                            annotations.filter((a) => selectedAnnotations.includes(a.name))
-                        )
-                    );
-                }
+            selections={columnNames}
+            setSelections={(selectedColumns) => {
+                const adjustedColumns = columns.filter((column) =>
+                    selectedColumns.includes(column.name)
+                );
+                selectedColumns.forEach((selectedColumn) => {
+                    if (!columnNames.includes(selectedColumn)) {
+                        adjustedColumns.push({
+                            name: selectedColumn,
+                            width: 0.25, // Default width of 25%
+                        });
+                    }
+                });
+                dispatch(selection.actions.setColumns(adjustedColumns));
             }}
         />
     );

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -10,6 +10,18 @@
     height: calc(100% - 3px);
 }
 
+.horizontal-overflow::after {
+    background-image: linear-gradient(to right, transparent, var(--secondary-background-color));
+    bottom: 0;
+    content: " ";
+    height: 100%;
+    right: 0;
+    position: absolute;
+    pointer-events: none;
+    width: 60px;
+    z-index: 11;
+}
+
 .row-count-display {
     color: var(--secondary-text-color);
     opacity: 0.8;

--- a/packages/core/components/FileList/Header.tsx
+++ b/packages/core/components/FileList/Header.tsx
@@ -28,40 +28,37 @@ function Header(
     const annotationNameToAnnotationMap = useSelector(
         metadata.selectors.getAnnotationNameToAnnotationMap
     );
-    const columnAnnotations = useSelector(selection.selectors.getAnnotationsToDisplay);
-    const columnWidths = useSelector(selection.selectors.getColumnWidths);
+    const columns = useSelector(selection.selectors.getColumns);
     const sortColumn = useSelector(selection.selectors.getSortColumn);
 
-    const onResize = (columnKey: string, nextWidthPercent?: number) => {
-        if (nextWidthPercent) {
-            dispatch(selection.actions.resizeColumn(columnKey, nextWidthPercent));
-        } else {
-            dispatch(selection.actions.resetColumnWidth(columnKey));
-        }
+    const onResize = (name: string, width?: number) => {
+        // Default to 0.25 if width is undefined
+        // which resets the column width to the default
+        dispatch(selection.actions.resizeColumn({ name, width: width || 0.25 }));
     };
-    const headerCells: CellConfig[] = map(columnAnnotations, (annotation) => {
-        const isSortedColumn = sortColumn?.annotationName === annotation.name;
-        return {
-            columnKey: annotation.name, // needs to match the value used to produce `column`s passed to the `useResizableColumns` hook
-            displayValue: (
-                <span
-                    className={styles.headerCell}
-                    onClick={() => dispatch(selection.actions.sortColumn(annotation.name))}
-                >
-                    <Tooltip content={annotationNameToAnnotationMap[annotation.name]?.description}>
-                        <span className={styles.headerTitle}>{annotation.displayName}</span>
-                    </Tooltip>
-                    {isSortedColumn &&
-                        (sortColumn?.order === SortOrder.DESC ? (
-                            <Icon className={styles.sortIcon} iconName="ChevronDown" />
-                        ) : (
-                            <Icon className={styles.sortIcon} iconName="ChevronUp" />
-                        ))}
-                </span>
-            ),
-            width: columnWidths[annotation.name] || 1 / columnAnnotations.length,
-        };
-    });
+    const headerCells: CellConfig[] = map(columns, (column) => ({
+        // needs to match the value used to produce `column`s passed to the `useResizableColumns` hook
+        columnKey: column.name,
+        displayValue: (
+            <span
+                className={styles.headerCell}
+                onClick={() => dispatch(selection.actions.sortColumn(column.name))}
+            >
+                <Tooltip content={annotationNameToAnnotationMap[column.name]?.description}>
+                    <span className={styles.headerTitle}>
+                        {annotationNameToAnnotationMap[column.name]?.displayName}
+                    </span>
+                </Tooltip>
+                {sortColumn?.annotationName === column.name &&
+                    (sortColumn?.order === SortOrder.DESC ? (
+                        <Icon className={styles.sortIcon} iconName="ChevronDown" />
+                    ) : (
+                        <Icon className={styles.sortIcon} iconName="ChevronUp" />
+                    ))}
+            </span>
+        ),
+        width: column.width,
+    }));
 
     const onHeaderColumnContextMenu = (evt: React.MouseEvent) => {
         evt.preventDefault();

--- a/packages/core/components/FileList/LazilyRenderedRow.tsx
+++ b/packages/core/components/FileList/LazilyRenderedRow.tsx
@@ -66,7 +66,7 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
             <FileRow
                 cells={map(columns, (column) => ({
                     columnKey: column.name,
-                    displayValue: annotationNameToAnnotationMap[column.name].extractFromFile(file),
+                    displayValue: annotationNameToAnnotationMap[column.name]?.extractFromFile(file),
                     width: column.width,
                 }))}
                 rowIdentifier={{ index, id: file.id }}

--- a/packages/core/components/FileList/LazilyRenderedRow.tsx
+++ b/packages/core/components/FileList/LazilyRenderedRow.tsx
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 
 import FileRow from "../../components/FileRow";
 import FileSet from "../../entity/FileSet";
-import { selection } from "../../state";
+import { metadata, selection } from "../../state";
 import { OnSelect } from "./useFileSelector";
 
 import styles from "./LazilyRenderedRow.module.css";
@@ -39,9 +39,11 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
         style,
     } = props;
 
+    const columns = useSelector(selection.selectors.getColumns);
     const isSmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
-    const annotations = useSelector(selection.selectors.getAnnotationsToDisplay);
-    const columnWidths = useSelector(selection.selectors.getColumnWidths);
+    const annotationNameToAnnotationMap = useSelector(
+        metadata.selectors.getAnnotationNameToAnnotationMap
+    );
     const fileSelection = useSelector(selection.selectors.getFileSelection);
 
     const file = fileSet.getFileByIndex(index);
@@ -62,10 +64,10 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
     if (file) {
         content = (
             <FileRow
-                cells={map(annotations, (annotation) => ({
-                    columnKey: annotation.name,
-                    displayValue: annotation.extractFromFile(file),
-                    width: columnWidths[annotation.name] || 1 / annotations.length,
+                cells={map(columns, (column) => ({
+                    columnKey: column.name,
+                    displayValue: annotationNameToAnnotationMap[column.name].extractFromFile(file),
+                    width: column.width,
                 }))}
                 rowIdentifier={{ index, id: file.id }}
                 onSelect={onSelect}

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
@@ -5,9 +5,9 @@ import { useSelector } from "react-redux";
 
 import { OnSelect } from "./useFileSelector";
 import Tooltip from "../Tooltip";
-import FileSet from "../../entity/FileSet";
 import FileThumbnail from "../../components/FileThumbnail";
-import { THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
+import { FileView } from "../../entity/FileExplorerURL";
+import FileSet from "../../entity/FileSet";
 import { selection } from "../../state";
 
 import styles from "./LazilyRenderedThumbnail.module.css";
@@ -48,7 +48,8 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
 
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const fileSelection = useSelector(selection.selectors.getFileSelection);
-    const fileGridColCount = useSelector(selection.selectors.getFileGridColumnCount);
+    const fileView = useSelector(selection.selectors.getFileView);
+    const fileGridColCount = useSelector(selection.selectors.getFileGridColCount);
     const overallIndex = fileGridColCount * rowIndex + columnIndex;
     const file = fileSet.getFileByIndex(overallIndex);
     const thumbnailSize = measuredWidth / fileGridColCount - 2 * MARGIN;
@@ -92,7 +93,7 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
 
     // Display the start of the file name and at least part of the file type
     const clipFileName = (filename: string) => {
-        if (fileGridColCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL && filename.length > 15) {
+        if (fileView === FileView.SMALL_THUMBNAIL && filename.length > 15) {
             return filename.slice(0, 6) + "..." + filename.slice(-4);
         } else if (filename.length > 20) {
             return filename.slice(0, 9) + "..." + filename.slice(-8);
@@ -123,8 +124,7 @@ export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailPr
                     <div
                         className={classNames(styles.thumbnailLabel, {
                             [styles.smallFont]:
-                                shouldDisplaySmallFont ||
-                                fileGridColCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL,
+                                shouldDisplaySmallFont || fileView === FileView.SMALL_THUMBNAIL,
                         })}
                     >
                         {filenameForRender}

--- a/packages/core/components/FileList/test/FileList.test.tsx
+++ b/packages/core/components/FileList/test/FileList.test.tsx
@@ -35,7 +35,7 @@ describe("<FileList />", () => {
         expect(queryByText("Counting files...")).to.not.exist;
     });
 
-    it("displays 'No files found' when no files found", async () => {
+    it("displays 'No files match your query' when no files found", async () => {
         // Arrange
         const { store } = configureMockStore({ state: initialState });
 
@@ -55,7 +55,7 @@ describe("<FileList />", () => {
         expect(queryByText("Counting files...")).to.exist;
 
         // Wait for the fileService call to return, then check for updated list length display
-        await findByText("Sorry! No files found");
+        await findByText("No files match your query");
 
         // Assert
         expect(queryByText("Counting files...")).to.not.exist;

--- a/packages/core/components/FileList/test/Header.test.tsx
+++ b/packages/core/components/FileList/test/Header.test.tsx
@@ -19,6 +19,13 @@ describe("<Header />", () => {
             AnnotationName.UPLOADED,
         ];
         const state = mergeState(initialState, {
+            metadata: {
+                annotations: annotations.map((name) => ({
+                    name,
+                    displayName: name,
+                    description: name,
+                })),
+            },
             selection: {
                 columns: annotations.map((name) => ({
                     name: name,
@@ -51,6 +58,13 @@ describe("<Header />", () => {
             AnnotationName.UPLOADED,
         ];
         const state = mergeState(initialState, {
+            metadata: {
+                annotations: annotations.map((name) => ({
+                    name,
+                    displayName: name,
+                    description: name,
+                })),
+            },
             selection: {
                 columns: annotations.map((name) => ({
                     name: name,
@@ -83,6 +97,13 @@ describe("<Header />", () => {
             AnnotationName.UPLOADED,
         ];
         const state = mergeState(initialState, {
+            metadata: {
+                annotations: annotations.map((name) => ({
+                    name,
+                    displayName: name,
+                    description: name,
+                })),
+            },
             selection: {
                 columns: annotations.map((name) => ({
                     name: name,

--- a/packages/core/components/FileList/test/Header.test.tsx
+++ b/packages/core/components/FileList/test/Header.test.tsx
@@ -4,7 +4,6 @@ import { expect } from "chai";
 import * as React from "react";
 import { Provider } from "react-redux";
 
-import Annotation from "../../../entity/Annotation";
 import AnnotationName from "../../../entity/Annotation/AnnotationName";
 import FileSort, { SortOrder } from "../../../entity/FileSort";
 import { initialState, selection } from "../../../state";
@@ -21,22 +20,10 @@ describe("<Header />", () => {
         ];
         const state = mergeState(initialState, {
             selection: {
-                displayAnnotations: annotations.map(
-                    (name) =>
-                        new Annotation({
-                            annotationName: name,
-                            description: "Column Header Annotation",
-                            annotationDisplayName: name,
-                            type: "TEXT",
-                        })
-                ),
-                columnWidths: annotations.reduce(
-                    (accum, name) => ({
-                        ...accum,
-                        [name]: 1 / annotations.length,
-                    }),
-                    {}
-                ),
+                columns: annotations.map((name) => ({
+                    name: name,
+                    width: 1 / annotations.length,
+                })),
             },
         });
         const { actions, store } = configureMockStore({ state });
@@ -65,22 +52,10 @@ describe("<Header />", () => {
         ];
         const state = mergeState(initialState, {
             selection: {
-                displayAnnotations: annotations.map(
-                    (name) =>
-                        new Annotation({
-                            annotationName: name,
-                            description: "Column Header Annotation",
-                            annotationDisplayName: name,
-                            type: "TEXT",
-                        })
-                ),
-                columnWidths: annotations.reduce(
-                    (accum, name) => ({
-                        ...accum,
-                        [name]: 1 / annotations.length,
-                    }),
-                    {}
-                ),
+                columns: annotations.map((name) => ({
+                    name: name,
+                    width: 1 / annotations.length,
+                })),
                 sortColumn: new FileSort(AnnotationName.FILE_SIZE, SortOrder.DESC),
             },
         });
@@ -109,22 +84,10 @@ describe("<Header />", () => {
         ];
         const state = mergeState(initialState, {
             selection: {
-                displayAnnotations: annotations.map(
-                    (name) =>
-                        new Annotation({
-                            annotationName: name,
-                            description: "Column Header Annotation",
-                            annotationDisplayName: name,
-                            type: "TEXT",
-                        })
-                ),
-                columnWidths: annotations.reduce(
-                    (accum, name) => ({
-                        ...accum,
-                        [name]: 1 / annotations.length,
-                    }),
-                    {}
-                ),
+                columns: annotations.map((name) => ({
+                    name: name,
+                    width: 1 / annotations.length,
+                })),
                 sortColumn: new FileSort(AnnotationName.FILE_SIZE, SortOrder.ASC),
             },
         });

--- a/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
@@ -52,7 +52,7 @@ describe("<LazilyRenderedRow />", () => {
         // Arrange
         const state = mergeState(initialState, {});
         state.metadata.annotations = [fileNameAnnotation];
-        state.selection.displayAnnotations = [fileNameAnnotation];
+        state.selection.columns = [{ name: fileNameAnnotation.name, width: 0.25 }];
 
         const { store } = configureMockStore({ state });
 

--- a/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
@@ -9,6 +9,7 @@ import LazilyRenderedThumbnail from "../LazilyRenderedThumbnail";
 import { initialState } from "../../../state";
 import FileSet from "../../../entity/FileSet";
 import FileDetail from "../../../entity/FileDetail";
+import { FileView } from "../../../entity/FileExplorerURL";
 
 describe("<LazilyRenderedThumbnail />", () => {
     function makeItemData() {
@@ -82,7 +83,13 @@ describe("<LazilyRenderedThumbnail />", () => {
 
     it("renders file as thumbnail if file is renderable type", async () => {
         // Arrange
-        const { store } = configureMockStore({ state: initialState });
+        const { store } = configureMockStore({
+            state: mergeState(initialState, {
+                selection: {
+                    fileView: FileView.LARGE_THUMBNAIL,
+                },
+            }),
+        });
 
         // Act
         const { getAllByText, findByRole } = render(
@@ -105,7 +112,13 @@ describe("<LazilyRenderedThumbnail />", () => {
 
     it("renders svg as thumbnail if file has no renderable thumbnail", () => {
         // Arrange
-        const { store } = configureMockStore({ state: initialState });
+        const { store } = configureMockStore({
+            state: mergeState(initialState, {
+                selection: {
+                    fileView: FileView.LARGE_THUMBNAIL,
+                },
+            }),
+        });
 
         // Act
         const { getAllByText, queryByRole } = render(
@@ -176,7 +189,7 @@ describe("<LazilyRenderedThumbnail />", () => {
             ...initialState,
             selection: {
                 ...initialState.selection,
-                fileGridColumnCount: 10,
+                fileView: FileView.SMALL_THUMBNAIL,
             },
         };
         const { store } = configureMockStore({ state });

--- a/packages/core/components/GlobalActionButtonRow/index.tsx
+++ b/packages/core/components/GlobalActionButtonRow/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TertiaryButton } from "../Buttons";
-import { THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
+import { FileView } from "../../entity/FileExplorerURL";
 import { selection } from "../../state";
 
 import styles from "./GlobalActionButtonRow.module.css";
@@ -17,11 +17,8 @@ interface Props {
  */
 export default function GlobalActionButtonRow(props: Props) {
     const dispatch = useDispatch();
-    const fileGridColumnCount = useSelector(selection.selectors.getFileGridColumnCount);
+    const fileView = useSelector(selection.selectors.getFileView);
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
-    const shouldDisplayThumbnailView = useSelector(
-        selection.selectors.getShouldDisplayThumbnailView
-    );
 
     return (
         <div className={classNames(styles.container, props.className)}>
@@ -29,52 +26,26 @@ export default function GlobalActionButtonRow(props: Props) {
                 <TertiaryButton
                     className={styles.listViewButton}
                     iconName="NumberedListText"
-                    isSelected={!shouldDisplayThumbnailView}
-                    disabled={!shouldDisplayThumbnailView}
-                    onClick={() =>
-                        dispatch(
-                            selection.actions.setFileThumbnailView(!shouldDisplayThumbnailView)
-                        )
-                    }
+                    disabled={fileView === FileView.LIST}
+                    isSelected={fileView === FileView.LIST}
+                    onClick={() => dispatch(selection.actions.setFileView(FileView.LIST))}
                     title="List view"
                 />
                 <TertiaryButton
                     iconName="GridViewMedium"
-                    disabled={
-                        shouldDisplayThumbnailView &&
-                        fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE
-                    }
-                    isSelected={
-                        shouldDisplayThumbnailView &&
-                        fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE
-                    }
+                    disabled={fileView === FileView.LARGE_THUMBNAIL}
+                    isSelected={fileView === FileView.LARGE_THUMBNAIL}
                     onClick={() => {
-                        dispatch(selection.actions.setFileThumbnailView(true));
-                        dispatch(
-                            selection.actions.setFileGridColumnCount(
-                                THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE
-                            )
-                        );
+                        dispatch(selection.actions.setFileView(FileView.LARGE_THUMBNAIL));
                     }}
                     title="Large thumbnail view"
                 />
                 <TertiaryButton
                     iconName="GridViewSmall"
-                    disabled={
-                        shouldDisplayThumbnailView &&
-                        fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL
-                    }
-                    isSelected={
-                        shouldDisplayThumbnailView &&
-                        fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL
-                    }
+                    disabled={fileView === FileView.SMALL_THUMBNAIL}
+                    isSelected={fileView === FileView.SMALL_THUMBNAIL}
                     onClick={() => {
-                        dispatch(selection.actions.setFileThumbnailView(true));
-                        dispatch(
-                            selection.actions.setFileGridColumnCount(
-                                THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL
-                            )
-                        );
+                        dispatch(selection.actions.setFileView(FileView.SMALL_THUMBNAIL));
                     }}
                     title="Small thumbnail view"
                 />

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -54,9 +54,4 @@ export const TOP_LEVEL_FILE_ANNOTATIONS = [
 
 export const TOP_LEVEL_FILE_ANNOTATION_NAMES = TOP_LEVEL_FILE_ANNOTATIONS.map((a) => a.name);
 
-export const THUMBNAIL_SIZE_TO_NUM_COLUMNS = {
-    LARGE: 5,
-    SMALL: 10,
-};
-
 export const AICS_FMS_DATA_SOURCE_NAME = "AICS FMS";

--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -98,10 +98,13 @@ class ColumnCoder {
     }
 
     public static decode(encoded: string): Column[] {
-        return encoded.split(ColumnCoder.COLUMN_DELIMETER).map((unparsedColumn: string) => {
-            const [name, widthAsStr] = unparsedColumn.split(ColumnCoder.VALUE_DELIMETER);
-            return { name, width: parseFloat(widthAsStr) };
-        });
+        return encoded
+            .split(ColumnCoder.COLUMN_DELIMETER)
+            .filter((unparsedColumn) => !!unparsedColumn)
+            .map((unparsedColumn) => {
+                const [name, widthAsStr] = unparsedColumn.split(ColumnCoder.VALUE_DELIMETER);
+                return { name, width: parseFloat(widthAsStr) };
+            });
     }
 }
 
@@ -181,7 +184,7 @@ export default class FileExplorerURL {
         const unparsedSources = params.getAll("source");
         const hierarchy = params.getAll("group");
         const unparsedSort = params.get("sort");
-        const unparsedColumns = params.get(URLQueryArgShorthands.COLUMNS) || "{}";
+        const unparsedColumns = params.get(URLQueryArgShorthands.COLUMNS) || "";
         const fileView = (params.get(URLQueryArgShorthands.FILE_VIEW) as FileView) || FileView.LIST;
         const hierarchyDepth = hierarchy.length;
 

--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -3,6 +3,15 @@ import FileFilter from "../FileFilter";
 import FileFolder from "../FileFolder";
 import FileSort, { SortOrder } from "../FileSort";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
+import { Column } from "../../state/selection/actions";
+
+// These values CANNOT change otherwise it would break compatibility
+// with any existing URLs that use these in the encoding
+export enum FileView {
+    LIST = "1",
+    SMALL_THUMBNAIL = "2",
+    LARGE_THUMBNAIL = "3",
+}
 
 export interface Source {
     name: string;
@@ -12,7 +21,9 @@ export interface Source {
 
 // Components of the application state this captures
 export interface FileExplorerURLComponents {
+    columns?: Column[];
     hierarchy: string[];
+    fileView?: FileView;
     sources: Source[];
     sourceMetadata?: Source;
     filters: FileFilter[];
@@ -44,6 +55,13 @@ export const PAST_YEAR_FILTER = new FileFilter(
     `RANGE(${DATE_LAST_YEAR.toISOString()},${END_OF_TODAY.toISOString()})`
 );
 export const DEFAULT_AICS_FMS_QUERY: FileExplorerURLComponents = {
+    columns: [
+        { name: AnnotationName.FILE_NAME, width: 0.4 },
+        { name: AnnotationName.KIND, width: 0.2 },
+        { name: AnnotationName.TYPE, width: 0.25 },
+        { name: AnnotationName.FILE_SIZE, width: 0.15 },
+    ],
+    fileView: FileView.LIST,
     hierarchy: [],
     openFolders: [],
     sources: [{ name: AICS_FMS_DATA_SOURCE_NAME }],
@@ -62,6 +80,31 @@ export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
     return { name, extensionGuess };
 };
 
+// We want to eventually use shorthands and other tricks to
+// try to shortern the resulting URL however we can
+enum URLQueryArgShorthands {
+    COLUMNS = "c",
+    FILE_VIEW = "v",
+}
+
+class ColumnCoder {
+    private static readonly COLUMN_DELIMETER = ",";
+    private static readonly VALUE_DELIMETER = ":";
+
+    public static encode(columns: Column[]): string {
+        return columns
+            .map((column) => `${column.name}${ColumnCoder.VALUE_DELIMETER}${column.width}`)
+            .join(ColumnCoder.COLUMN_DELIMETER);
+    }
+
+    public static decode(encoded: string): Column[] {
+        return encoded.split(ColumnCoder.COLUMN_DELIMETER).map((unparsedColumn: string) => {
+            const [name, widthAsStr] = unparsedColumn.split(ColumnCoder.VALUE_DELIMETER);
+            return { name, width: parseFloat(widthAsStr) };
+        });
+    }
+}
+
 /**
  * This represents a system for encoding application state information in a way
  * that allows users to copy, share, and paste the result back into the app and have the
@@ -77,6 +120,13 @@ export default class FileExplorerURL {
      * */
     public static encode(urlComponents: Partial<FileExplorerURLComponents>): string {
         const params = new URLSearchParams();
+        if (urlComponents.columns?.length) {
+            params.append(URLQueryArgShorthands.COLUMNS, ColumnCoder.encode(urlComponents.columns));
+        }
+        // Avoid including default in the URL
+        if (urlComponents.fileView && urlComponents.fileView !== FileView.LIST) {
+            params.append(URLQueryArgShorthands.FILE_VIEW, urlComponents.fileView);
+        }
         urlComponents.hierarchy?.forEach((annotation) => {
             params.append("group", annotation);
         });
@@ -131,6 +181,8 @@ export default class FileExplorerURL {
         const unparsedSources = params.getAll("source");
         const hierarchy = params.getAll("group");
         const unparsedSort = params.get("sort");
+        const unparsedColumns = params.get(URLQueryArgShorthands.COLUMNS) || "{}";
+        const fileView = (params.get(URLQueryArgShorthands.FILE_VIEW) as FileView) || FileView.LIST;
         const hierarchyDepth = hierarchy.length;
 
         const parsedSort = unparsedSort ? JSON.parse(unparsedSort) : undefined;
@@ -142,22 +194,24 @@ export default class FileExplorerURL {
             throw new Error("Sort order must be ASC or DESC");
         }
         return {
+            fileView,
             hierarchy,
-            sortColumn: parsedSort
-                ? new FileSort(parsedSort.annotationName, parsedSort.order || SortOrder.ASC)
-                : undefined,
+            columns: ColumnCoder.decode(unparsedColumns),
             filters: unparsedFilters
                 .map((unparsedFilter) => JSON.parse(unparsedFilter))
                 .map(
                     (parsedFilter) =>
                         new FileFilter(parsedFilter.name, parsedFilter.value, parsedFilter.type)
                 ),
-            sources: unparsedSources.map((unparsedSource) => JSON.parse(unparsedSource)),
-            sourceMetadata: unparsedSourceMetadata ? JSON.parse(unparsedSourceMetadata) : undefined,
             openFolders: unparsedOpenFolders
                 .map((unparsedFolder) => JSON.parse(unparsedFolder))
                 .filter((parsedFolder) => parsedFolder.length <= hierarchyDepth)
                 .map((parsedFolder) => new FileFolder(parsedFolder)),
+            sortColumn: parsedSort
+                ? new FileSort(parsedSort.annotationName, parsedSort.order || SortOrder.ASC)
+                : undefined,
+            sources: unparsedSources.map((unparsedSource) => JSON.parse(unparsedSource)),
+            sourceMetadata: unparsedSourceMetadata ? JSON.parse(unparsedSourceMetadata) : undefined,
         };
     }
 

--- a/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
+++ b/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import FileExplorerURL, { FileExplorerURLComponents, Source } from "..";
+import FileExplorerURL, { FileExplorerURLComponents, FileView, Source } from "..";
 import AnnotationName from "../../Annotation/AnnotationName";
 import FileFilter from "../../FileFilter";
 import ExcludeFilter from "../../FileFilter/ExcludeFilter";
@@ -37,6 +37,8 @@ describe("FileExplorerURL", () => {
                 ["AICS-0", "ACTB-mEGFP", true],
             ];
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: expectedAnnotationNames,
                 filters: expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
                 openFolders: expectedOpenFolders.map((folder) => new FileFolder(folder)),
@@ -74,6 +76,8 @@ describe("FileExplorerURL", () => {
             const expectedExcludeFilters = [{ annotationName: "Gene" }];
 
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: expectedAnnotationNames,
                 filters: [
                     ...expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
@@ -111,6 +115,8 @@ describe("FileExplorerURL", () => {
         it("Encodes empty state", () => {
             // Arrange
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: [],
                 filters: [],
                 openFolders: [],
@@ -127,6 +133,8 @@ describe("FileExplorerURL", () => {
         it("encodes source URIs when 'string' type is provided", () => {
             // Arrange
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: [],
                 filters: [],
                 openFolders: [],
@@ -170,6 +178,8 @@ describe("FileExplorerURL", () => {
                 ["3500000654", "ACTB-mEGFP", true],
             ];
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: expectedAnnotationNames,
                 filters: [
                     ...expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
@@ -201,6 +211,8 @@ describe("FileExplorerURL", () => {
         it("Decodes to empty app state", () => {
             // Arrange
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LIST,
                 hierarchy: [],
                 filters: [],
                 openFolders: [],
@@ -220,6 +232,8 @@ describe("FileExplorerURL", () => {
         it("Removes folders that are too deep for hierachy", () => {
             // Arrange
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.SMALL_THUMBNAIL,
                 hierarchy: ["Cell Line"],
                 filters: [],
                 openFolders: [new FileFolder(["AICS-0"]), new FileFolder(["AICS-0", false])],
@@ -246,6 +260,8 @@ describe("FileExplorerURL", () => {
                 ["3500000654", "ACTB-mEGFP", true],
             ];
             const components: FileExplorerURLComponents = {
+                columns: [],
+                fileView: FileView.LARGE_THUMBNAIL,
                 hierarchy: expectedAnnotationNames,
                 filters: expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
                 openFolders: expectedOpenFolders.map((folder) => new FileFolder(folder)),

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -141,8 +141,8 @@ export default abstract class DatabaseService {
     }
 
     public async prepareSourceMetadata(sourceMetadata: Source): Promise<void> {
-        const isOldSource = sourceMetadata.name === this.sourceMetadataName;
-        if (isOldSource) {
+        const isPreviousSource = sourceMetadata.name === this.sourceMetadataName;
+        if (isPreviousSource) {
             return;
         }
 

--- a/packages/core/services/PersistentConfigService/index.ts
+++ b/packages/core/services/PersistentConfigService/index.ts
@@ -1,13 +1,14 @@
 import { AnnotationResponse } from "../../entity/Annotation";
-import { Query } from "../../state/selection/actions";
+import { Column, Query } from "../../state/selection/actions";
 
 /**
  * Keys for the data saved by this service
  */
 export enum PersistedConfigKeys {
     AllenMountPoint = "ALLEN_MOUNT_POINT",
+    Columns = "COLUMNS",
     CsvColumns = "CSV_COLUMNS",
-    DisplayAnnotations = "DISPLAY_ANNOTATIONS",
+    DisplayAnnotations = "DISPLAY_ANNOTATIONS", // Deprecated, kept for backwards compatibility
     ImageJExecutable = "IMAGE_J_EXECUTABLE", // Deprecated
     HasUsedApplicationBefore = "HAS_USED_APPLICATION_BEFORE",
     UserSelectedApplications = "USER_SELECTED_APPLICATIONS",
@@ -22,6 +23,7 @@ export interface UserSelectedApplication {
 
 export interface PersistedConfig {
     [PersistedConfigKeys.AllenMountPoint]?: string;
+    [PersistedConfigKeys.Columns]?: Column[];
     [PersistedConfigKeys.CsvColumns]?: string[];
     [PersistedConfigKeys.DisplayAnnotations]?: AnnotationResponse[];
     [PersistedConfigKeys.ImageJExecutable]?: string; // Deprecated

--- a/packages/core/state/index.ts
+++ b/packages/core/state/index.ts
@@ -8,7 +8,6 @@ import metadata, { MetadataStateBranch } from "./metadata";
 import selection, { SelectionStateBranch } from "./selection";
 import { PlatformDependentServices } from "../services";
 import { PersistedConfig, PersistedConfigKeys } from "../services/PersistentConfigService";
-import Annotation from "../entity/Annotation";
 import FileSort from "../entity/FileSort";
 import FileFilter from "../entity/FileFilter";
 import FileFolder from "../entity/FileFolder";
@@ -67,11 +66,6 @@ export function createReduxStore(options: CreateStoreOptions = {}) {
     const queries = persistedConfig?.[PersistedConfigKeys.Queries]?.length
         ? (persistedConfig[PersistedConfigKeys.Queries] as Query[])
         : [];
-    const rawDisplayAnnotations =
-        persistedConfig && persistedConfig[PersistedConfigKeys.DisplayAnnotations];
-    const displayAnnotations = rawDisplayAnnotations
-        ? rawDisplayAnnotations.map((annotation) => new Annotation(annotation))
-        : [];
     const recentAnnotations = persistedConfig?.[PersistedConfigKeys.RecentAnnotations]?.length
         ? persistedConfig?.[PersistedConfigKeys.RecentAnnotations]
         : [];
@@ -89,7 +83,7 @@ export function createReduxStore(options: CreateStoreOptions = {}) {
                 persistedConfig?.[PersistedConfigKeys.UserSelectedApplications],
         },
         selection: {
-            displayAnnotations,
+            columns: persistedConfig?.[PersistedConfigKeys.Columns] || [],
             queries: queries.map((query) => ({
                 ...query,
                 parts: {

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -14,7 +14,6 @@ import {
     RequestDatasetManifest,
 } from "./actions";
 import * as metadataSelectors from "./selectors";
-import Annotation from "../../entity/Annotation";
 import AnnotationName from "../../entity/Annotation/AnnotationName";
 import FileSort, { SortOrder } from "../../entity/FileSort";
 import HttpAnnotationService from "../../services/AnnotationService/HttpAnnotationService";
@@ -57,73 +56,53 @@ const receiveAnnotationsLogic = createLogic({
         const actions = deps.action as ReceiveAnnotationAction;
         const annotations = actions.payload;
         const currentSortColumn = selection.selectors.getSortColumn(deps.getState());
-        const currentDisplayAnnotations = selection.selectors.getAnnotationsToDisplay(
-            deps.getState()
+        const currentColumns = selection.selectors.getColumns(deps.getState());
+        const isQueryingAicsFms = selection.selectors.isQueryingAicsFms(deps.getState());
+
+        const annotationNamesInDataSource = annotations.reduce(
+            (set, annotation) => set.add(annotation.name),
+            new Set<string>()
         );
-
-        const annotationNameToAnnotationMap = annotations.reduce(
-            (map, annotation) => ({ ...map, [annotation.name]: annotation }),
-            {} as Record<string, Annotation>
+        // Filter out any columns that were selected for display that no longer
+        // exist as annotations in the data source
+        const columnsThatStillExist = currentColumns.filter((column) =>
+            annotationNamesInDataSource.has(column.name)
         );
-        // Filter out any annotations that were selected for display that no longer
-        // exist as annotations in the state
-        const displayAnnotationsThatStillExist = currentDisplayAnnotations.flatMap((annotation) =>
-            annotation.name in annotationNameToAnnotationMap
-                ? [annotationNameToAnnotationMap[annotation.name]]
-                : []
+        const columnNamesThatStillExist = columnsThatStillExist.map((column) => column.name);
+
+        // Grab the first countOfColumnsToShow annotations as columns based on the following priority:
+        // 1) Was already a column
+        // 2) Is just in the data source
+        const countOfColumnsToShow = Math.max(4, columnsThatStillExist.length);
+        const remainingMaxWidth = columnsThatStillExist.reduce(
+            (remainingWidth, column) => remainingWidth - column.width,
+            1
         );
+        const columns = [
+            ...columnsThatStillExist,
+            ...annotations
+                .filter((annotation) => !columnNamesThatStillExist.includes(annotation.name))
+                .slice(0, countOfColumnsToShow - columnsThatStillExist.length)
+                .map((annotation) => ({
+                    name: annotation.name,
+                    width:
+                        remainingMaxWidth / (countOfColumnsToShow - columnsThatStillExist.length),
+                })),
+        ];
+        dispatch(selection.actions.setColumns(columns));
 
-        // These are the default annotations we want to display so this will
-        // iterate over each of the default annotations and add them as display
-        // annotations IF the annotations exist in the data source and we have room
-        // to display them
-        [
-            "File Name",
-            AnnotationName.FILE_NAME,
-            AnnotationName.KIND,
-            AnnotationName.TYPE,
-            AnnotationName.FILE_SIZE,
-        ].forEach((annotationName) => {
-            const isAlreadyDisplayed = displayAnnotationsThatStillExist.some(
-                (annotation) => annotation.name === annotationName
-            );
-            const existsInDataSource = annotationName in annotationNameToAnnotationMap;
-            const canFitInList = displayAnnotationsThatStillExist.length < 4;
-            if (!isAlreadyDisplayed && existsInDataSource && canFitInList) {
-                displayAnnotationsThatStillExist.push(
-                    annotationNameToAnnotationMap[annotationName]
-                );
-            }
-        });
-
-        // In the event we can't find the above annotations, just grab some random ones
-        // until we have 4 to display
-        for (
-            let i = 0;
-            displayAnnotationsThatStillExist.length < 4 && i < annotations.length;
-            i++
-        ) {
-            if (
-                !displayAnnotationsThatStillExist.find(
-                    (annotation) => annotation.name === annotations[i].name
-                )
-            ) {
-                displayAnnotationsThatStillExist.push(annotations[i]);
-            }
-        }
-
-        // If the current sort column is not valid and we can default the using the "Uploaded" column try to do so
         const isCurrentSortColumnValid =
-            currentSortColumn &&
-            annotations.some((annotation) => annotation.name === currentSortColumn.annotationName);
-        if (
-            !isCurrentSortColumnValid &&
-            annotations.some((annotation) => annotation.name === AnnotationName.UPLOADED)
-        ) {
-            const sortByUploaded = new FileSort(AnnotationName.UPLOADED, SortOrder.DESC);
-            dispatch(selection.actions.setSortColumn(sortByUploaded));
+            currentSortColumn && annotationNamesInDataSource.has(currentSortColumn.annotationName);
+        if (!isCurrentSortColumnValid) {
+            // Default to sorting by "Uploaded" for AICS FMS queries
+            if (isQueryingAicsFms) {
+                const sortByUploaded = new FileSort(AnnotationName.UPLOADED, SortOrder.DESC);
+                dispatch(selection.actions.setSortColumn(sortByUploaded));
+            } else {
+                dispatch(selection.actions.setSortColumn());
+            }
         }
-        dispatch(selection.actions.setDisplayAnnotations(displayAnnotationsThatStillExist));
+
         done();
     },
     type: RECEIVE_ANNOTATIONS,

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -1,6 +1,5 @@
 import { makeConstant } from "@aics/redux-utils";
 
-import Annotation from "../../entity/Annotation";
 import FileFilter, { FilterType } from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
 import FileSelection from "../../entity/FileSelection";
@@ -11,6 +10,7 @@ import Tutorial from "../../entity/Tutorial";
 import {
     EMPTY_QUERY_COMPONENTS,
     FileExplorerURLComponents,
+    FileView,
     Source,
 } from "../../entity/FileExplorerURL";
 
@@ -138,26 +138,9 @@ export function setSortColumn(fileSort?: FileSort): SetSortColumnAction {
     };
 }
 
-/**
- * SET_DISPLAY_ANNOTATIONS
- *
- * Intention to select annotations for a file to display in the file list (i.e., as a column).
- *
- * For example, by default, we may only see "File name | File size | Date created" as the columns in the file list. This
- * is the mechanism for a user to then add/remove a column to view.
- */
-export const SET_DISPLAY_ANNOTATIONS = makeConstant(STATE_BRANCH_NAME, "set-display-annotations");
-
-export interface SetDisplayAnnotationsAction {
-    payload: Annotation[];
-    type: string;
-}
-
-export function setDisplayAnnotations(annotations: Annotation[]): SetDisplayAnnotationsAction {
-    return {
-        payload: annotations,
-        type: SET_DISPLAY_ANNOTATIONS,
-    };
+export interface Column {
+    name: string;
+    width: number; // percent between 0 and 1
 }
 
 /**
@@ -168,40 +151,33 @@ export function setDisplayAnnotations(annotations: Annotation[]): SetDisplayAnno
 export const RESIZE_COLUMN = makeConstant(STATE_BRANCH_NAME, "resize-column");
 
 export interface ResizeColumnAction {
-    payload: {
-        columnHeader: string;
-        widthPercent: number; // between 0 and 1
-    };
+    payload: Column;
     type: string;
 }
 
-export function resizeColumn(columnHeader: string, widthPercent: number) {
+export function resizeColumn(column: Column) {
     return {
-        payload: {
-            columnHeader,
-            widthPercent,
-        },
+        payload: column,
         type: RESIZE_COLUMN,
     };
 }
 
 /**
- * RESET_COLUMN_WIDTH
+ * SET_COLUMNS
  *
- * Intention to remove a previous manual resizing of a column using the ResizeColumnAction. The expectation
- * is that if no specific mapping between a column and a width exists in state, a default will apply.
+ * Intention to set the columns that are displayed to the user in the file list
  */
-export const RESET_COLUMN_WIDTH = makeConstant(STATE_BRANCH_NAME, "reset-column-width");
+export const SET_COLUMNS = makeConstant(STATE_BRANCH_NAME, "set-columns");
 
-export interface ResetColumnWidthAction {
-    payload: string; // columnHeader
+export interface SetColumns {
+    payload: Column[];
     type: string;
 }
 
-export function resetColumnWidth(columnHeader: string) {
+export function setColumns(columns: Column[]) {
     return {
-        payload: columnHeader,
-        type: RESET_COLUMN_WIDTH,
+        payload: columns,
+        type: SET_COLUMNS,
     };
 }
 
@@ -653,41 +629,21 @@ export function adjustGlobalFontSize(shouldDisplaySmallFont: boolean): AdjustGlo
 }
 
 /**
- * SET_FILE_VIEW_TYPE
+ * SET_FILE_VIEW
  *
- * Intention to set the file view type to thumbnail or list
+ * Intention to set how the user sees the files displayed (ex. a list)
  */
-export const SET_FILE_THUMBNAIL_VIEW = makeConstant(STATE_BRANCH_NAME, "set-file-thumbnail-view");
+export const SET_FILE_VIEW = makeConstant(STATE_BRANCH_NAME, "set-file-view");
 
-export interface SetFileThumbnailView {
-    payload: boolean;
+export interface SetFileView {
+    payload: FileView;
     type: string;
 }
 
-export function setFileThumbnailView(shouldDisplayThumbnailView: boolean): SetFileThumbnailView {
+export function setFileView(view: FileView): SetFileView {
     return {
-        payload: shouldDisplayThumbnailView,
-        type: SET_FILE_THUMBNAIL_VIEW,
-    };
-}
-
-/**
- * SET_FILE_GRID_COLUMN_COUNT
- */
-export const SET_FILE_GRID_COLUMN_COUNT = makeConstant(
-    STATE_BRANCH_NAME,
-    "set-file-grid-column-count"
-);
-
-export interface SetFileGridColumnCount {
-    payload: number;
-    type: string;
-}
-
-export function setFileGridColumnCount(fileGridColumnCount: number): SetFileGridColumnCount {
-    return {
-        payload: fileGridColumnCount,
-        type: SET_FILE_GRID_COLUMN_COUNT,
+        payload: view,
+        type: SET_FILE_VIEW,
     };
 }
 

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -46,6 +46,8 @@ import {
     REMOVE_DATASOURCE_RELOAD_ERROR,
     CHANGE_FILE_FILTER_TYPE,
     AddDataSourceReloadError,
+    setFileView,
+    setColumns,
 } from "./actions";
 import { interaction, metadata, ReduxLogicDeps, selection } from "../";
 import * as selectionSelectors from "./selectors";
@@ -346,7 +348,9 @@ const decodeFileExplorerURLLogics = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const encodedURL = deps.action.payload;
         const {
+            columns,
             hierarchy,
+            fileView,
             filters,
             openFolders,
             sortColumn,
@@ -358,7 +362,9 @@ const decodeFileExplorerURLLogics = createLogic({
             dispatch(changeSourceMetadata(sourceMetadata));
             dispatch(changeDataSources(sources));
             dispatch(setAnnotationHierarchy(hierarchy));
+            columns && dispatch(setColumns(columns));
             dispatch(setFileFilters(filters));
+            fileView && dispatch(setFileView(fileView) as AnyAction);
             dispatch(setOpenFileFolders(openFolders));
             dispatch(setSortColumn(sortColumn));
         });

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -47,8 +47,8 @@ export const isQueryingAicsFms = createSelector(
 
 const FILE_VIEW_TO_COL_COUNT = {
     [FileView.LIST]: 1,
-    [FileView.SMALL_THUMBNAIL]: 5,
-    [FileView.LARGE_THUMBNAIL]: 10,
+    [FileView.SMALL_THUMBNAIL]: 10,
+    [FileView.LARGE_THUMBNAIL]: 5,
 };
 export const getFileGridColCount = createSelector(
     [getFileView],

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -3,23 +3,21 @@ import { createSelector } from "reselect";
 
 import { State } from "../";
 import Annotation from "../../entity/Annotation";
-import FileExplorerURL, { FileExplorerURLComponents } from "../../entity/FileExplorerURL";
+import FileExplorerURL, { FileExplorerURLComponents, FileView } from "../../entity/FileExplorerURL";
 import FileFilter, { FilterType } from "../../entity/FileFilter";
 import { getAnnotations } from "../metadata/selectors";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
 
 // BASIC SELECTORS
 export const getAnnotationHierarchy = (state: State) => state.selection.annotationHierarchy;
-export const getAnnotationsToDisplay = (state: State) => state.selection.displayAnnotations;
 export const getAvailableAnnotationsForHierarchy = (state: State) =>
     state.selection.availableAnnotationsForHierarchy;
 export const getAvailableAnnotationsForHierarchyLoading = (state: State) =>
     state.selection.availableAnnotationsForHierarchyLoading;
-export const getColumnWidths = (state: State) => state.selection.columnWidths;
-export const getFileGridColumnCount = (state: State) => state.selection.fileGridColumnCount;
+export const getColumns = (state: State) => state.selection.columns;
 export const getFileFilters = (state: State) => state.selection.filters;
 export const getFileSelection = (state: State) => state.selection.fileSelection;
-export const getIsDarkTheme = (state: State) => state.selection.isDarkTheme;
+export const getFileView = (state: State) => state.selection.fileView;
 export const getOpenFileFolders = (state: State) => state.selection.openFileFolders;
 export const getRecentAnnotations = (state: State) => state.selection.recentAnnotations;
 export const getRequiresDataSourceReload = (state: State) =>
@@ -28,8 +26,6 @@ export const getSelectedDataSources = (state: State) => state.selection.dataSour
 export const getSelectedSourceMetadata = (state: State) => state.selection.sourceMetadata;
 export const getSelectedQuery = (state: State) => state.selection.selectedQuery;
 export const getShouldDisplaySmallFont = (state: State) => state.selection.shouldDisplaySmallFont;
-export const getShouldDisplayThumbnailView = (state: State) =>
-    state.selection.shouldDisplayThumbnailView;
 export const getSortColumn = (state: State) => state.selection.sortColumn;
 export const getTutorial = (state: State) => state.selection.tutorial;
 export const getQueries = (state: State) => state.selection.queries;
@@ -38,9 +34,25 @@ const getPlatformDependentServices = (state: State) => state.interaction.platfor
 // COMPOSED SELECTORS
 export const hasQuerySelected = createSelector([getSelectedQuery], (query): boolean => !!query);
 
+export const isColumnWidthOverflowing = createSelector(
+    [getColumns, getFileView],
+    (columns, fileView): boolean =>
+        fileView === FileView.LIST && columns.reduce((acc, column) => acc + column.width, 0) > 1
+);
+
 export const isQueryingAicsFms = createSelector(
     [getSelectedDataSources],
     (dataSources): boolean => dataSources[0]?.name === AICS_FMS_DATA_SOURCE_NAME
+);
+
+const FILE_VIEW_TO_COL_COUNT = {
+    [FileView.LIST]: 1,
+    [FileView.SMALL_THUMBNAIL]: 5,
+    [FileView.LARGE_THUMBNAIL]: 10,
+};
+export const getFileGridColCount = createSelector(
+    [getFileView],
+    (fileView): number => FILE_VIEW_TO_COL_COUNT[fileView]
 );
 
 export const getFuzzyFilters = createSelector([getFileFilters], (filters): FileFilter[] =>
@@ -59,10 +71,16 @@ export const getDefaultFileFilters = createSelector([getFileFilters], (filters):
     filters.filter((filter) => filter.type === FilterType.DEFAULT)
 );
 
+export const getColumnNames = createSelector([getColumns], (columns): string[] =>
+    columns.map((column) => column.name)
+);
+
 export const getCurrentQueryParts = createSelector(
     [
         getAnnotationHierarchy,
+        getColumns,
         getFileFilters,
+        getFileView,
         getOpenFileFolders,
         getSortColumn,
         getSelectedDataSources,
@@ -70,13 +88,17 @@ export const getCurrentQueryParts = createSelector(
     ],
     (
         hierarchy,
+        columns,
         filters,
+        fileView,
         openFolders,
         sortColumn,
         sources,
         sourceMetadata
     ): FileExplorerURLComponents => ({
+        columns,
         hierarchy,
+        fileView,
         filters,
         openFolders,
         sortColumn,

--- a/packages/core/state/selection/test/reducer.test.ts
+++ b/packages/core/state/selection/test/reducer.test.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import selection from "..";
 import { initialState } from "../..";
 import interaction from "../../interaction";
-import { TOP_LEVEL_FILE_ANNOTATIONS } from "../../../constants";
 import FileFilter from "../../../entity/FileFilter";
 import FileSelection from "../../../entity/FileSelection";
 import FileSet from "../../../entity/FileSet";
@@ -78,26 +77,30 @@ describe("Selection reducer", () => {
         });
     });
 
-    describe("SET_DISPLAY_ANNOTATIONS", () => {
+    describe("SET_COLUMNS", () => {
         it("performs a set", () => {
             // arrange
             const initialSelectionState = {
                 ...selection.initialState,
-                displayAnnotations: [TOP_LEVEL_FILE_ANNOTATIONS[0]],
+                columns: [{ name: "Green", width: 0.11 }],
             };
+            const columns = [
+                { name: "Orange", width: 0.42 },
+                { name: "Red", width: 0.47 },
+            ];
 
-            const action = selection.actions.setDisplayAnnotations(TOP_LEVEL_FILE_ANNOTATIONS);
+            const action = selection.actions.setColumns(columns);
 
             // act
             const nextSelectionState = selection.reducer(initialSelectionState, action);
 
             // assert
             expect(
-                selection.selectors.getAnnotationsToDisplay({
+                selection.selectors.getColumns({
                     ...initialState,
                     selection: nextSelectionState,
                 })
-            ).to.deep.equal(TOP_LEVEL_FILE_ANNOTATIONS);
+            ).to.deep.equal(columns);
         });
     });
 

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -82,21 +82,16 @@ const store = createReduxStore({
 // https://redux.js.org/api/store#subscribelistener
 store.subscribe(() => {
     const state = store.getState();
+    const columns = selection.selectors.getColumns(state);
     const queries = selection.selectors.getQueries(state);
     const csvColumns = interaction.selectors.getCsvColumns(state);
-    const displayAnnotations = selection.selectors.getAnnotationsToDisplay(state);
     const hasUsedApplicationBefore = interaction.selectors.hasUsedApplicationBefore(state);
     const recentAnnotations = selection.selectors.getRecentAnnotations(state);
     const userSelectedApplications = interaction.selectors.getUserSelectedApplications(state);
 
     const appState = {
+        [PersistedConfigKeys.Columns]: columns,
         [PersistedConfigKeys.CsvColumns]: csvColumns,
-        [PersistedConfigKeys.DisplayAnnotations]: displayAnnotations.map((annotation) => ({
-            annotationDisplayName: annotation.displayName,
-            annotationName: annotation.name,
-            description: annotation.description,
-            type: annotation.type,
-        })),
         [PersistedConfigKeys.HasUsedApplicationBefore]: hasUsedApplicationBefore,
         [PersistedConfigKeys.Queries]: queries,
         [PersistedConfigKeys.RecentAnnotations]: recentAnnotations,

--- a/packages/desktop/src/services/PersistentConfigServiceElectron.ts
+++ b/packages/desktop/src/services/PersistentConfigServiceElectron.ts
@@ -16,12 +16,33 @@ const OPTIONS: Options<Record<string, unknown>> = {
         [PersistedConfigKeys.AllenMountPoint]: {
             type: "string",
         },
+        [PersistedConfigKeys.Columns]: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    annotationDisplayName: {
+                        type: "string",
+                    },
+                    annotationName: {
+                        type: "string",
+                    },
+                    description: {
+                        type: "string",
+                    },
+                    type: {
+                        type: "string",
+                    },
+                },
+            },
+        },
         [PersistedConfigKeys.CsvColumns]: {
             type: "array",
             items: {
                 type: "string",
             },
         },
+        // Deprecated in 8.10.0
         [PersistedConfigKeys.DisplayAnnotations]: {
             type: "array",
             items: {
@@ -115,6 +136,12 @@ const OPTIONS: Options<Record<string, unknown>> = {
         ">5.2.0": (store) => {
             if (store.has(PersistedConfigKeys.AllenMountPoint)) {
                 store.delete(PersistedConfigKeys.AllenMountPoint);
+            }
+        },
+        // Remove PersistedConfigKeys.DisplayAnnotations
+        ">8.9.3": (store) => {
+            if (store.has(PersistedConfigKeys.DisplayAnnotations)) {
+                store.delete(PersistedConfigKeys.DisplayAnnotations);
             }
         },
     },

--- a/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
+++ b/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
@@ -61,8 +61,10 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                     units: "string",
                 },
             ];
+            const expectedColumns = [{ file_size: 0.4 }, { file_name: 0.6 }];
 
             service.persist(PersistedConfigKeys.AllenMountPoint, expectedAllenMountPoint);
+            service.persist(PersistedConfigKeys.Columns, expectedColumns);
             service.persist(PersistedConfigKeys.CsvColumns, expectedCsvColumns);
             service.persist(PersistedConfigKeys.ImageJExecutable, expectedImageJExecutable);
             service.persist(PersistedConfigKeys.Queries, expectedQueries);
@@ -76,6 +78,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
 
             const expectedConfig = {
                 [PersistedConfigKeys.AllenMountPoint]: expectedAllenMountPoint,
+                [PersistedConfigKeys.Columns]: expectedColumns,
                 [PersistedConfigKeys.CsvColumns]: expectedCsvColumns,
                 [PersistedConfigKeys.ImageJExecutable]: expectedImageJExecutable,
                 [PersistedConfigKeys.Queries]: expectedQueries,
@@ -99,6 +102,10 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
             const service = new PersistentConfigServiceElectron({ clearExistingData: true });
             const config = {
                 [PersistedConfigKeys.AllenMountPoint]: "/some/path/to/allen",
+                [PersistedConfigKeys.Columns]: [
+                    { name: "a", width: 0.25 },
+                    { name: "b", width: 0.3 },
+                ],
                 [PersistedConfigKeys.CsvColumns]: ["a", "b"],
                 [PersistedConfigKeys.ImageJExecutable]: "/my/imagej",
                 [PersistedConfigKeys.Queries]: [],


### PR DESCRIPTION
## Description
Users have wanted to control which columns are shown in shared queries for a while. This adds them to the query arguments decoded/encoded.

While I was in here I noticed the columns & file view were tracked in multiple pieces. I added an interface and enum (respectively) to capture those pieces of information more simply.

## Testing
Tested against AICS FMS, cloud hosted, and local data sources

## Related Issue
Resolves #329 