### PR TITLE
376: Downloads use labkey URL when file is available on Vast

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -148,10 +148,10 @@ export default class FileDetail {
     }
 
     public get downloadPath(): string {
-        // For AICS files we don't have permission to the bucket nor do we expect to have the /allen
-        // drive mounted on the client machine. So we use the NGINX server to serve the file.
-        if (this.path.startsWith("/allen")) {
-            return `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${this.path}`;
+        // For AICS files that are available on the Vast, users can use the cloud path, but the
+        // download will be faster and not incur egress fees if we download via the local network.
+        if (this.localPath && this.localPath.startsWith("/allen")) {
+            return `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${this.localPath}`;
         }
 
         // Otherwise just return the path as is and hope for the best

--- a/packages/core/entity/FileDetail/test/FileDetail.test.ts
+++ b/packages/core/entity/FileDetail/test/FileDetail.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+
+import FileDetail from "..";
+
+describe("FileDetail", () => {
+    describe("file path representation", () => {
+        it("creates downloadPath from /allen path", () => {
+            // Arrange
+            const relativePath = "path/to/MyFile.txt";
+
+            // Act
+            const fileDetail = new FileDetail({
+                file_path: `production.files.allencell.org/${relativePath}`,
+                annotations: [
+                    {
+                        name: "Local File Path",
+                        values: [`/allen/programs/allencell/data/proj0/${relativePath}`],
+                    },
+                ],
+            });
+
+            // Assert
+            expect(fileDetail.downloadPath).to.equal(
+                // The downloadPath is HTTP, but will get redirected to HTTPS
+                `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image/allen/programs/allencell/data/proj0/${relativePath}`
+            );
+        });
+    });
+});


### PR DESCRIPTION
Cloud-first FMS backend changes and existing updates for them (https://github.com/AllenInstitute/biofile-finder/pull/370, https://github.com/AllenInstitute/biofile-finder/pull/375) cause downloads to use the S3 URL. But for files available on the Vast, the download will be faster and use fewer resources if we download from the Vast via the labkey URL `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image/allen/...`

Closes #376 

# Testing
* I added an automated test that confirms the `downloadPath` has the expected format.
* I was unable to test this manually. This is because this PR depends on the latest changes to the ETL pipeline, which are only deployed to staging, but downloading files from staging is broken #293 (perhaps it has never worked).

# Notes
I believe we should merge this despite being unable to manually test it, because we know that the latest ETL pipeline changes will break the current `downloadPath` logic.