### PR TITLE
Add custom input fields for editing metadata

### DIFF
--- a/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
+++ b/packages/core/components/ChoiceGroup/ChoiceGroup.module.css
@@ -8,7 +8,7 @@
 }
 
 .choice-group label > span {
-  font-size: var(--l-paragraph-size);
+  font-size: var(--s-paragraph-size);
   margin-right: 5px;
   margin-top: 1px;
   padding-left: 24px !important;

--- a/packages/core/components/ComboBox/index.tsx
+++ b/packages/core/components/ComboBox/index.tsx
@@ -24,7 +24,6 @@ interface Props {
     multiSelect?: boolean;
     options: IComboBoxOption[];
     placeholder: string;
-    useComboBoxAsMenuWidth?: boolean;
     onChange?: (option: IComboBoxOption | undefined, value?: string | undefined) => void;
 }
 
@@ -88,7 +87,7 @@ export default function BaseComboBox(props: Props) {
                 callout: styles.comboBoxCallout,
                 optionsContainer: styles.optionsContainer,
             }}
-            useComboBoxAsMenuWidth={props?.useComboBoxAsMenuWidth}
+            useComboBoxAsMenuWidth
         />
     );
 }

--- a/packages/core/components/DurationForm/DurationForm.module.css
+++ b/packages/core/components/DurationForm/DurationForm.module.css
@@ -1,0 +1,15 @@
+.input-wrapper {
+  display: flex;
+}
+
+.input-field {
+  margin-right: 3px;
+  max-height: fit-content;
+  display: flex; 
+}
+
+.input-field > input {
+  padding: 6px;
+  font-size: var(--s-paragraph-size);
+  max-width: 70px; 
+}

