### PR TITLE
[Large] Create UI for metadata editing workflow

### DIFF
--- a/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
+++ b/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
@@ -9,9 +9,9 @@
 }
 
 .choice-group label > span {
-  font-size: var(--s-paragraph-size);
+  font-size: var(--l-paragraph-size);
   margin-right: 5px;
-  margin-top: 2px;
+  margin-top: 1px;
   padding-left: 24px !important;
 }
 
@@ -43,5 +43,5 @@
 }
 
 .choice-group > div > div > div:not(:first-child) {
-  margin-left: 6px;
+  margin-left: var(--margin);
 }

--- a/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
+++ b/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
@@ -24,8 +24,8 @@
   border-color: var(--aqua);
   width: 16px;
   height: 16px;
-  top: 2.1px;
-  left: 2.1px;
+  top: 2px;
+  left: 2px;
 }
 
 .choice-group label::after {

--- a/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
+++ b/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
@@ -1,4 +1,3 @@
-
 .choice-group input:disabled + label {
   cursor: not-allowed;
   opacity: 0.5;

--- a/packages/core/components/ChoiceGroup/index.tsx
+++ b/packages/core/components/ChoiceGroup/index.tsx
@@ -1,6 +1,8 @@
 import { ChoiceGroup, IChoiceGroupOption } from "@fluentui/react";
 import * as React from "react";
 
+import Tooltip from "../Tooltip";
+
 import styles from "./ChoiceGroup.module.css";
 
 interface Props {
@@ -22,7 +24,21 @@ export default function BaseChoiceGroup(props: Props) {
         <ChoiceGroup
             className={props?.className}
             defaultSelectedKey={props?.defaultSelectedKey}
-            options={props.options}
+            options={props.options.map((option) => {
+                return {
+                    ...option,
+                    onRenderField: (optionProps, defaultRender) => {
+                        if (optionProps && defaultRender) {
+                            return (
+                                <Tooltip content={optionProps.title}>
+                                    {defaultRender(optionProps) || <></>}
+                                </Tooltip>
+                            );
+                        }
+                        return <></>;
+                    },
+                };
+            })}
             onChange={props.onChange}
             styles={{ root: styles.choiceGroup }}
         />

--- a/packages/core/components/ComboBox/ComboBox.module.css
+++ b/packages/core/components/ComboBox/ComboBox.module.css
@@ -1,0 +1,99 @@
+.combo-box {
+  border: 1px solid var(--border-color);
+  border-radius: var(--small-border-radius);
+}
+
+.combo-box, .combo-box > :is(div, input), .combo-box :is(button, i) {
+  background-color: var(--secondary-background-color) !important;
+  color: var(--secondary-text-color) !important;
+}
+
+.combo-box:focus, .combo-box:focus-visible {
+  outline: none;
+}
+
+.combo-box:hover > button, .combo-box:hover > button i {
+  color: var(--highlight-text-color) !important;
+}
+
+.combo-box > *::placeholder {
+  color: var(--secondary-text-color) !important;
+  font-style: italic;
+}
+
+.combo-box::after {
+  border: unset;
+}
+
+.combo-box:focus-within, .combo-box:focus, .combo-box:active {
+  border: 1px solid var(--aqua);
+}
+
+.combo-box-caret {
+  position: absolute;
+  right: 0;
+}
+
+.combo-box-label {
+  color: var(--primary-text-color) !important;
+  font-size: var(--l-paragraph-size);
+}
+
+.combo-box-callout {
+  background-color: var(--primary-background-color);
+  border-radius: var(--small-border-radius);
+  box-shadow: var(--box-shadow);
+  padding: 8px 0;
+  max-height: 250px !important;
+}
+
+.combo-box-callout > div {
+  background-color: var(--primary-background-color);
+  border-radius: 0;
+}
+
+.combo-box-item :is(input, button, label){
+  color: var(--primary-text-color);
+}
+
+.combo-box-item button:disabled, .combo-box-item-disabled {
+  color: var(--primary-text-color);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.combo-box-item-disabled > div:hover,
+.combo-box-item-disabled > div:hover :is(input, label) {
+  background-color: var(--primary-background-color) !important;
+  color: unset !important;
+}
+
+.combo-box-item button:not(:disabled):hover,
+.combo-box-item > div:hover,
+.combo-box-item > div:hover :is(input, label) {
+  background-color: var(--highlight-background-color);
+  color: var(--highlight-text-color);
+}
+
+.combo-box-callout button:not(:disabled):active, 
+.combo-box-callout button:not(:disabled):active:hover,
+.combo-box-callout button:not(:disabled):focus,
+.combo-box-item > div:active,
+.combo-box-item > div:active:hover,
+.combo-box-item > div:focus,
+.combo-box-item > div:active :is(input, label),
+.combo-box-item > div:active:hover :is(input, label),
+.combo-box-item > div:focus :is(input, label)  {
+  background-color: var(--secondary-dark);
+  color: var(--highlight-text-color);
+}
+
+/* Remove border and background from checkbox for multiselect */
+.combo-box-item > div :is(i, div) {
+  border: none !important;
+  background: none !important;
+}
+
+.combo-box-item > div:hover :is(i, div) {
+  color: var(--highlight-text-color) !important;
+}

--- a/packages/core/components/ComboBox/ComboBox.module.css
+++ b/packages/core/components/ComboBox/ComboBox.module.css
@@ -44,12 +44,25 @@
   border-radius: var(--small-border-radius);
   box-shadow: var(--box-shadow);
   padding: 8px 0;
-  max-height: 250px !important;
+  max-height: 300px !important;
 }
 
 .combo-box-callout > div {
   background-color: var(--primary-background-color);
   border-radius: 0;
+}
+
+.combo-box-callout::after  {
+  background-image: linear-gradient(transparent,  var(--primary-background-color));
+  content: " ";
+  display: block;
+  height: 30px;
+  pointer-events: none;
+  /* Adjusted for height - footer height */
+  width: 100%;
+  z-index: 10;
+  position: absolute;
+  bottom: 5px;
 }
 
 .combo-box-item :is(input, button, label){
@@ -96,4 +109,8 @@
 
 .combo-box-item > div:hover :is(i, div) {
   color: var(--highlight-text-color) !important;
+}
+
+.options-container {
+  padding-bottom: var(--margin);
 }

--- a/packages/core/components/ComboBox/index.tsx
+++ b/packages/core/components/ComboBox/index.tsx
@@ -1,0 +1,91 @@
+import { ComboBox, IComboBoxOption, IRenderFunction, ISelectableOption } from "@fluentui/react";
+import classNames from "classnames";
+import Fuse from "fuse.js";
+import * as React from "react";
+
+import styles from "./ComboBox.module.css";
+
+interface Props {
+    className?: string;
+    disabled?: boolean;
+    label: string;
+    multiSelect?: boolean;
+    options: IComboBoxOption[];
+    placeholder: string;
+    threshold?: number;
+    useComboBoxAsMenuWidth?: boolean;
+    onChange?: (option: IComboBoxOption | undefined) => void;
+}
+
+/**
+ * Custom styled wrapper for default fluentui component
+ */
+export default function BaseComboBox(props: Props) {
+    const { options, label, placeholder } = props;
+
+    const FUZZY_SEARCH_OPTIONS = {
+        // which keys to search on
+        keys: [{ name: "text", weight: 1.0 }],
+
+        // return resulting matches sorted
+        shouldSort: true,
+
+        // arbitrarily tuned; 0.0 requires a perfect match, 1.0 would match anything
+        threshold: props?.threshold || 0.3,
+    };
+
+    const [searchValue, setSearchValue] = React.useState("");
+
+    // Fuse logic borrowed from the ListPicker component
+    const fuse = React.useMemo(() => new Fuse(options, FUZZY_SEARCH_OPTIONS), [options]);
+    const filteredOptions = React.useMemo(() => {
+        const filteredRows = searchValue ? fuse.search(searchValue) : options;
+        return filteredRows.sort((a, b) => {
+            // If disabled, sort to the bottom
+            return a.disabled === b.disabled ? 0 : a.disabled ? 1 : -1;
+        });
+    }, [options, searchValue, fuse]);
+
+    const onRenderItem = (
+        itemProps: ISelectableOption | undefined,
+        defaultRender: IRenderFunction<ISelectableOption> | undefined
+    ): JSX.Element => {
+        if (itemProps && defaultRender) {
+            return (
+                <span
+                    key={`${itemProps.key}-${itemProps.index}`}
+                    className={classNames(styles.comboBoxItem, {
+                        [styles.comboBoxItemDisabled]: !!itemProps.disabled,
+                    })}
+                >
+                    {defaultRender(itemProps)}
+                </span>
+            );
+        }
+        return <></>;
+    };
+
+    return (
+        <ComboBox
+            allowFreeform
+            caretDownButtonStyles={{ root: styles.comboBoxCaret }}
+            className={props?.className}
+            disabled={props?.disabled}
+            placeholder={placeholder}
+            label={label}
+            multiSelect={props?.multiSelect}
+            options={filteredOptions}
+            onChange={(_, option) => props.onChange?.(option)}
+            onInputValueChange={(value) => {
+                setSearchValue(value || "");
+            }}
+            onRenderItem={(props, defaultRender) => onRenderItem(props, defaultRender)}
+            styles={{
+                root: styles.comboBox,
+                label: styles.comboBoxLabel,
+                callout: styles.comboBoxCallout,
+            }}
+            useComboBoxAsMenuWidth={props?.useComboBoxAsMenuWidth}
+        />
+    );
+}

--- a/packages/core/components/ComboBox/index.tsx
+++ b/packages/core/components/ComboBox/index.tsx
@@ -18,7 +18,7 @@ const FUZZY_SEARCH_OPTIONS = {
 
 interface Props {
     className?: string;
-    defaultValue?: string;
+    selectedKey?: string;
     disabled?: boolean;
     label: string;
     multiSelect?: boolean;
@@ -70,7 +70,7 @@ export default function BaseComboBox(props: Props) {
             allowFreeform
             caretDownButtonStyles={{ root: styles.comboBoxCaret }}
             className={props?.className}
-            defaultValue={props?.defaultValue}
+            selectedKey={props?.selectedKey}
             disabled={props?.disabled}
             placeholder={placeholder}
             label={label}

--- a/packages/core/components/ComboBox/index.tsx
+++ b/packages/core/components/ComboBox/index.tsx
@@ -5,16 +5,27 @@ import * as React from "react";
 
 import styles from "./ComboBox.module.css";
 
+const FUZZY_SEARCH_OPTIONS = {
+    // which keys to search on
+    keys: [{ name: "text", weight: 1.0 }],
+
+    // return resulting matches sorted
+    shouldSort: true,
+
+    // arbitrarily tuned; 0.0 requires a perfect match, 1.0 would match anything
+    threshold: 0.3,
+};
+
 interface Props {
     className?: string;
+    defaultValue?: string;
     disabled?: boolean;
     label: string;
     multiSelect?: boolean;
     options: IComboBoxOption[];
     placeholder: string;
-    threshold?: number;
     useComboBoxAsMenuWidth?: boolean;
-    onChange?: (option: IComboBoxOption | undefined) => void;
+    onChange?: (option: IComboBoxOption | undefined, value?: string | undefined) => void;
 }
 
 /**
@@ -22,17 +33,6 @@ interface Props {
  */
 export default function BaseComboBox(props: Props) {
     const { options, label, placeholder } = props;
-
-    const FUZZY_SEARCH_OPTIONS = {
-        // which keys to search on
-        keys: [{ name: "text", weight: 1.0 }],
-
-        // return resulting matches sorted
-        shouldSort: true,
-
-        // arbitrarily tuned; 0.0 requires a perfect match, 1.0 would match anything
-        threshold: props?.threshold || 0.3,
-    };
 
     const [searchValue, setSearchValue] = React.useState("");
 
@@ -70,12 +70,14 @@ export default function BaseComboBox(props: Props) {
             allowFreeform
             caretDownButtonStyles={{ root: styles.comboBoxCaret }}
             className={props?.className}
+            defaultValue={props?.defaultValue}
             disabled={props?.disabled}
             placeholder={placeholder}
             label={label}
             multiSelect={props?.multiSelect}
             options={filteredOptions}
-            onChange={(_, option) => props.onChange?.(option)}
+            onChange={(_ev, option, _ind, value) => props.onChange?.(option, value)}
+            onItemClick={(_, option) => props.onChange?.(option)}
             onInputValueChange={(value) => {
                 setSearchValue(value || "");
             }}

--- a/packages/core/components/ComboBox/index.tsx
+++ b/packages/core/components/ComboBox/index.tsx
@@ -86,6 +86,7 @@ export default function BaseComboBox(props: Props) {
                 root: styles.comboBox,
                 label: styles.comboBoxLabel,
                 callout: styles.comboBoxCallout,
+                optionsContainer: styles.optionsContainer,
             }}
             useComboBoxAsMenuWidth={props?.useComboBoxAsMenuWidth}
         />

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -1,0 +1,113 @@
+.footer {
+  margin-top: 20px;
+  width: 100%;
+}
+
+.footer-align-right {
+  width: 100%;
+  display: flex;
+}
+
+.footer-align-right > * {
+  margin-left: 10px;
+  width: min-content;
+}
+
+.footer-align-right > *:first-child{
+  margin-left: auto;
+}
+
+.text-field {
+  padding-top: var(--margin);
+  max-width: 300px;;
+}
+
+.text-field > div > label, .text-field > div > label::after {
+  color: var(--secondary-text-color) !important;
+  font-size: var(--l-paragraph-size);
+}
+
+.text-field :is(input) {
+  background-color: var(--secondary-background-color) !important;
+  color: var(--secondary-text-color) !important;
+  border-radius: 4px;
+}
+
+.text-field > div:focus, .text-field div:focus-visible, .text-field:focus-visible, .text-field > div:active {
+  outline: none;
+}
+
+.text-field > div > div {
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background-color: var(--secondary-background-color) !important;
+  color: var(--secondary-text-color) !important;
+}
+
+.text-field > div > div::after {
+  border: 1px solid var(--aqua);
+  border-radius: 4px;
+  outline: none;
+}
+
+.text-field > div > div > *::placeholder {
+  color: var(--secondary-text-color);
+  font-style: italic;
+}
+
+.text-field > div > div:hover {
+  border: 1px solid var(--border-color)
+}
+
+.combo-box {
+  width: 295px;
+  padding-top: var(--margin);
+}
+
+.chips {
+  padding-left: 5px;
+}
+
+.submit-icon {
+  align-items: center;
+  border-radius: var(--small-border-radius);
+  cursor: pointer;
+  display: flex;
+  padding: 0 0.5em;
+}
+
+.submit-icon.disabled {
+  cursor: default;
+  opacity: 0.8;
+}
+
+.submit-icon:hover:not(.disabled), .submit-icon:focus:not(.disabled) {
+  background-color: var(--highlight-background-color);
+  color: var(--highlight-text-color);
+}
+
+.selected-option-container {
+  display: flex;
+  margin-left: var(--margin);
+}
+
+.selected-option {
+  align-items: center;
+  display: flex;
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: min-content;
+  white-space: nowrap;
+}
+
+.selected-option-button {
+  color: var(--primary-text-color);
+  margin-left: 10px;
+}
+
+.selected-option-button:hover {
+  background-color: unset;
+  color: var(--highlight-text-color);
+}

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -1,3 +1,12 @@
+.combo-box {
+  width: 295px;
+  padding-top: var(--margin);
+}
+
+.chips {
+  padding-left: 5px;
+}
+
 .footer {
   margin-top: 20px;
   width: 100%;
@@ -17,55 +26,9 @@
   margin-left: auto;
 }
 
-.text-field {
-  padding-top: var(--margin);
-  max-width: 300px;;
-}
-
-.text-field > div > label, .text-field > div > label::after {
-  color: var(--secondary-text-color) !important;
-  font-size: var(--l-paragraph-size);
-}
-
-.text-field :is(input) {
-  background-color: var(--secondary-background-color) !important;
-  color: var(--secondary-text-color) !important;
-  border-radius: 4px;
-}
-
-.text-field > div:focus, .text-field div:focus-visible, .text-field:focus-visible, .text-field > div:active {
-  outline: none;
-}
-
-.text-field > div > div {
-  border-radius: 4px;
-  border: 1px solid var(--border-color);
-  background-color: var(--secondary-background-color) !important;
-  color: var(--secondary-text-color) !important;
-}
-
-.text-field > div > div::after {
-  border: 1px solid var(--aqua);
-  border-radius: 4px;
-  outline: none;
-}
-
-.text-field > div > div > *::placeholder {
-  color: var(--secondary-text-color);
-  font-style: italic;
-}
-
-.text-field > div > div:hover {
-  border: 1px solid var(--border-color)
-}
-
-.combo-box {
-  width: 295px;
-  padding-top: var(--margin);
-}
-
-.chips {
-  padding-left: 5px;
+.primary-button:disabled {
+  background-color: var(--border-color);
+  color: var(--primary-text-color)
 }
 
 .submit-icon {
@@ -110,4 +73,46 @@
 .selected-option-button:hover {
   background-color: unset;
   color: var(--highlight-text-color);
+}
+
+.text-field {
+  padding-top: var(--margin);
+  max-width: 300px;;
+}
+
+.text-field > div > label, .text-field > div > label::after {
+  color: var(--secondary-text-color) !important;
+  font-size: var(--l-paragraph-size);
+}
+
+.text-field :is(input) {
+  background-color: var(--secondary-background-color) !important;
+  color: var(--secondary-text-color) !important;
+  border-radius: 4px;
+}
+
+.text-field > div:focus, .text-field div:focus-visible, .text-field:focus-visible, .text-field > div:active {
+  outline: none;
+}
+
+.text-field > div > div {
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background-color: var(--secondary-background-color) !important;
+  color: var(--secondary-text-color) !important;
+}
+
+.text-field > div > div::after {
+  border: 1px solid var(--aqua);
+  border-radius: 4px;
+  outline: none;
+}
+
+.text-field > div > div > *::placeholder {
+  color: var(--secondary-text-color);
+  font-style: italic;
+}
+
+.text-field > div > div:hover {
+  border: 1px solid var(--border-color)
 }

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -1,6 +1,10 @@
 .combo-box {
   width: 295px;
-  padding-top: var(--margin);
+  padding-bottom: var(--margin);
+}
+
+.choice-group {
+  padding-bottom: var(--margin);
 }
 
 .chips {
@@ -76,7 +80,7 @@
 }
 
 .text-field {
-  padding-top: var(--margin);
+  padding-bottom: var(--margin);
   max-width: 300px;;
 }
 

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -1,0 +1,93 @@
+import { IComboBoxOption } from "@fluentui/react";
+import classNames from "classnames";
+import * as React from "react";
+
+import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
+import { PrimaryButton, SecondaryButton } from "../Buttons";
+import ComboBox from "../ComboBox";
+
+import styles from "./EditMetadata.module.css";
+
+interface ExistingAnnotationProps {
+    onDismiss: () => void;
+    annotationValueMap: Map<string, any> | undefined;
+    annotationOptions: { key: string; text: string }[];
+    selectedFileCount: number;
+}
+
+/**
+ * Component for selecting an existing annotation
+ * and then entering values for the selected files
+ */
+export default function ExistingAnnotationPathway(props: ExistingAnnotationProps) {
+    const [newValues, setNewValues] = React.useState<string>();
+    const [valueCount, setValueCount] = React.useState<ValueCountItem[]>();
+
+    const onSelectMetadataField = (
+        option: IComboBoxOption | undefined,
+        value: string | undefined
+    ) => {
+        let valueMap: ValueCountItem[] = [];
+        // FluentUI's combobox doesn't always register the entered value as an option,
+        // so we need to be able to check both
+        const selectedFieldName = option?.text || value;
+        if (!selectedFieldName) return;
+        // Track how many values we've seen, since some files may not have a value for this field
+        let totalValueCount = 0;
+        if (props?.annotationValueMap?.has(selectedFieldName)) {
+            const fieldValues = props.annotationValueMap.get(selectedFieldName);
+            valueMap = Object.keys(fieldValues).map((fieldName) => {
+                totalValueCount += fieldValues[fieldName];
+                return {
+                    value: fieldName,
+                    fileCount: fieldValues[fieldName],
+                };
+            });
+        }
+        // If some or all of the files don't have values for this annotation,
+        // they won't be in the annotation map
+        if (totalValueCount < props.selectedFileCount) {
+            valueMap = [
+                {
+                    value: undefined,
+                    fileCount: props.selectedFileCount - totalValueCount,
+                },
+                ...valueMap,
+            ];
+        }
+        setValueCount(valueMap);
+    };
+
+    function onSubmit() {
+        // TO DO: endpoint logic is in progress on a different branch
+        props.onDismiss();
+    }
+
+    return (
+        <>
+            <ComboBox
+                className={styles.comboBox}
+                label="Select a metadata field"
+                placeholder="Select a field"
+                options={props.annotationOptions}
+                useComboBoxAsMenuWidth
+                onChange={onSelectMetadataField}
+            />
+            {valueCount && (
+                <MetadataDetails
+                    onChange={(value) => setNewValues(value)}
+                    items={valueCount || []}
+                />
+            )}
+            <div className={classNames(styles.footer, styles.footerAlignRight)}>
+                <SecondaryButton title="Cancel" text="CANCEL" onClick={props.onDismiss} />
+                <PrimaryButton
+                    disabled={!newValues}
+                    title="Replace"
+                    text="REPLACE"
+                    onClick={onSubmit}
+                />
+            </div>
+        </>
+    );
+}

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -82,6 +82,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
             <div className={classNames(styles.footer, styles.footerAlignRight)}>
                 <SecondaryButton title="Cancel" text="CANCEL" onClick={props.onDismiss} />
                 <PrimaryButton
+                    className={styles.primaryButton}
                     disabled={!newValues}
                     title="Replace"
                     text="REPLACE"

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -35,12 +35,12 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
         // Track how many values we've seen, since some files may not have a value for this field
         let totalValueCount = 0;
         if (props?.annotationValueMap?.has(selectedFieldName)) {
-            const fieldValues = props.annotationValueMap.get(selectedFieldName);
-            valueMap = Object.keys(fieldValues).map((fieldName) => {
-                totalValueCount += fieldValues[fieldName];
+            const fieldValueToOccurenceMap = props.annotationValueMap.get(selectedFieldName);
+            valueMap = Object.keys(fieldValueToOccurenceMap).map((fieldName) => {
+                totalValueCount += fieldValueToOccurenceMap[fieldName];
                 return {
                     value: fieldName,
-                    fileCount: fieldValues[fieldName],
+                    fileCount: fieldValueToOccurenceMap[fieldName],
                 };
             });
         }
@@ -81,13 +81,15 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
             )}
             <div className={classNames(styles.footer, styles.footerAlignRight)}>
                 <SecondaryButton title="Cancel" text="CANCEL" onClick={props.onDismiss} />
-                <PrimaryButton
-                    className={styles.primaryButton}
-                    disabled={!newValues}
-                    title="Replace"
-                    text="REPLACE"
-                    onClick={onSubmit}
-                />
+                {valueCount && (
+                    <PrimaryButton
+                        className={styles.primaryButton}
+                        disabled={!newValues}
+                        title="Replace"
+                        text="REPLACE"
+                        onClick={onSubmit}
+                    />
+                )}
             </div>
         </>
     );

--- a/packages/core/components/EditMetadata/MetadataDetails.module.css
+++ b/packages/core/components/EditMetadata/MetadataDetails.module.css
@@ -41,11 +41,15 @@
   width: 100%;
 }
 
-.left-stack-item {
+.stack-item-left {
   padding-top: 5px;
   width: 300px;
 }
 
-.right-stack-item {
+.stack-item-center {
+  padding-bottom: 14px;
+}
+
+.stack-item-right {
   width: 275px;
 }

--- a/packages/core/components/EditMetadata/MetadataDetails.module.css
+++ b/packages/core/components/EditMetadata/MetadataDetails.module.css
@@ -1,0 +1,51 @@
+.wrapper {
+  padding: var(--margin);
+  margin: var(--margin) 0;
+  border: 1px solid var(--border-color);
+  border-radius: var(--small-border-radius);
+}
+
+.details-header > div, .details-header > div:hover, .details-header span {
+  background-color: var(--primary-background-color);
+  color: var(--secondary-text-color);
+}
+
+.details-header > div {
+  padding-top: 5px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.column-right-align span, .column-right-align-cell {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.table-row {
+  position: relative;
+  cursor: default;
+}
+
+.table-row > div:first-child {
+  color: var(--secondary-text-color);
+  background-color: unset;
+  font-family: var(--font-family);
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.table-row > div:hover:first-child, .table-row > div:hover {
+  color: var(--secondary-text-color);
+}
+
+.stack {
+  width: 100%;
+}
+
+.left-stack-item {
+  padding-top: 5px;
+  width: 300px;
+}
+
+.right-stack-item {
+  width: 275px;
+}

--- a/packages/core/components/EditMetadata/MetadataDetails.module.css
+++ b/packages/core/components/EditMetadata/MetadataDetails.module.css
@@ -8,11 +8,17 @@
 .details-header > div, .details-header > div:hover, .details-header span {
   background-color: var(--primary-background-color);
   color: var(--secondary-text-color);
+  font-size: var(--xs-paragraph-size);
+  height: 36px;
 }
 
 .details-header > div {
   padding-top: 5px;
   border-bottom: 1px solid var(--border-color);
+}
+
+.details-header > div > div:hover {
+  background-color: unset;
 }
 
 .column-right-align span, .column-right-align-cell {
@@ -28,13 +34,16 @@
 .table-row > div:first-child {
   color: var(--secondary-text-color);
   background-color: unset;
-  font-family: var(--font-family);
-  font-size: 14px;
+  font-size: var(--l-paragraph-size);
   font-weight: 400;
 }
 
 .table-row > div:hover:first-child, .table-row > div:hover {
   color: var(--secondary-text-color);
+}
+
+.table-title {
+  padding-bottom: 5px
 }
 
 .stack {

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -58,7 +58,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
     return (
         <div className={styles.wrapper}>
             <Stack className={styles.stack} horizontal tokens={{ childrenGap: 20 }}>
-                <StackItem grow className={styles.leftStackItem}>
+                <StackItem grow className={styles.stackItemLeft}>
                     <h4>Existing values</h4>
                     <DetailsList
                         setKey="items"
@@ -94,10 +94,10 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                         onRenderItemColumn={renderItemColumn}
                     />
                 </StackItem>
-                <StackItem grow align="center">
+                <StackItem grow align="center" className={styles.stackItemCenter}>
                     <Icon iconName="Forward" />
                 </StackItem>
-                <StackItem grow className={styles.rightStackItem}>
+                <StackItem grow className={styles.stackItemRight}>
                     {/* TODO: Display different entry types depending on datatype of annotation */}
                     <TextField
                         label="Replace with"

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -1,0 +1,115 @@
+import {
+    DetailsList,
+    IColumn,
+    Icon,
+    IDetailsRowProps,
+    IRenderFunction,
+    SelectionMode,
+    Stack,
+    StackItem,
+    TextField,
+} from "@fluentui/react";
+import * as React from "react";
+
+import rootStyles from "./EditMetadata.module.css";
+import styles from "./MetadataDetails.module.css";
+
+export interface ValueCountItem {
+    value: string | undefined;
+    fileCount: number;
+}
+
+interface DetailsListProps {
+    items: ValueCountItem[];
+    onChange: (value: string | undefined) => void;
+    newValues?: string;
+}
+
+/**
+ * Component that displays a table of the current values for the selected annotation
+ * and provides an field for user to input new values.
+ * Used by both the new & existing annotation pathways
+ */
+export default function EditMetadataDetailsList(props: DetailsListProps) {
+    const { items } = props;
+    const renderRow = (
+        rowProps: IDetailsRowProps | undefined,
+        defaultRender: IRenderFunction<IDetailsRowProps> | undefined
+    ): JSX.Element => {
+        if (rowProps && defaultRender) {
+            return <span className={styles.tableRow}>{defaultRender(rowProps)}</span>;
+        }
+        return <></>;
+    };
+
+    function renderItemColumn(
+        item: ValueCountItem,
+        _: number | undefined,
+        column: IColumn | undefined
+    ) {
+        const fieldContent = item[column?.fieldName as keyof ValueCountItem] as string;
+        if (!fieldContent) return "[No value] (blank)";
+        if (column?.fieldName === "fileCount") {
+            return <div className={styles.columnRightAlignCell}>{fieldContent}</div>;
+        }
+        return fieldContent;
+    }
+
+    return (
+        <div className={styles.wrapper}>
+            <Stack className={styles.stack} horizontal tokens={{ childrenGap: 20 }}>
+                <StackItem grow className={styles.leftStackItem}>
+                    <h4>Existing values</h4>
+                    <DetailsList
+                        setKey="items"
+                        cellStyleProps={{
+                            cellLeftPadding: 0,
+                            cellRightPadding: 5,
+                            cellExtraRightPadding: 0,
+                        }}
+                        styles={{
+                            headerWrapper: styles.detailsHeader,
+                        }}
+                        items={items}
+                        selectionMode={SelectionMode.none}
+                        compact
+                        columns={[
+                            {
+                                key: "value",
+                                name: "VALUES",
+                                minWidth: 100,
+                                fieldName: "value",
+                            },
+                            {
+                                key: "fileCount",
+                                name: "# OF FILES",
+                                minWidth: 100,
+                                fieldName: "fileCount",
+                                styles: {
+                                    root: styles.columnRightAlign,
+                                },
+                            },
+                        ]}
+                        onRenderRow={(props, defaultRender) => renderRow(props, defaultRender)}
+                        onRenderItemColumn={renderItemColumn}
+                    />
+                </StackItem>
+                <StackItem grow align="center">
+                    <Icon iconName="Forward" />
+                </StackItem>
+                <StackItem grow className={styles.rightStackItem}>
+                    {/* TODO: Display different entry types depending on datatype of annotation */}
+                    <TextField
+                        label="Replace with"
+                        className={rootStyles.textField}
+                        onBlur={(e) =>
+                            e.currentTarget.value && props.onChange(e.currentTarget.value)
+                        }
+                        placeholder="Value(s)"
+                        defaultValue={props.newValues}
+                    />
+                </StackItem>
+            </Stack>
+        </div>
+    );
+}

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -59,7 +59,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
         <div className={styles.wrapper}>
             <Stack className={styles.stack} horizontal tokens={{ childrenGap: 20 }}>
                 <StackItem grow className={styles.stackItemLeft}>
-                    <h4>Existing values</h4>
+                    <h4 className={styles.tableTitle}>Existing values</h4>
                     <DetailsList
                         setKey="items"
                         cellStyleProps={{

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -1,0 +1,168 @@
+import { IComboBoxOption, IconButton, Stack, StackItem, TextField } from "@fluentui/react";
+import classNames from "classnames";
+import * as React from "react";
+
+import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
+import { PrimaryButton, SecondaryButton } from "../Buttons";
+import ComboBox from "../ComboBox";
+import Tooltip from "../Tooltip";
+import { AnnotationType } from "../../entity/AnnotationFormatter";
+
+import styles from "./EditMetadata.module.css";
+
+enum EditStep {
+    PASSWORD = 0, // Placeholder
+    CREATE_FIELD = 1,
+    EDIT_FILES = 2,
+}
+
+interface NewAnnotationProps {
+    onDismiss: () => void;
+    selectedFileCount: number;
+}
+
+/**
+ * Component for submitting a new annotation
+ * and then entering values for the selected files
+ */
+export default function NewAnnotationPathway(props: NewAnnotationProps) {
+    const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
+    const [_newValues, setNewValues] = React.useState<string | undefined>();
+    const [newFieldName, setNewFieldName] = React.useState<string>("");
+    const [newFieldDataType, setNewFieldDataType] = React.useState<string | undefined>();
+    const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
+    const [dropdownOptions, setDropdownOptions] = React.useState<IComboBoxOption[]>([]);
+
+    const addDropdownChip = (evt: React.FormEvent) => {
+        evt.preventDefault();
+        if (
+            newDropdownOption &&
+            !dropdownOptions.filter((opt) => opt.key === newDropdownOption).length
+        ) {
+            const newOptionAsIComboBox: IComboBoxOption = {
+                key: newDropdownOption,
+                text: newDropdownOption,
+            };
+            setDropdownOptions([...dropdownOptions, newOptionAsIComboBox]);
+            setNewDropdownOption("");
+        }
+    };
+
+    const removeDropdownChip = (optionToRemove: IComboBoxOption) => {
+        setDropdownOptions(dropdownOptions.filter((opt) => opt !== optionToRemove));
+    };
+
+    function onSubmit() {
+        // TO DO: endpoint logic is in progress on a different branch
+        props.onDismiss();
+    }
+
+    return (
+        <>
+            {/* TO DO: Prevent user from entering a name that collides with existing annotation */}
+            <TextField
+                required
+                label="New metadata field name"
+                className={styles.textField}
+                onChange={(_, newValue) => setNewFieldName(newValue || "")}
+                placeholder="Add a new field name..."
+                value={newFieldName}
+            />
+            {step === EditStep.CREATE_FIELD && (
+                <>
+                    <ComboBox
+                        className={styles.comboBox}
+                        defaultValue={newFieldDataType || undefined}
+                        label="Data type"
+                        placeholder="Select a data type"
+                        options={Object.values(AnnotationType).map((type, index) => {
+                            return {
+                                key: `datatype-${index}`,
+                                text: type,
+                            };
+                        })}
+                        useComboBoxAsMenuWidth
+                        onChange={(option) => setNewFieldDataType(option?.text || "")}
+                    />
+                    {newFieldDataType === AnnotationType.DROPDOWN && (
+                        <>
+                            <form onSubmit={addDropdownChip}>
+                                <TextField
+                                    label="Add dropdown options"
+                                    className={styles.textField}
+                                    onChange={(_, newValue) => setNewDropdownOption(newValue || "")}
+                                    placeholder="Type an option name..."
+                                    iconProps={{
+                                        className: classNames(styles.submitIcon),
+                                        iconName: "ReturnKey",
+                                        onClick: newDropdownOption ? addDropdownChip : undefined,
+                                    }}
+                                    value={newDropdownOption}
+                                />
+                            </form>
+                            <div>
+                                {dropdownOptions.map((option) => (
+                                    <div
+                                        key={option.key}
+                                        className={styles.selectedOptionContainer}
+                                    >
+                                        <Tooltip content={option.text}>
+                                            <p className={styles.selectedOption}>{option.text}</p>
+                                        </Tooltip>
+                                        <IconButton
+                                            className={styles.selectedOptionButton}
+                                            iconProps={{ iconName: "Cancel" }}
+                                            onClick={() => removeDropdownChip(option)}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        </>
+                    )}
+                </>
+            )}
+            {step === EditStep.EDIT_FILES && (
+                <MetadataDetails
+                    onChange={(value) => setNewValues(value)}
+                    items={[
+                        {
+                            value: undefined,
+                            fileCount: props.selectedFileCount,
+                        } as ValueCountItem,
+                    ]}
+                />
+            )}
+            <div className={styles.footer}>
+                <Stack horizontal>
+                    <StackItem>
+                        {step === EditStep.EDIT_FILES && (
+                            <SecondaryButton
+                                title="Go back"
+                                text="BACK"
+                                onClick={() => setStep(EditStep.CREATE_FIELD)}
+                            />
+                        )}
+                    </StackItem>
+                    <StackItem grow align="end" className={styles.footerAlignRight}>
+                        <SecondaryButton title="Cancel" text="CANCEL" onClick={props.onDismiss} />
+                        {step === EditStep.CREATE_FIELD && (
+                            <PrimaryButton
+                                disabled={
+                                    !newFieldName ||
+                                    (newFieldDataType === AnnotationType.DROPDOWN &&
+                                        !dropdownOptions.length)
+                                }
+                                title="Next"
+                                text="NEXT"
+                                onClick={() => setStep(EditStep.EDIT_FILES)}
+                            />
+                        )}
+                        {step === EditStep.EDIT_FILES && (
+                            <PrimaryButton title="Submit" text="SUBMIT" onClick={onSubmit} />
+                        )}
+                    </StackItem>
+                </Stack>
+            </div>
+        </>
+    );
+}

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -27,7 +27,7 @@ interface NewAnnotationProps {
  */
 export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
-    const [_newValues, setNewValues] = React.useState<string | undefined>();
+    const [newValues, setNewValues] = React.useState<string | undefined>();
     const [newFieldName, setNewFieldName] = React.useState<string>("");
     const [newFieldDataType, setNewFieldDataType] = React.useState<string | undefined>();
     const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
@@ -147,18 +147,30 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                         <SecondaryButton title="Cancel" text="CANCEL" onClick={props.onDismiss} />
                         {step === EditStep.CREATE_FIELD && (
                             <PrimaryButton
+                                className={styles.primaryButton}
                                 disabled={
                                     !newFieldName ||
                                     (newFieldDataType === AnnotationType.DROPDOWN &&
                                         !dropdownOptions.length)
                                 }
-                                title="Next"
                                 text="NEXT"
+                                title="Next"
                                 onClick={() => setStep(EditStep.EDIT_FILES)}
                             />
                         )}
                         {step === EditStep.EDIT_FILES && (
-                            <PrimaryButton title="Submit" text="SUBMIT" onClick={onSubmit} />
+                            <PrimaryButton
+                                className={styles.primaryButton}
+                                disabled={
+                                    !newFieldName ||
+                                    (newFieldDataType === AnnotationType.DROPDOWN &&
+                                        !dropdownOptions.length) ||
+                                    !newValues
+                                }
+                                text="SUBMIT"
+                                title="Submit"
+                                onClick={onSubmit}
+                            />
                         )}
                     </StackItem>
                 </Stack>

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -72,12 +72,12 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                 <>
                     <ComboBox
                         className={styles.comboBox}
-                        defaultValue={newFieldDataType || undefined}
+                        selectedKey={`datatype-${newFieldDataType}` || undefined}
                         label="Data type"
                         placeholder="Select a data type"
-                        options={Object.values(AnnotationType).map((type, index) => {
+                        options={Object.values(AnnotationType).map((type) => {
                             return {
-                                key: `datatype-${index}`,
+                                key: `datatype-${type}`,
                                 text: type,
                             };
                         })}

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -78,10 +78,12 @@ export default function EditMetadataForm() {
                     {
                         key: EditMetadataPathway.EXISTING,
                         text: "Existing field",
+                        title: "Choose a field that already exists in the data source(s).",
                     },
                     {
                         key: EditMetadataPathway.NEW,
                         text: "New field",
+                        title: "Create a new field that doesn't yet exist in the data source(s).",
                     },
                 ]}
             />

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -66,6 +66,7 @@ export default function EditMetadataForm() {
     return (
         <>
             <ChoiceGroup
+                className={styles.choiceGroup}
                 defaultSelectedKey={editPathway}
                 onChange={(_ev, option) =>
                     setEditPathway(

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -20,10 +20,11 @@ enum EditMetadataPathway {
  */
 export default function EditMetadataForm() {
     const dispatch = useDispatch();
-    const fileSelection = useSelector(selection.selectors.getFileSelection);
     const onDismiss = () => {
         dispatch(interaction.actions.hideVisibleModal());
     };
+    const fileSelection = useSelector(selection.selectors.getFileSelection);
+    const fileCount = fileSelection.count();
     // Don't allow users to edit top level annotations (e.g., File Name)
     const annotationOptions = useSelector(metadata.selectors.getSortedAnnotations)
         .filter((annotation) => !TOP_LEVEL_FILE_ANNOTATION_NAMES.includes(annotation.name))
@@ -90,13 +91,10 @@ export default function EditMetadataForm() {
                         onDismiss={onDismiss}
                         annotationValueMap={annotationValueMap}
                         annotationOptions={annotationOptions}
-                        selectedFileCount={fileSelection.count()}
+                        selectedFileCount={fileCount}
                     />
                 ) : (
-                    <NewAnnotationPathway
-                        onDismiss={onDismiss}
-                        selectedFileCount={fileSelection.count()}
-                    />
+                    <NewAnnotationPathway onDismiss={onDismiss} selectedFileCount={fileCount} />
                 )}
             </div>
         </>

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import ExistingAnnotationPathway from "./ExistingAnnotationPathway";
+import NewAnnotationPathway from "./NewAnnotationPathway";
+import ChoiceGroup from "../ChoiceGroup";
+import { TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../constants";
+import { interaction, metadata, selection } from "../../state";
+
+import styles from "./EditMetadata.module.css";
+
+enum EditMetadataPathway {
+    EXISTING = "existing",
+    NEW = "new",
+}
+
+/**
+ * Form that acts as a wrapper for both metadata editing pathways (new vs existing annotations).
+ * Performs all necessary state selections on render and passes data as props to child components
+ */
+export default function EditMetadataForm() {
+    const dispatch = useDispatch();
+    const fileSelection = useSelector(selection.selectors.getFileSelection);
+    const onDismiss = () => {
+        dispatch(interaction.actions.hideVisibleModal());
+    };
+    // Don't allow users to edit top level annotations (e.g., File Name)
+    const annotationOptions = useSelector(metadata.selectors.getSortedAnnotations)
+        .filter((annotation) => !TOP_LEVEL_FILE_ANNOTATION_NAMES.includes(annotation.name))
+        .map((annotation) => {
+            return {
+                key: annotation.name,
+                text: annotation.displayName,
+            };
+        });
+    const [editPathway, setEditPathway] = React.useState<EditMetadataPathway>(
+        EditMetadataPathway.EXISTING
+    );
+    const [annotationValueMap, setAnnotationValueMap] = React.useState<Map<string, any>>();
+
+    React.useEffect(() => {
+        fileSelection.fetchAllDetails().then((fileDetails) => {
+            const annotationMapping = new Map();
+            // Group details by annotation with a count for each value
+            fileDetails.forEach((file) => {
+                file.annotations.map((annotation) => {
+                    // For now, if a file has multiple values for an annotation it should be considered a distinct set
+                    const joinedValues = annotation.values.join(", ");
+                    if (!annotationMapping.has(annotation.name)) {
+                        annotationMapping.set(annotation.name, { [joinedValues]: 1 });
+                    } else {
+                        const existing = annotationMapping.get(annotation.name);
+                        annotationMapping.set(annotation.name, {
+                            ...existing,
+                            [joinedValues]: existing?.[joinedValues]
+                                ? existing[joinedValues] + 1
+                                : 1,
+                        });
+                    }
+                });
+            });
+            setAnnotationValueMap(annotationMapping);
+        });
+    }, [fileSelection]);
+
+    return (
+        <>
+            <ChoiceGroup
+                defaultSelectedKey={editPathway}
+                onChange={(_ev, option) =>
+                    setEditPathway(
+                        (option?.key as EditMetadataPathway) || EditMetadataPathway.EXISTING
+                    )
+                }
+                options={[
+                    {
+                        key: EditMetadataPathway.EXISTING,
+                        text: "Existing field",
+                    },
+                    {
+                        key: EditMetadataPathway.NEW,
+                        text: "New field",
+                    },
+                ]}
+            />
+            <div className={styles.contentWrapper}>
+                {editPathway === EditMetadataPathway.EXISTING ? (
+                    <ExistingAnnotationPathway
+                        onDismiss={onDismiss}
+                        annotationValueMap={annotationValueMap}
+                        annotationOptions={annotationOptions}
+                        selectedFileCount={fileSelection.count()}
+                    />
+                ) : (
+                    <NewAnnotationPathway
+                        onDismiss={onDismiss}
+                        selectedFileCount={fileSelection.count()}
+                    />
+                )}
+            </div>
+        </>
+    );
+}

--- a/packages/core/components/Modal/EditMetadata/index.tsx
+++ b/packages/core/components/Modal/EditMetadata/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 
 import { ModalProps } from "..";
 import BaseModal from "../BaseModal";
-// import EditMetadataForm from "../../EditMetadata";
+import EditMetadataForm from "../../EditMetadata";
 import { selection } from "../../../state";
 import FileSelection from "../../../entity/FileSelection";
 
@@ -20,11 +20,9 @@ export default function EditMetadata({ onDismiss }: ModalProps) {
         totalFilesSelected === 1 ? "" : "s"
     })`;
 
-    const body = <></>; //<EditMetadataForm />
-
     return (
         <BaseModal
-            body={body}
+            body={<EditMetadataForm />}
             onDismiss={onDismiss}
             title={`Edit Metadata ${filesSelectedCountString}`}
         />

--- a/packages/core/components/Modal/EditMetadata/index.tsx
+++ b/packages/core/components/Modal/EditMetadata/index.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { useSelector } from "react-redux";
+
+import { ModalProps } from "..";
+import BaseModal from "../BaseModal";
+// import EditMetadataForm from "../../EditMetadata";
+import { selection } from "../../../state";
+import FileSelection from "../../../entity/FileSelection";
+
+/**
+ * Dialog to display workflow for editing metadata for selected files
+ */
+export default function EditMetadata({ onDismiss }: ModalProps) {
+    const fileSelection = useSelector(
+        selection.selectors.getFileSelection,
+        FileSelection.selectionsAreEqual
+    );
+    const totalFilesSelected = fileSelection.count();
+    const filesSelectedCountString = `(${totalFilesSelected} file${
+        totalFilesSelected === 1 ? "" : "s"
+    })`;
+
+    const body = <></>; //<EditMetadataForm />
+
+    return (
+        <BaseModal
+            body={body}
+            onDismiss={onDismiss}
+            title={`Edit Metadata ${filesSelectedCountString}`}
+        />
+    );
+}

--- a/packages/core/components/Modal/index.tsx
+++ b/packages/core/components/Modal/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { interaction } from "../../state";
 import CodeSnippet from "./CodeSnippet";
 import DataSource from "./DataSource";
+import EditMetadata from "./EditMetadata";
 import MetadataManifest from "./MetadataManifest";
 import SmallScreenWarning from "./SmallScreenWarning";
 
@@ -14,8 +15,9 @@ export interface ModalProps {
 export enum ModalType {
     CodeSnippet = 1,
     DataSource = 2,
-    MetadataManifest = 3,
-    SmallScreenWarning = 4,
+    EditMetadata = 3,
+    MetadataManifest = 4,
+    SmallScreenWarning = 5,
 }
 
 /**
@@ -34,6 +36,8 @@ export default function Modal() {
             return <CodeSnippet onDismiss={onDismiss} />;
         case ModalType.DataSource:
             return <DataSource onDismiss={onDismiss} />;
+        case ModalType.EditMetadata:
+            return <EditMetadata onDismiss={onDismiss} />;
         case ModalType.MetadataManifest:
             return <MetadataManifest onDismiss={onDismiss} />;
         case ModalType.SmallScreenWarning:

--- a/packages/core/entity/AnnotationFormatter/index.ts
+++ b/packages/core/entity/AnnotationFormatter/index.ts
@@ -12,6 +12,7 @@ export enum AnnotationType {
     STRING = "Text",
     BOOLEAN = "YesNo",
     DURATION = "Duration",
+    DROPDOWN = "Dropdown",
 }
 
 export interface AnnotationFormatter {

--- a/packages/core/hooks/useFileAccessContextMenu.ts
+++ b/packages/core/hooks/useFileAccessContextMenu.ts
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import useOpenWithMenuItems from "./useOpenWithMenuItems";
+import { ModalType } from "../components/Modal";
 import FileDetail from "../entity/FileDetail";
 import FileFilter from "../entity/FileFilter";
 import { interaction, selection } from "../state";
@@ -135,6 +136,24 @@ export default (filters?: FileFilter[], onDismiss?: () => void) => {
                         ],
                     },
                 },
+                ...(isQueryingAicsFms
+                    ? [
+                          {
+                              key: "edit",
+                              text: "Edit metadata",
+                              title: "Edit metadata of selected files",
+                              disabled: !filters && fileSelection.count() === 0,
+                              iconProps: {
+                                  iconName: "Edit",
+                              },
+                              onClick() {
+                                  dispatch(
+                                      interaction.actions.setVisibleModal(ModalType.EditMetadata)
+                                  );
+                              },
+                          },
+                      ]
+                    : []),
                 {
                     key: "download",
                     text: "Download",


### PR DESCRIPTION
This PR creates the main part of the UI for editing file metadata from BFF based on [the Figma designs](https://www.figma.com/design/oNQvOAK11YINcbPvNmkgwO/Public-File-Explorer?node-id=875-4724&node-type=canvas&t=JUN2ieb9MDJMnUxO-0). Does not include any backend logic.

~[Temporarily deployed to staging](https://staging.biofile-finder.allencell.org/app)~

Part of #96 

## Reviewing
Lots of changes with a slightly complicated file structure, so here's suggested review order:
- Entrypoint: added edit to the dropdown menu in [packages/core/hooks/useFileAccessContextMenu.ts](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-71bcb3b6133f882ebdd1dd66c282d671a299b33032af1c33744369ec05c99339)
- This opens the modal, which is [packages/core/components/Modal/EditMetadata/index.tsx](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-a6ec79eb3ac34e5ecd40a3aead96f6e047d6d3143b78100b3d65728380350a9f)
- The modal renders the actual editing component ([packages/core/components/EditMetadata/index.tsx](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-264e2d9d82ffe4d96144ff07cb2dac39ff71aab629579b15dbf783ce1a68d9fc)), which is a wrapper for both the "new" and "existing" annotation pathways 
    - Pathway for editing files' values for an existing annotation: [packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-f4052c195644362a2061021276d6bb4298a6a4d91c4cedd54acd4b25a461a490)
    - Pathway for creating a new annotation on the files: [packages/core/components/EditMetadata/NewAnnotationPathway.tsx](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-a6c315bc57c9c1a4506e78753a90b1b1a4445bd9f28a80ccdca3e358b3f91b25)
- BOTH pathways then point at [packages/core/components/EditMetadata/MetadataDetails.tsx](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-b43d09942ca733e4d46c2cdaf4192858058d787863858b8195a302c7c055e9b8), which displays the current values for the files and provides an input field to enter the desired replacement values

There's also a brand new ['ComboBox' component](https://github.com/AllenInstitute/biofile-finder/pull/338/files#diff-ecbdd5e8e843d5406ce8ffcc340ebe5ac1035cf11ba43ed7aca8929eac8e1f01) (dropdown selector with search), which is a styled wrapper for the [FluentUI combo box](https://developer.microsoft.com/en-us/fluentui#/controls/web/combobox)

## To Dos (UI only)
- Unit tests
- #340 (date, number, yes/no, etc)
- #341
- #342 -- Ideally should open on click and react to users hitting enter, but has been behaving inconsistently
- #343 Add disabled annotations (e.g., from labkey) & prevent new annotations that collide with existing
- #344 Warn users on exit w/ unsaved changes

## Screenshots

### Existing annotation pathway: 
<img width="250" alt="Screenshot 2024-11-19 at 4 42 56 PM" src="https://github.com/user-attachments/assets/306bc6e5-21eb-49ca-adb2-a17345d31639">
<img width="250" alt="Screenshot 2024-11-19 at 4 43 10 PM" src="https://github.com/user-attachments/assets/fddb01be-6562-4e22-a1da-e8d3ee29825e">
<img width="500" alt="Screenshot 2024-11-19 at 4 43 33 PM" src="https://github.com/user-attachments/assets/db2c0c94-a648-40ba-b8fb-3d0b7ac932ad">

### New annotation pathway:
<img width="250" alt="Screenshot 2024-11-19 at 4 43 51 PM" src="https://github.com/user-attachments/assets/e9e9b46f-1e92-40b0-84d9-f773f6b1752c">
<img width="250" alt="Screenshot 2024-11-19 at 4 44 09 PM" src="https://github.com/user-attachments/assets/31e88dc7-c282-4430-bab0-fc23f5b2f0b4">
<img width="500" alt="Screenshot 2024-11-19 at 4 44 16 PM" src="https://github.com/user-attachments/assets/37dcfc56-7ceb-4f6e-afda-d3e6ad2defc6">

