### PR TITLE
feature/rename-annotation

### DIFF
--- a/packages/core/entity/Annotation/AnnotationName.ts
+++ b/packages/core/entity/Annotation/AnnotationName.ts
@@ -6,6 +6,7 @@ export default {
     FILE_NAME: "file_name", // a file attribute (top-level prop on file documents in MongoDb)
     FILE_SIZE: "file_size", // a file attribute (top-level prop on file documents in MongoDb)
     FILE_PATH: "file_path", // a file attribute (top-level prop on file documents in MongoDb)
+    CACHE_EVICTION_DATE: "Cache Eviction Date", // (optional) file attribute (top-level prop on the file documents in MongoDb)
     LOCAL_FILE_PATH: "File Path (Local VAST)", // (optional) annotation for FMS files on the local NAS
     PLATE_BARCODE: "Plate Barcode",
     SHOULD_BE_IN_LOCAL: "Should Be in Local Cache",

--- a/packages/core/entity/Annotation/mocks.ts
+++ b/packages/core/entity/Annotation/mocks.ts
@@ -35,4 +35,10 @@ export const annotationsJson = [
         description: "Path to file in on-premises storage.",
         type: "Text",
     },
+    {
+        annotationName: "Cache Eviction Date",
+        annotationDisplayName: "Cache Eviction Date",
+        description: "Date to remove from local storage (VAST)",
+        type: "Date",
+    },
 ];

--- a/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/FMSAnnotationPresentationLayer.ts
@@ -1,0 +1,13 @@
+import { AnnotationResponse } from "../../../entity/Annotation";
+import AnnotationName from "../../../entity/Annotation/AnnotationName";
+
+export default function renameAnnotation(annotation: AnnotationResponse): AnnotationResponse {
+    if (annotation.annotationName === AnnotationName.CACHE_EVICTION_DATE) {
+        return {
+            ...annotation,
+            annotationDisplayName: "VAST Expiration Date",
+        } as AnnotationResponse;
+    } else {
+        return annotation;
+    }
+}

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -1,5 +1,6 @@
 import { map } from "lodash";
 
+import renameAnnotation from "./FMSAnnotationPresentationLayer";
 import AnnotationService, { AnnotationValue } from "..";
 import HttpServiceBase from "../../HttpServiceBase";
 import Annotation, { AnnotationResponse } from "../../../entity/Annotation";
@@ -35,7 +36,10 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
         const response = await this.get<AnnotationResponse>(requestUrl);
         return [
             ...TOP_LEVEL_FILE_ANNOTATIONS,
-            ...map(response.data, (annotationResponse) => new Annotation(annotationResponse)),
+            ...map(
+                response.data,
+                (annotationResponse) => new Annotation(renameAnnotation(annotationResponse))
+            ),
         ];
     }
 

--- a/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/test/HttpAnnotationService.test.ts
@@ -31,6 +31,16 @@ describe("HttpAnnotationService", () => {
             );
             expect(annotations[0]).to.be.instanceOf(Annotation);
         });
+
+        it("renames Cache Eviction Date to VAST Expiration Date", async () => {
+            const annotationService = new HttpAnnotationService({
+                fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
+                httpClient,
+            });
+            const annotations = await annotationService.fetchAnnotations();
+            const localPathAnnotation = annotations.find((a) => a.name === "Cache Eviction Date");
+            expect(localPathAnnotation?.displayName).to.equal("VAST Expiration Date");
+        });
     });
 
     describe("fetchAnnotationValues", () => {


### PR DESCRIPTION
### Description 
The purpose of this PR is to rename "Cache Eviction Date" to "VAST Expiration Date" as per the poll in the #general Slack channel. This PR uses the code originally written by @pgarrison [here](https://github.com/AllenInstitute/biofile-finder/pull/370). It sets up the option to rename annotations in the future.