### PR TITLE
368: Use Local File Path annotation

### DIFF
--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -80,7 +80,8 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
 
             if (annotation.name === AnnotationName.LOCAL_FILE_PATH) {
                 if (localPath === null) {
-                    // localPath hasn't loaded yet
+                    // localPath hasn't loaded yet, but it should eventually because there is an
+                    // annotation named AnnotationName.LOCAL_FILE_PATH
                     return accum;
                 } else {
                     // Use the user's /allen mount point, if known

--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -37,7 +37,14 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
                 return;
             }
 
-            const path = await executionEnvService.formatPathForHost(fileDetails.path);
+            let path;
+            if (fileDetails.localPath === null) {
+                // The Local File Path annotation is not defined because the file is not available
+                // on-premises
+                path = fileDetails.localPath;
+            } else {
+                path = await executionEnvService.formatPathForHost(fileDetails.localPath);
+            }
             if (!active) {
                 return;
             }
@@ -65,10 +72,20 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
                 return accum;
             }
 
-            const annotationValue = annotation.extractFromFile(fileDetails);
+            let annotationValue = annotation.extractFromFile(fileDetails);
             if (annotationValue === Annotation.MISSING_VALUE) {
                 // Nothing to show for this annotation -- skip
                 return accum;
+            }
+
+            if (annotation.name === AnnotationName.LOCAL_FILE_PATH) {
+                if (localPath === null) {
+                    // localPath hasn't loaded yet
+                    return accum;
+                } else {
+                    // Use the user's /allen mount point, if known
+                    annotationValue = localPath;
+                }
             }
 
             const ret = [
@@ -92,20 +109,6 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
                             className={styles.row}
                             name="File Path (Cloud)"
                             value={fileDetails.cloudPath}
-                        />
-                    );
-                }
-
-                // In certain circumstances (i.e., linux), the path at which a file is accessible is === the canonical path
-                if (localPath && localPath !== annotationValue && !localPath.startsWith("http")) {
-                    ret.splice(
-                        -1, // Insert before the "canonical" path so that it is the first path-like row to be seen
-                        0, // ...don't delete the "canonical" path
-                        <FileAnnotationRow
-                            key="file-path-local"
-                            className={styles.row}
-                            name="File Path (Local)"
-                            value={localPath}
                         />
                     );
                 }

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -37,15 +37,18 @@ describe("<FileAnnotationList />", () => {
 
             const filePathInsideAllenDrive = "path/to/MyFile.txt";
             const filePath = `production.allencell.org/${filePathInsideAllenDrive}`;
-            const localPath = `${hostMountPoint}/${filePathInsideAllenDrive}`;
             const fileDetails = new FileDetail({
                 file_path: filePath,
                 file_id: "abc123",
                 file_name: "MyFile.txt",
                 file_size: 7,
                 uploaded: "01/01/01",
-                annotations: [{ name: "Local File Path", values: [localPath] }],
+                annotations: [
+                    { name: "Local File Path", values: [`/allen/${filePathInsideAllenDrive}`] },
+                ],
             });
+
+            const localPath = `${hostMountPoint}/${filePathInsideAllenDrive}`;
 
             // Act
             const { findByText } = render(

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -9,6 +9,8 @@ import FileDetail from "../../../entity/FileDetail";
 import ExecutionEnvServiceNoop from "../../../services/ExecutionEnvService/ExecutionEnvServiceNoop";
 import { initialState } from "../../../state";
 import { TOP_LEVEL_FILE_ANNOTATIONS } from "../../../constants";
+import Annotation from "../../../entity/Annotation";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
 
 describe("<FileAnnotationList />", () => {
     describe("file path representation", () => {
@@ -25,7 +27,15 @@ describe("<FileAnnotationList />", () => {
             const { store } = configureMockStore({
                 state: mergeState(initialState, {
                     metadata: {
-                        annotations: TOP_LEVEL_FILE_ANNOTATIONS,
+                        annotations: [
+                            ...TOP_LEVEL_FILE_ANNOTATIONS,
+                            new Annotation({
+                                annotationName: "Local File Path",
+                                annotationDisplayName: "File Path (Local)",
+                                description: "Path to file in on-premises storage.",
+                                type: AnnotationType.STRING,
+                            }),
+                        ],
                     },
                     interaction: {
                         platformDependentServices: {

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -36,17 +36,16 @@ describe("<FileAnnotationList />", () => {
             });
 
             const filePathInsideAllenDrive = "path/to/MyFile.txt";
-            const filePath = `/allen/${filePathInsideAllenDrive}`;
+            const filePath = `production.allencell.org/${filePathInsideAllenDrive}`;
+            const localPath = `${hostMountPoint}/${filePathInsideAllenDrive}`;
             const fileDetails = new FileDetail({
                 file_path: filePath,
                 file_id: "abc123",
                 file_name: "MyFile.txt",
                 file_size: 7,
                 uploaded: "01/01/01",
-                annotations: [],
+                annotations: [{ name: "Local File Path", values: [localPath] }],
             });
-
-            const expectedLocalPath = `${hostMountPoint}/${filePathInsideAllenDrive}`;
 
             // Act
             const { findByText } = render(
@@ -60,7 +59,7 @@ describe("<FileAnnotationList />", () => {
                 "File Path (Canonical)",
                 filePath,
                 "File Path (Local)",
-                expectedLocalPath,
+                localPath,
             ]) {
                 expect(await findByText(cellText)).to.not.be.undefined;
             }

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -31,7 +31,7 @@ describe("<FileAnnotationList />", () => {
                             ...TOP_LEVEL_FILE_ANNOTATIONS,
                             new Annotation({
                                 annotationName: "Local File Path",
-                                annotationDisplayName: "File Path (Local)",
+                                annotationDisplayName: "File Path (Vast)",
                                 description: "Path to file in on-premises storage.",
                                 type: AnnotationType.STRING,
                             }),
@@ -71,7 +71,7 @@ describe("<FileAnnotationList />", () => {
             for (const cellText of [
                 "File Path (Canonical)",
                 filePath,
-                "File Path (Local)",
+                "File Path (Vast)",
                 localPath,
             ]) {
                 expect(await findByText(cellText)).to.not.be.undefined;
@@ -118,7 +118,7 @@ describe("<FileAnnotationList />", () => {
             );
 
             // Assert
-            expect(() => getByText("File Path (Local)")).to.throw();
+            expect(() => getByText("File Path (Vast)")).to.throw();
             ["File Path (Canonical)", filePath].forEach((cellText) => {
                 expect(getByText(cellText)).to.not.be.undefined;
             });

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -24,6 +24,9 @@ describe("<FileAnnotationList />", () => {
 
             const { store } = configureMockStore({
                 state: mergeState(initialState, {
+                    metadata: {
+                        annotations: TOP_LEVEL_FILE_ANNOTATIONS,
+                    },
                     interaction: {
                         platformDependentServices: {
                             executionEnvService: new FakeExecutionEnvService(),
@@ -33,10 +36,9 @@ describe("<FileAnnotationList />", () => {
             });
 
             const filePathInsideAllenDrive = "path/to/MyFile.txt";
-
-            const canonicalFilePath = `/allen/${filePathInsideAllenDrive}`;
+            const filePath = `/allen/${filePathInsideAllenDrive}`;
             const fileDetails = new FileDetail({
-                file_path: canonicalFilePath,
+                file_path: filePath,
                 file_id: "abc123",
                 file_name: "MyFile.txt",
                 file_size: 7,
@@ -54,14 +56,14 @@ describe("<FileAnnotationList />", () => {
             );
 
             // Assert
-            [
+            for (const cellText of [
                 "File Path (Canonical)",
-                canonicalFilePath,
+                filePath,
                 "File Path (Local)",
                 expectedLocalPath,
-            ].forEach(async (cellText) => {
+            ]) {
                 expect(await findByText(cellText)).to.not.be.undefined;
-            });
+            }
         });
 
         it("has only canonical file path when no allen mount point is found", () => {

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -31,7 +31,7 @@ describe("<FileAnnotationList />", () => {
                             ...TOP_LEVEL_FILE_ANNOTATIONS,
                             new Annotation({
                                 annotationName: "Local File Path",
-                                annotationDisplayName: "File Path (Vast)",
+                                annotationDisplayName: "File Path (Local VAST)",
                                 description: "Path to file in on-premises storage.",
                                 type: AnnotationType.STRING,
                             }),
@@ -71,7 +71,7 @@ describe("<FileAnnotationList />", () => {
             for (const cellText of [
                 "File Path (Canonical)",
                 filePath,
-                "File Path (Vast)",
+                "File Path (Local VAST)",
                 localPath,
             ]) {
                 expect(await findByText(cellText)).to.not.be.undefined;
@@ -118,7 +118,7 @@ describe("<FileAnnotationList />", () => {
             );
 
             // Assert
-            expect(() => getByText("File Path (Vast)")).to.throw();
+            expect(() => getByText("File Path (Local VAST)")).to.throw();
             ["File Path (Canonical)", filePath].forEach((cellText) => {
                 expect(getByText(cellText)).to.not.be.undefined;
             });

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -32,12 +32,6 @@ export const TOP_LEVEL_FILE_ANNOTATIONS = [
         type: AnnotationType.STRING,
     }),
     new Annotation({
-        annotationDisplayName: "File Path (Local)",
-        annotationName: AnnotationName.LOCAL_FILE_PATH,
-        description: "Path to the file on-premises.",
-        type: AnnotationType.STRING,
-    }),
-    new Annotation({
         annotationDisplayName: "Size",
         annotationName: AnnotationName.FILE_SIZE,
         description: "Size of file on disk.",

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -32,6 +32,12 @@ export const TOP_LEVEL_FILE_ANNOTATIONS = [
         type: AnnotationType.STRING,
     }),
     new Annotation({
+        annotationDisplayName: "File Path (Local)",
+        annotationName: AnnotationName.LOCAL_FILE_PATH,
+        description: "Path to the file on-premises.",
+        type: AnnotationType.STRING,
+    }),
+    new Annotation({
         annotationDisplayName: "Size",
         annotationName: AnnotationName.FILE_SIZE,
         description: "Size of file on disk.",

--- a/packages/core/entity/Annotation/AnnotationName.ts
+++ b/packages/core/entity/Annotation/AnnotationName.ts
@@ -6,6 +6,7 @@ export default {
     FILE_NAME: "file_name", // a file attribute (top-level prop on file documents in MongoDb)
     FILE_SIZE: "file_size", // a file attribute (top-level prop on file documents in MongoDb)
     FILE_PATH: "file_path", // a file attribute (top-level prop on file documents in MongoDb)
+    LOCAL_FILE_PATH: "Local File Path", // (optional) annotation for FMS files on the local NAS
     PLATE_BARCODE: "Plate Barcode",
     THUMBNAIL_PATH: "thumbnail", // (optional) file attribute (top-level prop on the file documents in MongoDb)
     TYPE: "Type", // matches an annotation in filemetadata.annotation

--- a/packages/core/entity/Annotation/mocks.ts
+++ b/packages/core/entity/Annotation/mocks.ts
@@ -29,4 +29,10 @@ export const annotationsJson = [
         description: "Imaging objective",
         type: "Number",
     },
+    {
+        annotationName: "Local File Path",
+        annotationDisplayName: "Local File Path",
+        description: "Path to file in on-premises storage.",
+        type: "Text",
+    },
 ];

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -121,7 +121,6 @@ export default class FileDetail {
 
     public get localPath(): string | null {
         const localPath = this.getFirstAnnotationValue("Local File Path");
-        console.log("local path is ", localPath);
         if (localPath === undefined) {
             return null;
         }

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -119,6 +119,15 @@ export default class FileDetail {
         return path as string;
     }
 
+    public get localPath(): string | null {
+        const localPath = this.getFirstAnnotationValue("Local File Path");
+        console.log("local path is ", localPath);
+        if (localPath === undefined) {
+            return null;
+        }
+        return localPath as string;
+    }
+
     public get cloudPath(): string {
         // Can retrieve a cloud like path for AICS FMS files
         if (this.path.startsWith("/allen")) {

--- a/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
@@ -1,0 +1,13 @@
+import { AnnotationResponse } from "../../../entity/Annotation";
+import AnnotationName from "../../../entity/Annotation/AnnotationName";
+
+export default function renameAnnotation(annotation: AnnotationResponse): AnnotationResponse {
+    if (annotation.annotationName === AnnotationName.LOCAL_FILE_PATH) {
+        return {
+            ...annotation,
+            annotationDisplayName: "File Path (Local)",
+        } as AnnotationResponse;
+    } else {
+        return annotation;
+    }
+}

--- a/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
@@ -5,7 +5,7 @@ export default function renameAnnotation(annotation: AnnotationResponse): Annota
     if (annotation.annotationName === AnnotationName.LOCAL_FILE_PATH) {
         return {
             ...annotation,
-            annotationDisplayName: "File Path (Vast)",
+            annotationDisplayName: "File Path (Local VAST)",
         } as AnnotationResponse;
     } else {
         return annotation;

--- a/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
@@ -5,7 +5,7 @@ export default function renameAnnotation(annotation: AnnotationResponse): Annota
     if (annotation.annotationName === AnnotationName.LOCAL_FILE_PATH) {
         return {
             ...annotation,
-            annotationDisplayName: "File Path (Local)",
+            annotationDisplayName: "File Path (Vast)",
         } as AnnotationResponse;
     } else {
         return annotation;

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -4,6 +4,7 @@ import AnnotationService, { AnnotationValue } from "..";
 import HttpServiceBase from "../../HttpServiceBase";
 import Annotation, { AnnotationResponse } from "../../../entity/Annotation";
 import FileFilter from "../../../entity/FileFilter";
+import renameAnnotation from "./FMSAnnotationPresentationLayer";
 import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../../constants";
 
 enum QueryParam {
@@ -35,7 +36,10 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
         const response = await this.get<AnnotationResponse>(requestUrl);
         return [
             ...TOP_LEVEL_FILE_ANNOTATIONS,
-            ...map(response.data, (annotationResponse) => new Annotation(annotationResponse)),
+            ...map(
+                response.data,
+                (annotationResponse) => new Annotation(renameAnnotation(annotationResponse))
+            ),
         ];
     }
 

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -1,10 +1,10 @@
 import { map } from "lodash";
 
+import renameAnnotation from "./FMSAnnotationPresentationLayer";
 import AnnotationService, { AnnotationValue } from "..";
 import HttpServiceBase from "../../HttpServiceBase";
 import Annotation, { AnnotationResponse } from "../../../entity/Annotation";
 import FileFilter from "../../../entity/FileFilter";
-import renameAnnotation from "./FMSAnnotationPresentationLayer";
 import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../../constants";
 
 enum QueryParam {

--- a/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
@@ -32,14 +32,14 @@ describe("HttpAnnotationService", () => {
             expect(annotations[0]).to.be.instanceOf(Annotation);
         });
 
-        it("renames Local File Path to File Path (Local)", async () => {
+        it("renames Local File Path to File Path (Vast)", async () => {
             const annotationService = new HttpAnnotationService({
                 fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
                 httpClient,
             });
             const annotations = await annotationService.fetchAnnotations();
             const localPathAnnotation = annotations.find((a) => a.name === "Local File Path");
-            expect(localPathAnnotation?.displayName).to.equal("File Path (Local)");
+            expect(localPathAnnotation?.displayName).to.equal("File Path (Vast)");
         });
     });
 

--- a/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
@@ -32,14 +32,14 @@ describe("HttpAnnotationService", () => {
             expect(annotations[0]).to.be.instanceOf(Annotation);
         });
 
-        it("renames Local File Path to File Path (Vast)", async () => {
+        it("renames Local File Path to File Path (Local VAST)", async () => {
             const annotationService = new HttpAnnotationService({
                 fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
                 httpClient,
             });
             const annotations = await annotationService.fetchAnnotations();
             const localPathAnnotation = annotations.find((a) => a.name === "Local File Path");
-            expect(localPathAnnotation?.displayName).to.equal("File Path (Vast)");
+            expect(localPathAnnotation?.displayName).to.equal("File Path (Local VAST)");
         });
     });
 

--- a/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
@@ -31,6 +31,16 @@ describe("HttpAnnotationService", () => {
             );
             expect(annotations[0]).to.be.instanceOf(Annotation);
         });
+
+        it("renames Local File Path to File Path (Local)", async () => {
+            const annotationService = new HttpAnnotationService({
+                fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
+                httpClient,
+            });
+            const annotations = await annotationService.fetchAnnotations();
+            const localPathAnnotation = annotations.find((a) => a.name === "Local File Path");
+            expect(localPathAnnotation?.displayName).to.equal("File Path (Local)");
+        });
     });
 
     describe("fetchAnnotationValues", () => {


### PR DESCRIPTION
# Purpose
Render the new "Local File Path" annotation nicely. The goal is to display something like this:

`File Path (Vast) /mypath/aics/software/apps/staging/fss/data/7fb/6fb/b0f/6bd/7d5/1db/a4c/1e4/2a6/2a5/c7/aicsfiles-test-a4cb9af6-bcfa-11ef-8fe8-0242ac110002.czi`

Closes #368 
Closes #369

# Changes
* I had to create some logic for renaming the annotation from "Local File Path." I ended up putting it in the `HttpAnnotationService`, which has a few benefits.
  * The implementation is simpler than putting the logic downstream (e.g., in the `FileAnnotationList`).
  * The renaming only applies to the FMS data source, so people running BFF from a CSV won't be surprised by it.

# Testing
* Fixed and updated existing test for renaming mount points (see #369 for more details)
* New test for renaming in `HttpAnnotationService`
* Manual test in staging:
![Screenshot 2024-12-20 at 10 50 35 AM](https://github.com/user-attachments/assets/f39f0c47-6c4c-4b07-b6bc-1c370d3f2313)


# Notes
* The name `File Path (Local)` was used before `File Path (Vast)`. I don't have a strong preference: please weigh in. The new `FMSAnnotationPresentationLayer` makes it easy to change it up.
* I'm not totally sure of the name `FMSAnnotationPresentationLayer` nor the choice to put this annotation-renaming logic here instead of FES or changing the name in LabKey and the ETL pipeline.