### PR TITLE
356: Copy to VAST status indicator

### DIFF
--- a/packages/core/components/FileDetails/FileAnnotationList.module.css
+++ b/packages/core/components/FileDetails/FileAnnotationList.module.css
@@ -12,3 +12,7 @@
   /* flex child */
   flex: 1 1 100%;
 }
+
+.status-indicator {
+  font-style: italic;
+}

--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -73,15 +73,12 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
             }
 
             let annotationValue = annotation.extractFromFile(fileDetails);
-            if (annotationValue === Annotation.MISSING_VALUE) {
-                // Nothing to show for this annotation -- skip
-                return accum;
-            }
 
             if (annotation.name === AnnotationName.LOCAL_FILE_PATH) {
-                if (localPath === null) {
-                    // localPath hasn't loaded yet, but it should eventually because there is an
-                    // annotation named AnnotationName.LOCAL_FILE_PATH
+                if (fileDetails && fileDetails.downloadInProgress) {
+                    annotationValue = "Copying to VAST in progress…";
+                } else if (localPath === null) {
+                    // localPath hasn't loaded yet or there is no local path annotation
                     return accum;
                 } else {
                     // Use the user's /allen mount point, if known
@@ -92,6 +89,11 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
             if (annotation.name === AnnotationName.FILE_PATH) {
                 // Display the full http://... URL
                 annotationValue = fileDetails.cloudPath;
+            }
+
+            if (annotationValue === Annotation.MISSING_VALUE) {
+                // Nothing to show for this annotation -- skip
+                return accum;
             }
 
             return [

--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -73,10 +73,12 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
             }
 
             let annotationValue = annotation.extractFromFile(fileDetails);
+            let fmsStateIndicator = false;
 
             if (annotation.name === AnnotationName.LOCAL_FILE_PATH) {
                 if (fileDetails && fileDetails.downloadInProgress) {
                     annotationValue = "Copying to VAST in progress…";
+                    fmsStateIndicator = true;
                 } else if (localPath === null) {
                     // localPath hasn't loaded yet or there is no local path annotation
                     return accum;
@@ -103,6 +105,7 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
                     className={styles.row}
                     name={annotation.displayName}
                     value={annotationValue}
+                    fmsStateIndicator={fmsStateIndicator}
                 />,
             ];
         }, [] as JSX.Element[]);

--- a/packages/core/components/FileDetails/FileAnnotationRow.module.css
+++ b/packages/core/components/FileDetails/FileAnnotationRow.module.css
@@ -52,3 +52,7 @@
     /* Allow whitespace to be rendered (including carriage returns & new lines) */
     white-space: pre-wrap; 
 }
+
+.fms-state-indicator {
+    font-style: italic;
+}

--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -11,6 +11,7 @@ interface FileAnnotationRowProps {
     className?: string;
     name: string;
     value: string;
+    fmsStateIndicator?: boolean;
 }
 
 /**
@@ -66,6 +67,7 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
             <Cell
                 className={classNames(styles.cell, styles.value, {
                     [styles.smallFont]: shouldDisplaySmallFont,
+                    [styles.fmsStateIndicator]: props.fmsStateIndicator,
                 })}
                 columnKey="value"
                 width={1}

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -126,6 +126,24 @@ describe("<FileAnnotationList />", () => {
 
         it("has loading message when file is downloading", () => {
             // Arrange
+            class FakeExecutionEnvService extends ExecutionEnvServiceNoop {
+                public formatPathForHost(posixPath: string): Promise<string> {
+                    return Promise.resolve(posixPath);
+                }
+            }
+            const { store } = configureMockStore({
+                state: mergeState(initialState, {
+                    metadata: {
+                        annotations: TOP_LEVEL_FILE_ANNOTATIONS,
+                    },
+                    interaction: {
+                        platformDependentServices: {
+                            executionEnvService: new FakeExecutionEnvService(),
+                        },
+                    },
+                }),
+            });
+
             const fileDetails = new FileDetail({
                 file_path: "path/to/file",
                 file_id: "abc123",
@@ -137,11 +155,13 @@ describe("<FileAnnotationList />", () => {
 
             // Act
             const { findByText } = render(
-                <FileAnnotationList isLoading={false} fileDetails={fileDetails} />
+                <Provider store={store}>
+                    <FileAnnotationList isLoading={false} fileDetails={fileDetails} />
+                </Provider>
             );
 
             // Assert
-            ["File Path (Canonical)", "Copying to Vast in progress…"].forEach(async (cellText) => {
+            ["File Path (Local VAST)", "Copying to VAST in progress…"].forEach(async (cellText) => {
                 expect(await findByText(cellText)).to.not.be.undefined;
             });
         });

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -123,5 +123,27 @@ describe("<FileAnnotationList />", () => {
                 }
             );
         });
+
+        it("has loading message when file is downloading", () => {
+            // Arrange
+            const fileDetails = new FileDetail({
+                file_path: "path/to/file",
+                file_id: "abc123",
+                file_name: "MyFile.txt",
+                file_size: 7,
+                uploaded: "01/01/01",
+                annotations: [{ name: "shouldBeInLocal", values: [true] }],
+            });
+
+            // Act
+            const { findByText } = render(
+                <FileAnnotationList isLoading={false} fileDetails={fileDetails} />
+            );
+
+            // Assert
+            ["File Path (Canonical)", "Copying to Vast in progress…"].forEach(async (cellText) => {
+                expect(await findByText(cellText)).to.not.be.undefined;
+            });
+        });
     });
 });

--- a/packages/core/entity/Annotation/AnnotationName.ts
+++ b/packages/core/entity/Annotation/AnnotationName.ts
@@ -8,6 +8,7 @@ export default {
     FILE_PATH: "file_path", // a file attribute (top-level prop on file documents in MongoDb)
     LOCAL_FILE_PATH: "Local File Path", // (optional) annotation for FMS files on the local NAS
     PLATE_BARCODE: "Plate Barcode",
+    SHOULD_BE_IN_LOCAL: "Should Be in Local Cache",
     THUMBNAIL_PATH: "thumbnail", // (optional) file attribute (top-level prop on the file documents in MongoDb)
     TYPE: "Type", // matches an annotation in filemetadata.annotation
     UPLOADED: "uploaded", // matches an annotation in filemetadata.annotation

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -173,6 +173,11 @@ export default class FileDetail {
         return this.path;
     }
 
+    public get downloadInProgress(): boolean {
+        const shouldBeInLocal = this.getFirstAnnotationValue(AnnotationName.SHOULD_BE_IN_LOCAL);
+        return Boolean(shouldBeInLocal) && !this.localPath;
+    }
+
     public get size(): number | undefined {
         const size = this.fileDetail.file_size || this.getFirstAnnotationValue("File Size");
         if (size === undefined) {


### PR DESCRIPTION
# Purpose
Scientists 1 and 2 are working on a project that needs to use file A on local storage, but File A is only on the cloud. Scientist 1 uses BFF to copy the file to the Vast. The file is 4TB so it isn't immediately available. Scientist 2 goes to BFF to do the same thing: they would like to know if the download is already in progress.

Resolves #356 

# Testing
* New unit test
* Manual test in staging
![Screenshot 2025-01-09 at 12 58 57 PM](https://github.com/user-attachments/assets/b22a83c3-bb45-46de-bee7-8d2dbc28435f)

