### PR TITLE
bugfix/svgicon-build-size

### DIFF
--- a/packages/core/components/FileThumbnail/index.tsx
+++ b/packages/core/components/FileThumbnail/index.tsx
@@ -45,10 +45,10 @@ export default function FileThumbnail(props: Props) {
     if (!props.uri) {
         return (
             <SvgIcon
-                height={props.height}
+                height={props?.height || 150}
                 pathData={NO_IMAGE_ICON_PATH_DATA}
                 viewBox="0,1,22,22"
-                width={props.width}
+                width={props?.width || 150}
                 className={classNames(styles.noThumbnail, {
                     [styles.noThumbnailSelected]: props?.selected,
                 })}

--- a/packages/core/components/SvgIcon/index.tsx
+++ b/packages/core/components/SvgIcon/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { castArray, defaults } from "lodash";
+import { castArray } from "lodash";
 import * as React from "react";
 
 import styles from "./SvgIcon.module.css";
@@ -13,22 +13,12 @@ interface SvgIconProps {
     width?: number | string;
     viewBox: string;
 }
-
-// forwardRef components cannot make use of React's defaultProps mechanism
-const DEFAULT_PROPS = {
-    height: 15,
-    pathAttrs: {},
-    width: 15,
-};
-
 /**
  * A generalized SVG icon.
  */
 function SvgIcon(props: SvgIconProps, ref?: React.Ref<SVGSVGElement>) {
-    const { className, height, onClick, pathAttrs, pathData, viewBox, width } = defaults(
-        props,
-        DEFAULT_PROPS
-    );
+    const { className, height, onClick, pathAttrs = {}, pathData, viewBox, width } = props;
+
     return (
         <svg
             className={classNames({ [styles.interactive]: onClick !== undefined }, className)}


### PR DESCRIPTION
### Description
The thumbnail size is incorrectly defaulting to 15 pixels when app is built (but not in local). SvgIcon/index.tsx sets height as 15 by default if the prop is undefined, and in the dmg files and the deployed web builds it correctly sets this as the svg height, but locally it just leaves the height undefined. There are a few different solutions to this. This PR is meant to be a discussion hub for the best solution.
![Screenshot 2025-01-06 at 9 47 24 AM](https://github.com/user-attachments/assets/9a145ae0-3dfa-4ffa-bd6e-e38b658b19c9)

### Solution
1) remove the defaults (changes on this PR)
2) refine thumbnail parameters like so
![image](https://github.com/user-attachments/assets/d0f504e4-dc68-4556-ad23-c24d5a06c293)
3) ensure build matches local (not sure how to do this)