--- a/packages/core/components/DurationForm/DurationForm.module.css
+++ b/packages/core/components/DurationForm/DurationForm.module.css
@@ -5,7 +5,6 @@
 .input-field {
   margin-right: 3px;
   max-height: fit-content;
-  display: flex; 
 }
 
 .input-field > input {

--- a/packages/core/components/DurationForm/index.tsx
+++ b/packages/core/components/DurationForm/index.tsx
@@ -17,10 +17,10 @@ interface DurationFormProps {
  */
 export default function DurationForm(props: DurationFormProps) {
     const { onChange } = props;
-    const [days, setDurationDays] = React.useState<string>("");
-    const [hours, setDurationHours] = React.useState<string>("");
-    const [minutes, setDurationMinutes] = React.useState<string>("");
-    const [seconds, setDurationSeconds] = React.useState<string>("");
+    const [days, setDurationDays] = React.useState<string>("0");
+    const [hours, setDurationHours] = React.useState<string>("0");
+    const [minutes, setDurationMinutes] = React.useState<string>("0");
+    const [seconds, setDurationSeconds] = React.useState<string>("0");
     const durationFormatter = annotationFormatterFactory(AnnotationType.DURATION);
 
     React.useEffect(() => {
@@ -39,32 +39,32 @@ export default function DurationForm(props: DurationFormProps) {
                     aria-label="Days"
                     className={styles.inputField}
                     id="durationDays"
+                    label="Days"
                     onChange={(event) => setDurationDays(event?.target?.value || "")}
-                    placeholder="Days..."
                     defaultValue={days}
                 />
                 <NumberField
                     aria-label="Hours"
                     className={styles.inputField}
                     id="durationHours"
+                    label="Hrs"
                     onChange={(event) => setDurationHours(event?.target?.value || "")}
-                    placeholder="Hrs..."
                     defaultValue={hours}
                 />
                 <NumberField
                     aria-label="Minutes"
                     className={styles.inputField}
                     id="durationMinutes"
+                    label="Mins"
                     onChange={(event) => setDurationMinutes(event?.target?.value || "")}
-                    placeholder="Mins..."
                     defaultValue={minutes}
                 />
                 <NumberField
                     aria-label="Seconds"
                     className={styles.inputField}
                     id="durationSeconds"
+                    label="Secs"
                     onChange={(event) => setDurationSeconds(event?.target?.value || "")}
-                    placeholder="Secs..."
                     defaultValue={seconds}
                 />
             </div>

--- a/packages/core/components/DurationForm/index.tsx
+++ b/packages/core/components/DurationForm/index.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+import NumberField from "../NumberRangePicker/NumberField";
+import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
+
+import styles from "./DurationForm.module.css";
+
+interface DurationFormProps {
+    className?: string;
+    defaultValue?: number;
+    onChange: (totalDuration: number) => void;
+    title?: string;
+}
+
+/**
+ * This component renders a simple form for entering durations
+ */
+export default function DurationForm(props: DurationFormProps) {
+    const { onChange } = props;
+    const [days, setDurationDays] = React.useState<string>("");
+    const [hours, setDurationHours] = React.useState<string>("");
+    const [minutes, setDurationMinutes] = React.useState<string>("");
+    const [seconds, setDurationSeconds] = React.useState<string>("");
+    const durationFormatter = annotationFormatterFactory(AnnotationType.DURATION);
+
+    React.useEffect(() => {
+        const durationString = `${Number(days) || 0}D ${Number(hours) || 0}H ${
+            Number(minutes) || 0
+        }M ${Number(seconds) || 0}S`;
+        const totalDurationInMs = Number(durationFormatter.valueOf(durationString));
+        onChange(totalDurationInMs);
+    }, [days, hours, minutes, seconds, durationFormatter, onChange]);
+
+    return (
+        <div>
+            <h3 className={styles.title}>{props?.title}</h3>
+            <div className={styles.inputWrapper}>
+                <NumberField
+                    aria-label="Days"
+                    className={styles.inputField}
+                    id="durationDays"
+                    onChange={(event) => setDurationDays(event?.target?.value || "")}
+                    placeholder="Days..."
+                    defaultValue={days}
+                />
+                <NumberField
+                    aria-label="Hours"
+                    className={styles.inputField}
+                    id="durationHours"
+                    onChange={(event) => setDurationHours(event?.target?.value || "")}
+                    placeholder="Hrs..."
+                    defaultValue={hours}
+                />
+                <NumberField
+                    aria-label="Minutes"
+                    className={styles.inputField}
+                    id="durationMinutes"
+                    onChange={(event) => setDurationMinutes(event?.target?.value || "")}
+                    placeholder="Mins..."
+                    defaultValue={minutes}
+                />
+                <NumberField
+                    aria-label="Seconds"
+                    className={styles.inputField}
+                    id="durationSeconds"
+                    onChange={(event) => setDurationSeconds(event?.target?.value || "")}
+                    placeholder="Secs..."
+                    defaultValue={seconds}
+                />
+            </div>
+        </div>
+    );
+}

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -81,7 +81,7 @@
 
 .text-field {
   padding-bottom: var(--margin);
-  max-width: 300px;;
+  width: 300px;;
 }
 
 .text-field > div > label, .text-field > div > label::after {

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -71,7 +71,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
             <ComboBox
                 className={styles.comboBox}
                 label="Select a metadata field"
-                placeholder="Select a field"
+                placeholder="Select a field..."
                 options={props.annotationOptions}
                 onChange={onSelectMetadataField}
             />

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -5,13 +5,14 @@ import * as React from "react";
 import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
 import { PrimaryButton, SecondaryButton } from "../Buttons";
 import ComboBox from "../ComboBox";
+import { AnnotationType } from "../../entity/AnnotationFormatter";
 
 import styles from "./EditMetadata.module.css";
 
 interface ExistingAnnotationProps {
     onDismiss: () => void;
     annotationValueMap: Map<string, any> | undefined;
-    annotationOptions: { key: string; text: string }[];
+    annotationOptions: { key: string; text: string; data: string }[];
     selectedFileCount: number;
 }
 
@@ -22,6 +23,7 @@ interface ExistingAnnotationProps {
 export default function ExistingAnnotationPathway(props: ExistingAnnotationProps) {
     const [newValues, setNewValues] = React.useState<string>();
     const [valueCount, setValueCount] = React.useState<ValueCountItem[]>();
+    const [annotationType, setAnnotationType] = React.useState<AnnotationType | undefined>();
 
     const onSelectMetadataField = (
         option: IComboBoxOption | undefined,
@@ -55,6 +57,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
                 ...valueMap,
             ];
         }
+        setAnnotationType(option?.data);
         setValueCount(valueMap);
     };
 
@@ -77,6 +80,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
                 <MetadataDetails
                     onChange={(value) => setNewValues(value)}
                     items={valueCount || []}
+                    fieldType={annotationType}
                 />
             )}
             <div className={classNames(styles.footer, styles.footerAlignRight)}>

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -73,7 +73,6 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
                 label="Select a metadata field"
                 placeholder="Select a field"
                 options={props.annotationOptions}
-                useComboBoxAsMenuWidth
                 onChange={onSelectMetadataField}
             />
             {valueCount && (

--- a/packages/core/components/EditMetadata/MetadataDetails.module.css
+++ b/packages/core/components/EditMetadata/MetadataDetails.module.css
@@ -62,3 +62,42 @@
 .stack-item-right {
   width: 275px;
 }
+
+.read-only-placeholder {
+  margin-right: 20px;
+  font-style: italic;
+  color: var(--primary-text-color);
+}
+
+.input-field input {
+  background-color: var(--secondary-background-color);
+  border-radius: var(--small-border-radius);
+  border: 1px solid var(--border-color);
+  color: var(--secondary-text-color);
+  outline: none;
+  padding: 6px;
+  font-size: var(--s-paragraph-size);
+  width: 100%;
+  min-width: fit-content;
+}
+
+.input-field:active > input, .input-field > input:active, 
+.input-field:focus > input, .input-field > input:focus,
+.input-field:focus-within > input, .input-field > input:focus-within  {
+  border: 1px solid var(--aqua);
+}
+
+.date-range-text-field div {
+  background-color: var(--secondary-background-color);
+  border: none;
+  border-radius: var(--small-border-radius);
+  color: var(--primary-text-color);
+}
+
+.date-range-text-field div::after {    
+  border: 1px solid var(--aqua)
+}
+
+.date-range-text-field > div {
+  border: 1px solid var(--border-color)
+}

--- a/packages/core/components/EditMetadata/MetadataDetails.module.css
+++ b/packages/core/components/EditMetadata/MetadataDetails.module.css
@@ -43,7 +43,12 @@
 }
 
 .table-title {
-  padding-bottom: 5px
+  padding-bottom: 5px;
+}
+
+.values-title {
+  padding-bottom: 5px;
+  padding-left: 35px;
 }
 
 .stack {
@@ -87,6 +92,16 @@
   border: 1px solid var(--aqua);
 }
 
+.input-wrapper {
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.date-range-root {
+  width: 300px;
+}
+
 .date-range-text-field div {
   background-color: var(--secondary-background-color);
   border: none;
@@ -100,4 +115,12 @@
 
 .date-range-text-field > div {
   border: 1px solid var(--border-color)
+}
+
+.no-padding {
+  padding-bottom: 0 !important;
+}
+
+.forward-icon {
+ padding-right: 20px;
 }

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -11,6 +11,7 @@ import {
     StackItem,
     TextField,
 } from "@fluentui/react";
+import classNames from "classnames";
 import * as React from "react";
 
 import ChoiceGroup from "../ChoiceGroup";
@@ -82,6 +83,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                             textField: styles.dateRangeTextField,
                         }}
                         placeholder={"Select a date"}
+                        onSelectDate={(date) => props.onChange(date?.toISOString())}
                     />
                 );
             case AnnotationType.NUMBER:
@@ -90,9 +92,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                         aria-label="Input a numerical value"
                         id="numInput"
                         placeholder="Enter value..."
-                        onChange={() => {
-                            console.info("placeholder for linting");
-                        }}
+                        onChange={(ev) => props.onChange(ev?.target?.value)}
                     />
                 );
             case AnnotationType.BOOLEAN:
@@ -100,9 +100,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     <ChoiceGroup
                         className={rootStyles.choiceGroup}
                         defaultSelectedKey={"true"}
-                        onChange={() => {
-                            console.info("placeholder");
-                        }}
+                        onChange={(_, opt?) => props.onChange(opt?.key)}
                         options={[
                             {
                                 key: "true",
@@ -117,14 +115,13 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                 );
             case AnnotationType.DURATION:
                 return (
-                    <DurationForm
-                        onChange={(totalDuration: number) => console.info(totalDuration)}
-                    />
+                    <DurationForm onChange={(duration) => props.onChange(duration.toString())} />
                 );
             case AnnotationType.DROPDOWN:
                 if (props?.dropdownOptions) {
                     return (
                         <ComboBox
+                            className={rootStyles.comboBox}
                             options={props?.dropdownOptions || []}
                             label=""
                             placeholder="values"
@@ -135,12 +132,10 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
             default:
                 return (
                     <TextField
-                        className={rootStyles.textField}
-                        onBlur={(e) =>
-                            e.currentTarget.value && props.onChange(e.currentTarget.value)
-                        }
+                        className={classNames(rootStyles.textField, styles.noPadding)}
+                        onChange={(e) => props.onChange(e?.currentTarget?.value)}
                         placeholder="Value(s)"
-                        defaultValue={props.newValues}
+                        defaultValue={props.newValues?.toString()}
                     />
                 );
         }
@@ -185,12 +180,14 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                         onRenderItemColumn={renderItemColumn}
                     />
                 </StackItem>
-                <StackItem grow align="center" className={styles.stackItemCenter}>
-                    <Icon iconName="Forward" />
-                </StackItem>
                 <StackItem grow className={styles.stackItemRight}>
-                    <h4 className={styles.tableTitle}>Replace with</h4>
-                    {inputField()}
+                    <h4 className={styles.valuesTitle}>Replace with</h4>
+                    {
+                        <div className={styles.inputWrapper}>
+                            <Icon iconName="Forward" className={styles.forwardIcon} />
+                            {inputField()}
+                        </div>
+                    }
                 </StackItem>
             </Stack>
         </div>

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -82,7 +82,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                             readOnlyPlaceholder: styles.readOnlyPlaceholder,
                             textField: styles.dateRangeTextField,
                         }}
-                        placeholder={"Select a date"}
+                        placeholder={"Select a date..."}
                         onSelectDate={(date) => props.onChange(date?.toISOString())}
                     />
                 );
@@ -91,7 +91,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     <NumberField
                         aria-label="Input a numerical value"
                         id="numInput"
-                        placeholder="Enter value..."
+                        placeholder="Numerical value..."
                         onChange={(ev) => props.onChange(ev?.target?.value)}
                     />
                 );
@@ -124,7 +124,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                             className={rootStyles.comboBox}
                             options={props?.dropdownOptions || []}
                             label=""
-                            placeholder="values"
+                            placeholder="Select value(s)..."
                         />
                     );
                 }
@@ -134,7 +134,7 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     <TextField
                         className={classNames(rootStyles.textField, styles.noPadding)}
                         onChange={(e) => props.onChange(e?.currentTarget?.value)}
-                        placeholder="Value(s)"
+                        placeholder="Value(s)..."
                         defaultValue={props.newValues?.toString()}
                     />
                 );

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -2,6 +2,7 @@ import {
     DatePicker,
     DetailsList,
     IColumn,
+    IComboBoxOption,
     Icon,
     IDetailsRowProps,
     IRenderFunction,
@@ -13,6 +14,7 @@ import {
 import * as React from "react";
 
 import ChoiceGroup from "../ChoiceGroup";
+import ComboBox from "../ComboBox";
 import DurationForm from "../DurationForm";
 import NumberField from "../NumberRangePicker/NumberField";
 import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
@@ -26,6 +28,7 @@ export interface ValueCountItem {
 }
 
 interface DetailsListProps {
+    dropdownOptions?: IComboBoxOption[];
     fieldType?: AnnotationType;
     items: ValueCountItem[];
     onChange: (value: string | undefined) => void;
@@ -119,6 +122,15 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     />
                 );
             case AnnotationType.DROPDOWN:
+                if (props?.dropdownOptions) {
+                    return (
+                        <ComboBox
+                            options={props?.dropdownOptions || []}
+                            label=""
+                            placeholder="values"
+                        />
+                    );
+                }
             case AnnotationType.STRING:
             default:
                 return (

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -1,4 +1,5 @@
 import {
+    DatePicker,
     DetailsList,
     IColumn,
     Icon,
@@ -11,6 +12,9 @@ import {
 } from "@fluentui/react";
 import * as React from "react";
 
+import ChoiceGroup from "../ChoiceGroup";
+import { AnnotationType } from "../../entity/AnnotationFormatter";
+
 import rootStyles from "./EditMetadata.module.css";
 import styles from "./MetadataDetails.module.css";
 
@@ -20,6 +24,7 @@ export interface ValueCountItem {
 }
 
 interface DetailsListProps {
+    fieldType?: AnnotationType;
     items: ValueCountItem[];
     onChange: (value: string | undefined) => void;
     newValues?: string;
@@ -54,6 +59,68 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
         }
         return fieldContent;
     }
+
+    const inputField = () => {
+        switch (props.fieldType) {
+            case AnnotationType.DATE:
+            case AnnotationType.DATETIME:
+                return (
+                    <DatePicker
+                        styles={{
+                            root: styles.dateRangeRoot,
+                            readOnlyPlaceholder: styles.readOnlyPlaceholder,
+                            textField: styles.dateRangeTextField,
+                        }}
+                        placeholder={"Select a date"}
+                    />
+                );
+            case AnnotationType.NUMBER:
+                return (
+                    <div className={styles.inputField}>
+                        <input
+                            aria-label="Input a numerical value"
+                            id="numInput"
+                            type="number"
+                            step="any"
+                        />
+                    </div>
+                );
+            case AnnotationType.BOOLEAN:
+                return (
+                    <ChoiceGroup
+                        className={rootStyles.choiceGroup}
+                        defaultSelectedKey={"true"}
+                        onChange={() => {
+                            console.info("placeholder");
+                        }}
+                        options={[
+                            {
+                                key: "true",
+                                text: "True",
+                            },
+                            {
+                                key: "false",
+                                text: "False",
+                            },
+                        ]}
+                    />
+                );
+            case AnnotationType.DURATION:
+            case AnnotationType.DROPDOWN:
+            case AnnotationType.STRING:
+            default:
+                return (
+                    <TextField
+                        className={rootStyles.textField}
+                        onBlur={(e) =>
+                            e.currentTarget.value && props.onChange(e.currentTarget.value)
+                        }
+                        placeholder="Value(s)"
+                        defaultValue={props.newValues}
+                    />
+                );
+        }
+    };
 
     return (
         <div className={styles.wrapper}>
@@ -98,16 +165,8 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     <Icon iconName="Forward" />
                 </StackItem>
                 <StackItem grow className={styles.stackItemRight}>
-                    {/* TODO: Display different entry types depending on datatype of annotation */}
-                    <TextField
-                        label="Replace with"
-                        className={rootStyles.textField}
-                        onBlur={(e) =>
-                            e.currentTarget.value && props.onChange(e.currentTarget.value)
-                        }
-                        placeholder="Value(s)"
-                        defaultValue={props.newValues}
-                    />
+                    <h4 className={styles.tableTitle}>Replace with</h4>
+                    {inputField()}
                 </StackItem>
             </Stack>
         </div>

--- a/packages/core/components/EditMetadata/MetadataDetails.tsx
+++ b/packages/core/components/EditMetadata/MetadataDetails.tsx
@@ -13,7 +13,9 @@ import {
 import * as React from "react";
 
 import ChoiceGroup from "../ChoiceGroup";
-import { AnnotationType } from "../../entity/AnnotationFormatter";
+import DurationForm from "../DurationForm";
+import NumberField from "../NumberRangePicker/NumberField";
+import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
 
 import rootStyles from "./EditMetadata.module.css";
 import styles from "./MetadataDetails.module.css";
@@ -46,6 +48,9 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
         }
         return <></>;
     };
+    const annotationFormatter = annotationFormatterFactory(
+        props.fieldType || AnnotationType.STRING
+    );
 
     function renderItemColumn(
         item: ValueCountItem,
@@ -53,8 +58,10 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
         column: IColumn | undefined
     ) {
         const fieldContent = item[column?.fieldName as keyof ValueCountItem] as string;
-        if (!fieldContent) return "[No value] (blank)";
-        if (column?.fieldName === "fileCount") {
+        if (column?.fieldName === "value") {
+            if (!fieldContent) return "[No value] (blank)";
+            else return annotationFormatter.displayValue(fieldContent);
+        } else if (column?.fieldName === "fileCount") {
             return <div className={styles.columnRightAlignCell}>{fieldContent}</div>;
         }
         return fieldContent;
@@ -76,14 +83,14 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                 );
             case AnnotationType.NUMBER:
                 return (
-                    <div className={styles.inputField}>
-                        <input
-                            aria-label="Input a numerical value"
-                            id="numInput"
-                            type="number"
-                            step="any"
-                        />
-                    </div>
+                    <NumberField
+                        aria-label="Input a numerical value"
+                        id="numInput"
+                        placeholder="Enter value..."
+                        onChange={() => {
+                            console.info("placeholder for linting");
+                        }}
+                    />
                 );
             case AnnotationType.BOOLEAN:
                 return (
@@ -106,6 +113,11 @@ export default function EditMetadataDetailsList(props: DetailsListProps) {
                     />
                 );
             case AnnotationType.DURATION:
+                return (
+                    <DurationForm
+                        onChange={(totalDuration: number) => console.info(totalDuration)}
+                    />
+                );
             case AnnotationType.DROPDOWN:
             case AnnotationType.STRING:
             default:

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -90,7 +90,6 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                 text,
                             };
                         })}
-                        useComboBoxAsMenuWidth
                         onChange={(option) =>
                             setNewFieldDataType((option?.key as AnnotationType) || "")
                         }
@@ -141,6 +140,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                             fileCount: props.selectedFileCount,
                         } as ValueCountItem,
                     ]}
