### PR TITLE
gitignore mise configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 *.log
 *.tgz
 .env
+mise.toml


### PR DESCRIPTION
I'm using [mise](https://mise.jdx.dev/) to manage my dev environment. Judging from the `.gitignore` I'm the only one, so we can leave mise's config file out of the repo.

In case anyone is curious, here's my `mise.toml`:

```toml
[tools]
node = "16"
npm = "8"
```