### PR TITLE
Feature/backwards-etl-compatibility

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -135,6 +135,11 @@ export default class FileDetail {
     }
 
     public get localPath(): string | null {
+        // REMOVE THIS (BACKWARDS COMPAT)
+        if (this.path.startsWith("/allen")) {
+            return this.path;
+        }
+
         const localPath = this.getFirstAnnotationValue("Local File Path");
         if (localPath === undefined) {
             return null;
@@ -143,11 +148,21 @@ export default class FileDetail {
     }
 
     public get cloudPath(): string {
+        // REMOVE THIS (BACKWARDS COMPAT)
+        if (this.path.startsWith("/allen")) {
+            return FileDetail.convertAicsDrivePathToAicsS3Path(this.path);
+        }
+
         // AICS FMS files' paths are cloud paths
         return this.path;
     }
 
     public get downloadPath(): string {
+        // REMOVE THIS (BACKWARDS COMPAT)
+        if (this.path.startsWith("/allen")) {
+            return `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${this.path}`;
+        }
+
         // For AICS files that are available on the Vast, users can use the cloud path, but the
         // download will be faster and not incur egress fees if we download via the local network.
         if (this.localPath && this.localPath.startsWith("/allen")) {


### PR DESCRIPTION

### Description 
The purpose of this PR is to resolve #378 and make it so users of the old ETL can update their version prior to the release of the new ETL 

I have the download working and the cloud path is correctly mapped now but we do not show the File Path (local VAST) since we removed that as a top level annotation and now get it from the new etl as a normal annotation. If we wanted it to be visible we would have to add a custom top level annotation that is only used if the old ETL is in place and maps correctly. I think this is too much just for backwards compatibility. For users this would just mean that they do not see the annotation File Path (Local VAST) until the new ETL rolls out.


also if this is approved we need to open an issue to remove it for the next version.