+                    dropdownOptions={dropdownOptions}
                     onChange={(value) => setNewValues(value)}
                 />
             )}

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -30,7 +30,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
     const [newValues, setNewValues] = React.useState<string | undefined>();
     const [newFieldName, setNewFieldName] = React.useState<string>("");
-    const [newFieldDataType, setNewFieldDataType] = React.useState<string | undefined>();
+    const [newFieldDataType, setNewFieldDataType] = React.useState<AnnotationType | undefined>();
     const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
     const [dropdownOptions, setDropdownOptions] = React.useState<IComboBoxOption[]>([]);
 
@@ -89,7 +89,9 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                             };
                         })}
                         useComboBoxAsMenuWidth
-                        onChange={(option) => setNewFieldDataType(option?.text || "")}
+                        onChange={(option) =>
+                            setNewFieldDataType((option?.text as AnnotationType) || "")
+                        }
                     />
                     {newFieldDataType === AnnotationType.DROPDOWN && (
                         <>
@@ -130,13 +132,14 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
             )}
             {step === EditStep.EDIT_FILES && (
                 <MetadataDetails
-                    onChange={(value) => setNewValues(value)}
+                    fieldType={newFieldDataType}
                     items={[
                         {
                             value: undefined,
                             fileCount: props.selectedFileCount,
                         } as ValueCountItem,
                     ]}
+                    onChange={(value) => setNewValues(value)}
                 />
             )}
             <div className={styles.footer}>

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -81,7 +81,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                         className={styles.comboBox}
                         selectedKey={newFieldDataType || undefined}
                         label="Data type"
