### PR TITLE
bugfix/ZEN-wrong-path

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -222,7 +222,9 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                 key: `open-with-${name}`,
                 text: name,
                 title: `Open files with ${name}`,
-                disabled: (!filters && !fileDetails) || app.filePath.toLowerCase().includes("zen"),
+                disabled:
+                    (!filters && !fileDetails) ||
+                    (app.filePath.toLowerCase().includes("zen") && !fileDetails?.localPath),
                 onClick() {
                     if (filters) {
                         dispatch(interaction.actions.openWith(app, filters));

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -222,7 +222,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                 key: `open-with-${name}`,
                 text: name,
                 title: `Open files with ${name}`,
-                disabled: (!filters && !fileDetails) || !fileDetails?.localPath,
+                disabled: (!filters && !fileDetails) || app.filePath.toLowerCase().includes("zen"),
                 onClick() {
                     if (filters) {
                         dispatch(interaction.actions.openWith(app, filters));

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -222,7 +222,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                 key: `open-with-${name}`,
                 text: name,
                 title: `Open files with ${name}`,
-                disabled: !filters && !fileDetails,
+                disabled: (!filters && !fileDetails) || !fileDetails?.localPath,
                 onClick() {
                     if (filters) {
                         dispatch(interaction.actions.openWith(app, filters));

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -1,4 +1,5 @@
 import { isEmpty, sumBy, throttle, uniq, uniqueId } from "lodash";
+import { isAbsolute } from "path";
 import { AnyAction } from "redux";
 import { createLogic } from "redux-logic";
 
@@ -489,8 +490,14 @@ const openWithLogic = createLogic({
         } else {
             filesToOpen = await fileSelection.fetchAllDetails();
         }
+
+        // Determine if exePath is local
+        const isLocalExecutable = isAbsolute(exePath);
         const filePaths = await Promise.all(
-            filesToOpen.map((file) => executionEnvService.formatPathForHost(file.path))
+            filesToOpen.map((file) => {
+                const filePath = isLocalExecutable ? file.localPath ?? file.path : file.path;
+                return executionEnvService.formatPathForHost(filePath);
+            })
         );
 
         // Open the files in the specified executable

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -1,5 +1,4 @@
 import { isEmpty, sumBy, throttle, uniq, uniqueId } from "lodash";
-import { isAbsolute } from "path";
 import { AnyAction } from "redux";
 import { createLogic } from "redux-logic";
 
@@ -491,11 +490,10 @@ const openWithLogic = createLogic({
             filesToOpen = await fileSelection.fetchAllDetails();
         }
 
-        // Determine if exePath is local
-        const isLocalExecutable = isAbsolute(exePath);
         const filePaths = await Promise.all(
+            // Default to local path for desktop apps
             filesToOpen.map((file) => {
-                const filePath = isLocalExecutable ? file.localPath ?? file.path : file.path;
+                const filePath = file.localPath ?? file.path;
                 return executionEnvService.formatPathForHost(filePath);
             })
         );


### PR DESCRIPTION
### Description 
The purpose of this PR is to resolve #401 and allow scientists to open local files ( VAST ) in ZEN. When we switched to cloud path being our primary path we then pass this path to external apps that try to "open it". This means that apps that need a local path like ZEN cannot open these paths.


### Development Decisions

In order to complete this PR we had to make a few decisions.

1) Desktop apps will default to using local path. This means that any app that users add will automatically use local path.
2) Disable desktop applications for cloud only files.


In the future if we want specific apps to use a cloud path then we need to add them manually to the repo, otherwise it'll default to opening with the local path.