-                        placeholder="Select a data type"
+                        placeholder="Select a data type..."
                         options={Object.values(AnnotationType).map((type) => {
                             const text =
                                 type === AnnotationType.BOOLEAN ? "Boolean (true/false)" : type;

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -79,18 +79,20 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                 <>
                     <ComboBox
                         className={styles.comboBox}
-                        selectedKey={`datatype-${newFieldDataType}` || undefined}
+                        selectedKey={newFieldDataType || undefined}
                         label="Data type"
                         placeholder="Select a data type"
                         options={Object.values(AnnotationType).map((type) => {
+                            const text =
+                                type === AnnotationType.BOOLEAN ? "Boolean (true/false)" : type;
                             return {
-                                key: `datatype-${type}`,
-                                text: type,
+                                key: type,
+                                text,
                             };
                         })}
                         useComboBoxAsMenuWidth
                         onChange={(option) =>
-                            setNewFieldDataType((option?.text as AnnotationType) || "")
+                            setNewFieldDataType((option?.key as AnnotationType) || "")
                         }
                     />
                     {newFieldDataType === AnnotationType.DROPDOWN && (

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -34,6 +34,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
             return {
                 key: annotation.name,
                 text: annotation.displayName,
+                data: annotation.type,
             };
         });
     const [editPathway, setEditPathway] = React.useState<EditMetadataPathway>(

--- a/packages/core/components/NumberRangePicker/NumberField.module.css
+++ b/packages/core/components/NumberRangePicker/NumberField.module.css
@@ -1,0 +1,35 @@
+.input-field {
+    flex-grow: 1;
+}
+
+.input-field input {
+    background-color: var(--secondary-background-color);
+    border-radius: var(--small-border-radius);
+    border: 1px solid var(--border-color);
+    color: var(--secondary-text-color);
+    outline: none;
+    padding: 6px;
+    font-size: var(--s-paragraph-size);
+    width: 100%;
+    min-width: fit-content;
+}
+
+.input-field > input::placeholder {
+    color: var(--secondary-text-color) !important;
+    font-style: italic;
+}
+
+.input-field:active > input,
+.input-field > input:active,
+.input-field:focus > input,
+.input-field > input:focus,
+.input-field:focus-within > input,
+.input-field > input:focus-within {
+    border: 1px solid var(--aqua);
+}
+
+.input-field input::-webkit-outer-spin-button,
+.input-field input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0; /* <-- Margins are still present when hidden */
+}

--- a/packages/core/components/NumberRangePicker/NumberField.tsx
+++ b/packages/core/components/NumberRangePicker/NumberField.tsx
@@ -5,12 +5,12 @@ import styles from "./NumberField.module.css";
 
 interface NumberFieldProps {
     className?: string;
-    id: string;
-    onChange: (event?: React.ChangeEvent<HTMLInputElement>) => void;
     defaultValue?: string | number;
+    id: string;
     label?: string;
-    min?: number;
     max?: number;
+    min?: number;
+    onChange: (event?: React.ChangeEvent<HTMLInputElement>) => void;
     placeholder?: string;
 }
 

--- a/packages/core/components/NumberRangePicker/NumberField.tsx
+++ b/packages/core/components/NumberRangePicker/NumberField.tsx
@@ -1,0 +1,39 @@
+import classNames from "classnames";
+import * as React from "react";
+
+import styles from "./NumberField.module.css";
+
+interface NumberFieldProps {
+    className?: string;
+    id: string;
+    onChange: (event?: React.ChangeEvent<HTMLInputElement>) => void;
+    defaultValue?: string | number;
+    label?: string;
+    min?: number;
+    max?: number;
+    placeholder?: string;
+}
+
+/**
+ * A simple wrapper to provide a consistently styled numerical input field.
+ * FluentUI does not have an equivalent that fulfills our UX requirements,
+ * so we instead use the basic html input with styling applied
+ */
+export default function NumberField(props: NumberFieldProps) {
+    return (
+        <div className={classNames(props.className, styles.inputField)}>
+            {props.label && <label htmlFor={props.id}>{props.label}</label>}
+            <input
+                data-testid={props.id}
+                id={props.id}
+                type="number"
+                value={props.defaultValue}
+                step="any"
+                onChange={props.onChange}
+                placeholder={props?.placeholder}
+                min={props?.min}
+                max={props?.max}
+            />
+        </div>
+    );
+}

--- a/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
+++ b/packages/core/components/NumberRangePicker/NumberRangePicker.module.css
@@ -70,32 +70,6 @@
     display: flex;
 }
 
-.input-field {
-    flex-grow: 1;
-}
-
-.input-field {
-    flex-grow: 1;
-}
-
-.input-field input {
-    background-color: var(--secondary-background-color);
-    border-radius: var(--small-border-radius);
-    border: 1px solid var(--border-color);
-    color: var(--secondary-text-color);
-    outline: none;
-    padding: 6px;
-    font-size: var(--s-paragraph-size);
-    width: 100%;
-    min-width: fit-content;
-}
-
-.input-field:active > input, .input-field > input:active, 
-.input-field:focus > input, .input-field > input:focus,
-.input-field:focus-within > input, .input-field > input:focus-within  {
-    border: 1px solid var(--aqua);
-}
-
 .range-seperator {
     align-items: flex-end;
     display: flex;
@@ -115,10 +89,4 @@
 
 .container label,input{
     display: block;
-}
-
-.container input::-webkit-outer-spin-button,
-.container input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
 }

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -8,6 +8,7 @@ import { extractValuesFromRangeOperatorFilterString } from "../../entity/Annotat
 import { AnnotationValue } from "../../services/AnnotationService";
 
 import styles from "./NumberRangePicker.module.css";
+import NumberField from "./NumberField";
 
 export interface ListItem {
     displayValue: AnnotationValue;
@@ -106,37 +107,27 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
             <h3 className={styles.title}>{units ? `${props.title} (in ${units})` : props.title}</h3>
             <div className={styles.header}>
                 <div className={styles.inputs}>
-                    <div className={styles.inputField}>
-                        <label htmlFor="rangemin">Min (inclusive)</label>
-                        <input
-                            aria-label="Input a minimum value (inclusive)"
-                            data-testid="rangemin"
-                            id="rangemin"
-                            type="number"
-                            value={searchMinValue}
-                            step="any"
-                            onChange={onMinChange}
-                            min={Number(overallMin)}
-                            max={Number(overallMax)}
-                        />
-                    </div>
+                    <NumberField
+                        aria-label="Input a minimum value (inclusive)"
+                        defaultValue={searchMinValue}
+                        id="rangemin"
+                        label="Min (inclusive)"
+                        onChange={onMinChange}
+                        min={Number(overallMin)}
+                        max={Number(overallMax)}
+                    />
                     <div className={styles.rangeSeperator}>
                         <Icon iconName="Forward" />
                     </div>
-                    <div className={styles.inputField}>
-                        <label htmlFor="rangemax">Max (exclusive)</label>
-                        <input
-                            aria-label="Input a maximum value (exclusive)"
-                            data-testid="rangemax"
-                            id="rangemax"
-                            type="number"
-                            value={searchMaxValue}
-                            step="any"
-                            onChange={onMaxChange}
-                            min={Number(overallMin)}
-                            max={Number(overallMax)}
-                        />
-                    </div>
+                    <NumberField
+                        aria-label="Input a maximum value (exclusive)"
+                        defaultValue={searchMaxValue}
+                        id="rangemax"
+                        label="Max (exclusive)"
+                        onChange={onMaxChange}
+                        min={Number(overallMin)}
+                        max={Number(overallMax)}
+                    />
                     <div className={styles.resetButtonContainer}>
                         <TertiaryButton
                             className={styles.resetButton}

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -2,13 +2,13 @@ import { Icon, Spinner, SpinnerSize } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
+import NumberField from "./NumberField";
 import { PrimaryButton, TertiaryButton } from "../Buttons";
 import FileFilter from "../../entity/FileFilter";
 import { extractValuesFromRangeOperatorFilterString } from "../../entity/AnnotationFormatter/number-formatter";
 import { AnnotationValue } from "../../services/AnnotationService";
 
 import styles from "./NumberRangePicker.module.css";
-import NumberField from "./NumberField";
 
 export interface ListItem {
     displayValue: AnnotationValue;

--- a/packages/core/entity/AnnotationFormatter/duration-formatter.ts
+++ b/packages/core/entity/AnnotationFormatter/duration-formatter.ts
@@ -1,4 +1,5 @@
-const msInAMinute = 60 * 1000;
+const msInASecond = 1000;
+const msInAMinute = 60 * msInASecond;
 const msInAnHour = 60 * msInAMinute;
 const msInADay = 24 * msInAnHour;
 
@@ -19,12 +20,22 @@ export default {
         addUnit(msInAnHour, "H");
         addUnit(msInAMinute, "M");
         // Since seconds can have values like "3.5S", don't use floor when calculating
-        addUnit(1000, "S", false);
+        addUnit(msInASecond, "S", false);
 
         return display.trim();
     },
 
     valueOf(value: any) {
+        const RANGE_OPERATOR_REGEX = /([0-9]+)D ([0-9]+)H ([0-9]+)M ([0-9]*\.?[0-9]+)S/g;
+        const exec = RANGE_OPERATOR_REGEX.exec(value);
+        // Check if value is a pre-formatted duration string
+        if (exec) {
+            const daysInMs = Number(exec[1]) * msInADay;
+            const hrsInMs = Number(exec[2]) * msInAnHour;
+            const minsInMs = Number(exec[3]) * msInAMinute;
+            const secsInMs = Number(exec[4]) * msInASecond;
+            return daysInMs + hrsInMs + minsInMs + secsInMs;
+        }
         return Number(value);
     },
 };


### PR DESCRIPTION
This is a follow-up to #338 that adds custom fields for different data types based on [the Figma designs](https://www.figma.com/design/oNQvOAK11YINcbPvNmkgwO/Public-File-Explorer?node-id=3138-10352&node-type=frame&t=FxEJXP0Ufqmnsazm-0).

### Description
The input type switch is modeled off the way we did it in AnnotationFilterForm and re-uses some of the same components.
- Uses our existing choice group/text field/date field components for boolean/string/date+datetime respectively
- Adds a new "duration" form type
- Creates a new numerical input component to be more stylistically consistent (and replaced usage in our NumberRangePicker component)

### Screenshots
Duration 
<img width="300" alt="new duration form" src="https://github.com/user-attachments/assets/718fd23c-3e11-4a21-978c-0967ffc6b442">
Boolean
<img width="300" alt="choice group" src="https://github.com/user-attachments/assets/a6f23685-5f0b-4eac-988d-e8643891deab">
Date/Date Time
<img width="300" alt="date picking form" src="https://github.com/user-attachments/assets/33c06857-c939-461e-96f2-362c5b53628d">
Dropdown
<img width="300" alt="combo box" src="https://github.com/user-attachments/assets/8114ea87-387b-4b92-a808-92d9616759e0">
Number
<img width="300" alt="new numerical input" src="https://github.com/user-attachments/assets/e4b4698d-08c1-42c0-bc4c-61cadb40ecea">
Text/Default
<img width="300" alt="default for any type" src="https://github.com/user-attachments/assets/651205b2-beb3-4208-8c85-c5c8b713f450">

