### PR TITLE
Add logic for creating new annotations

### DIFF
--- a/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
@@ -7,6 +7,7 @@ import { createSandbox } from "sinon";
 
 import AnnotationFilterForm from "..";
 import Annotation from "../../../entity/Annotation";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import FileFilter from "../../../entity/FileFilter";
 import { initialState, reducer, reduxLogics, interaction, selection } from "../../../state";
 import HttpAnnotationService from "../../../services/AnnotationService/HttpAnnotationService";
@@ -20,7 +21,7 @@ describe("<AnnotationFilterForm />", () => {
             annotationDisplayName: "Foo",
             annotationName: "foo",
             description: "",
-            type: "Text",
+            type: AnnotationType.STRING,
         });
 
         const sandbox = createSandbox();
@@ -169,7 +170,7 @@ describe("<AnnotationFilterForm />", () => {
             annotationDisplayName: "Foo",
             annotationName: "foo",
             description: "",
-            type: "YesNo",
+            type: AnnotationType.BOOLEAN,
         });
 
         const responseStub = {
@@ -268,7 +269,7 @@ describe("<AnnotationFilterForm />", () => {
             annotationDisplayName: "Foo",
             annotationName: "foo",
             description: "",
-            type: "Number",
+            type: AnnotationType.NUMBER,
         });
 
         const sandbox = createSandbox();
@@ -323,7 +324,7 @@ describe("<AnnotationFilterForm />", () => {
             annotationDisplayName: "Foo",
             annotationName: "foo",
             description: "",
-            type: "Duration",
+            type: AnnotationType.DURATION,
         });
 
         const sandbox = createSandbox();

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -22,6 +22,7 @@ import { createSandbox } from "sinon";
 import { FESBaseUrl, TOP_LEVEL_FILE_ANNOTATIONS } from "../../../constants";
 import Annotation from "../../../entity/Annotation";
 import AnnotationName from "../../../entity/Annotation/AnnotationName";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import { FmsFileAnnotation } from "../../../services/FileService";
 import FileFilter from "../../../entity/FileFilter";
 import FileDownloadServiceNoop from "../../../services/FileDownloadService/FileDownloadServiceNoop";
@@ -44,13 +45,13 @@ describe("<DirectoryTree />", () => {
         annotationDisplayName: "Foo",
         annotationName: "foo",
         description: "",
-        type: "Text",
+        type: AnnotationType.STRING,
     });
     const barAnnotation = new Annotation({
         annotationDisplayName: "Bar",
         annotationName: "bar",
         description: "",
-        type: "Text",
+        type: AnnotationType.STRING,
     });
 
     const baseDisplayAnnotations = TOP_LEVEL_FILE_ANNOTATIONS.filter(

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -13,6 +13,7 @@
 
 .error-message {
   color: var(--error-status-text-color);
+  line-height: 1.15;
 }
 
 .status-message {

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -11,6 +11,23 @@
   padding-left: 5px;
 }
 
+.error-message {
+  color: var(--error-status-text-color);
+}
+
+.status-message {
+  color: var(--info-status-text-color);
+  display: flex;
+}
+
+.spinner {
+  margin: 0 0.5em;
+}
+
+.spinner > div {
+  border-color: var(--info-status-background-color) var(--info-status-text-color) var(--info-status-text-color);
+}
+
 .footer {
   margin-top: 20px;
   width: 100%;
@@ -89,7 +106,7 @@
   font-size: var(--l-paragraph-size);
 }
 
-.text-field :is(input) {
+.text-field :is(input), .text-field :is(textarea) {
   background-color: var(--secondary-background-color) !important;
   color: var(--secondary-text-color) !important;
   border-radius: 4px;

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -47,6 +47,8 @@ interface AnnotationStatus {
  */
 export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const dispatch = useDispatch();
+    // Destructure to prevent unnecessary useEffect triggers
+    const { onDismiss, hasUnsavedChanges } = props;
 
     const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
     const [newValues, setNewValues] = React.useState<AnnotationValue | undefined>();
@@ -87,8 +89,8 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                 message: `Failed to create annotation: ${e}`,
                             });
                         } finally {
-                            props?.hasUnsavedChanges(false);
-                            props.onDismiss();
+                            hasUnsavedChanges(false);
+                            onDismiss();
                         }
                     }
                 default:
@@ -96,7 +98,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
             }
         };
         checkForStatusUpdates();
-    }, [statuses, annotationCreationStatus, dispatch]);
+    }, [annotationCreationStatus, dispatch, hasUnsavedChanges, newFieldName, newValues, onDismiss]);
 
     const addDropdownChip = (evt: React.FormEvent) => {
         evt.preventDefault();

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -100,6 +100,19 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
         checkForStatusUpdates();
     }, [annotationCreationStatus, dispatch, hasUnsavedChanges, newFieldName, newValues, onDismiss]);
 
+    const onChangeAlphanumericField = (
+        e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+        newValue: string | undefined
+    ) => {
+        const regex = /^[\w\-\s]+$/g;
+        // Restricts character entry to alphanumeric
+        if (newValue && !regex.test(newValue)) {
+            e.preventDefault();
+        } else {
+            setNewFieldName(newValue || "");
+        }
+    };
+
     const addDropdownChip = (evt: React.FormEvent) => {
         evt.preventDefault();
         if (
@@ -154,7 +167,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                 required
                 label="New metadata field name"
                 className={styles.textField}
-                onChange={(_, newValue) => setNewFieldName(newValue || "")}
+                onChange={(ev, newValue) => onChangeAlphanumericField(ev, newValue)}
                 placeholder="Add a new field name..."
                 value={newFieldName}
             />

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -54,7 +54,9 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const [newValues, setNewValues] = React.useState<AnnotationValue | undefined>();
     const [newFieldName, setNewFieldName] = React.useState<string>("");
     const [newFieldDescription, setNewFieldDescription] = React.useState<string>("");
-    const [newFieldDataType, setNewFieldDataType] = React.useState<AnnotationType | undefined>();
+    const [newFieldDataType, setNewFieldDataType] = React.useState<AnnotationType>(
+        AnnotationType.STRING
+    );
     const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
     const [dropdownOptions, setDropdownOptions] = React.useState<IComboBoxOption[]>([]);
     const [submissionStatus, setSubmissionStatus] = React.useState<AnnotationStatus | undefined>();
@@ -148,8 +150,8 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
         const annotation = new Annotation({
             annotationDisplayName: newFieldName,
             annotationName: newFieldName,
-            description: newFieldDescription ?? "",
-            type: newFieldDataType ?? AnnotationType.STRING,
+            description: newFieldDescription,
+            type: newFieldDataType,
         });
         // File editing step occurs after dispatch is processed and status is updated
         dispatch(
@@ -196,7 +198,9 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                             };
                         })}
                         onChange={(option) =>
-                            setNewFieldDataType((option?.key as AnnotationType) || "")
+                            setNewFieldDataType(
+                                (option?.key as AnnotationType) || AnnotationType.STRING
+                            )
                         }
                     />
                     {newFieldDataType === AnnotationType.DROPDOWN && (

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -31,7 +31,7 @@ enum EditStep {
 
 interface NewAnnotationProps {
     onDismiss: () => void;
-    hasUnsavedChanges: (arg: boolean) => void;
+    setHasUnsavedChanges: (arg: boolean) => void;
     selectedFileCount: number;
 }
 
@@ -48,7 +48,7 @@ interface AnnotationStatus {
 export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const dispatch = useDispatch();
     // Destructure to prevent unnecessary useEffect triggers
-    const { onDismiss, hasUnsavedChanges } = props;
+    const { onDismiss, setHasUnsavedChanges } = props;
 
     const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
     const [newValues, setNewValues] = React.useState<AnnotationValue | undefined>();
@@ -91,7 +91,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                 message: `Failed to create annotation: ${e}`,
                             });
                         } finally {
-                            hasUnsavedChanges(false);
+                            setHasUnsavedChanges(false);
                             onDismiss();
                         }
                     }
@@ -100,7 +100,14 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
             }
         };
         checkForStatusUpdates();
-    }, [annotationCreationStatus, dispatch, hasUnsavedChanges, newFieldName, newValues, onDismiss]);
+    }, [
+        annotationCreationStatus,
+        dispatch,
+        setHasUnsavedChanges,
+        newFieldName,
+        newValues,
+        onDismiss,
+    ]);
 
     const onChangeAlphanumericField = (
         e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -135,7 +142,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
     };
 
     function onCreateNewAnnotation() {
-        props?.hasUnsavedChanges(true);
+        setHasUnsavedChanges(true);
         setStep(EditStep.EDIT_FILES);
     }
 

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -1,12 +1,25 @@
-import { IComboBoxOption, IconButton, Stack, StackItem, TextField } from "@fluentui/react";
+import {
+    IComboBoxOption,
+    IconButton,
+    Spinner,
+    SpinnerSize,
+    Stack,
+    StackItem,
+    TextField,
+} from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
 import { PrimaryButton, SecondaryButton } from "../Buttons";
 import ComboBox from "../ComboBox";
 import Tooltip from "../Tooltip";
+import Annotation from "../../entity/Annotation";
 import { AnnotationType } from "../../entity/AnnotationFormatter";
+import { AnnotationValue } from "../../services/AnnotationService";
+import { interaction, metadata } from "../../state";
+import { ProcessStatus } from "../../state/interaction/actions";
 
 import styles from "./EditMetadata.module.css";
 
@@ -18,8 +31,14 @@ enum EditStep {
 
 interface NewAnnotationProps {
     onDismiss: () => void;
-    onUnsavedChanges: () => void;
+    hasUnsavedChanges: (arg: boolean) => void;
     selectedFileCount: number;
+}
+
+// Simplified version of status message
+interface AnnotationStatus {
+    status: ProcessStatus;
+    message: string | undefined;
 }
 
 /**
@@ -27,12 +46,57 @@ interface NewAnnotationProps {
  * and then entering values for the selected files
  */
 export default function NewAnnotationPathway(props: NewAnnotationProps) {
+    const dispatch = useDispatch();
+
     const [step, setStep] = React.useState<EditStep>(EditStep.CREATE_FIELD);
-    const [newValues, setNewValues] = React.useState<string | undefined>();
+    const [newValues, setNewValues] = React.useState<AnnotationValue | undefined>();
     const [newFieldName, setNewFieldName] = React.useState<string>("");
+    const [newFieldDescription, setNewFieldDescription] = React.useState<string>("");
     const [newFieldDataType, setNewFieldDataType] = React.useState<AnnotationType | undefined>();
     const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
     const [dropdownOptions, setDropdownOptions] = React.useState<IComboBoxOption[]>([]);
+    const [submissionStatus, setSubmissionStatus] = React.useState<AnnotationStatus | undefined>();
+
+    const statuses = useSelector(interaction.selectors.getProcessStatuses);
+    const annotationCreationStatus = React.useMemo(
+        () => statuses.find((status) => status.processId === newFieldName),
+        [newFieldName, statuses]
+    );
+    // Check for updates to the annotation submission status
+    React.useEffect(() => {
+        const checkForStatusUpdates = async () => {
+            const currentStatus = annotationCreationStatus?.data?.status;
+            switch (currentStatus) {
+                case ProcessStatus.ERROR:
+                case ProcessStatus.STARTED:
+                case ProcessStatus.PROGRESS:
+                    setSubmissionStatus({
+                        status: currentStatus,
+                        message: annotationCreationStatus?.data?.msg,
+                    });
+                    return;
+                case ProcessStatus.SUCCEEDED:
+                    if (newFieldName && newValues) {
+                        try {
+                            dispatch(
+                                interaction.actions.editFiles({ [newFieldName]: [newValues] })
+                            );
+                        } catch (e) {
+                            setSubmissionStatus({
+                                status: ProcessStatus.ERROR,
+                                message: `Failed to create annotation: ${e}`,
+                            });
+                        } finally {
+                            props?.hasUnsavedChanges(false);
+                            props.onDismiss();
+                        }
+                    }
+                default:
+                    return;
+            }
+        };
+        checkForStatusUpdates();
+    }, [statuses, annotationCreationStatus, dispatch]);
 
     const addDropdownChip = (evt: React.FormEvent) => {
         evt.preventDefault();
@@ -53,15 +117,32 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
         setDropdownOptions(dropdownOptions.filter((opt) => opt !== optionToRemove));
     };
 
-    function onSubmit() {
-        // TO DO: endpoint logic is in progress on a different branch
-        props.onDismiss();
+    function onCreateNewAnnotation() {
+        props?.hasUnsavedChanges(true);
+        setStep(EditStep.EDIT_FILES);
     }
 
-    // TO DO: determine when to submit the new annotation post req
-    function onCreateNewAnnotation() {
-        props?.onUnsavedChanges();
-        setStep(EditStep.EDIT_FILES);
+    function onSubmit() {
+        if (!newFieldName || !newValues) {
+            setSubmissionStatus({
+                status: ProcessStatus.ERROR,
+                message: `Missing ${!newFieldName ? "field name" : "values for file"}`,
+            });
+            return;
+        }
+        const annotation = new Annotation({
+            annotationDisplayName: newFieldName,
+            annotationName: newFieldName,
+            description: newFieldDescription ?? "",
+            type: newFieldDataType ?? AnnotationType.STRING,
+        });
+        // File editing step occurs after dispatch is processed and status is updated
+        dispatch(
+            metadata.actions.createAnnotation(
+                annotation,
+                dropdownOptions.map((opt) => opt.text)
+            )
+        );
     }
 
     return (
@@ -77,6 +158,15 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
             />
             {step === EditStep.CREATE_FIELD && (
                 <>
+                    <TextField
+                        multiline
+                        rows={2}
+                        label="Description"
+                        className={styles.textField}
+                        onChange={(_, newValue) => setNewFieldDescription(newValue || "")}
+                        placeholder="Add a short description of the new field..."
+                        value={newFieldDescription}
+                    />
                     <ComboBox
                         className={styles.comboBox}
                         selectedKey={newFieldDataType || undefined}
@@ -132,17 +222,38 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                 </>
             )}
             {step === EditStep.EDIT_FILES && (
-                <MetadataDetails
-                    fieldType={newFieldDataType}
-                    items={[
-                        {
-                            value: undefined,
-                            fileCount: props.selectedFileCount,
-                        } as ValueCountItem,
-                    ]}
-                    dropdownOptions={dropdownOptions}
-                    onChange={(value) => setNewValues(value)}
-                />
+                <>
+                    {newFieldDescription.trim() && (
+                        <>
+                            <b>Description: </b> {newFieldDescription}
+                        </>
+                    )}
+                    <MetadataDetails
+                        fieldType={newFieldDataType}
+                        items={[
+                            {
+                                value: undefined,
+                                fileCount: props.selectedFileCount,
+                            } as ValueCountItem,
+                        ]}
+                        dropdownOptions={dropdownOptions}
+                        onChange={(value) => setNewValues(value)}
+                    />
+                    {submissionStatus && (
+                        <div
+                            className={classNames(
+                                submissionStatus.status === ProcessStatus.ERROR
+                                    ? styles.errorMessage
+                                    : styles.statusMessage
+                            )}
+                        >
+                            {submissionStatus.status === ProcessStatus.STARTED && (
+                                <Spinner className={styles.spinner} size={SpinnerSize.small} />
+                            )}
+                            {submissionStatus?.message}
+                        </div>
+                    )}
+                </>
             )}
             <div className={styles.footer}>
                 <Stack horizontal>

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -17,7 +17,7 @@ enum EditMetadataPathway {
 interface EditMetadataProps {
     className?: string;
     onDismiss: () => void;
-    onUnsavedChanges: (hasUnsavedChanges: boolean) => void;
+    setHasUnsavedChanges: (hasUnsavedChanges: boolean) => void;
 }
 
 /**
@@ -101,7 +101,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
                 ) : (
                     <NewAnnotationPathway
                         onDismiss={props.onDismiss}
-                        hasUnsavedChanges={(arg) => props.onUnsavedChanges(arg)}
+                        setHasUnsavedChanges={(arg) => props.setHasUnsavedChanges(arg)}
                         selectedFileCount={fileCount}
                     />
                 )}

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -101,7 +101,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
                 ) : (
                     <NewAnnotationPathway
                         onDismiss={props.onDismiss}
-                        onUnsavedChanges={() => props.onUnsavedChanges(true)}
+                        hasUnsavedChanges={(arg) => props.onUnsavedChanges(arg)}
                         selectedFileCount={fileCount}
                     />
                 )}

--- a/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import * as sinon from "sinon";
 
 import Annotation from "../../../entity/Annotation";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import FileDetail from "../../../entity/FileDetail";
 import FileSet from "../../../entity/FileSet";
 import { initialState } from "../../../state";
@@ -18,7 +19,7 @@ describe("<LazilyRenderedRow />", () => {
         annotationDisplayName: "Name",
         annotationName: "file_name",
         description: "name of file",
-        type: "Text",
+        type: AnnotationType.STRING,
     });
 
     function makeItemData() {

--- a/packages/core/components/Modal/EditMetadata/index.tsx
+++ b/packages/core/components/Modal/EditMetadata/index.tsx
@@ -39,7 +39,7 @@ export default function EditMetadata({ onDismiss }: ModalProps) {
                     <EditMetadataForm
                         className={classNames({ [styles.hidden]: showWarning })}
                         onDismiss={onDismissWithWarning}
-                        onUnsavedChanges={setHasUnsavedChanges}
+                        setHasUnsavedChanges={setHasUnsavedChanges}
                     />
                     <div className={classNames({ [styles.hidden]: !showWarning })}>
                         <p className={styles.warning}>

--- a/packages/core/components/Modal/MetadataManifest/test/MetadataManifest.test.tsx
+++ b/packages/core/components/Modal/MetadataManifest/test/MetadataManifest.test.tsx
@@ -14,6 +14,7 @@ import { createSandbox } from "sinon";
 import Modal, { ModalType } from "../..";
 import { FESBaseUrl } from "../../../../constants";
 import Annotation from "../../../../entity/Annotation";
+import { AnnotationType } from "../../../../entity/AnnotationFormatter";
 import FileFilter from "../../../../entity/FileFilter";
 import { initialState, interaction, reduxLogics } from "../../../../state";
 import HttpFileService from "../../../../services/FileService/HttpFileService";
@@ -82,7 +83,7 @@ describe("<MetadataManifest />", () => {
                         annotationDisplayName: "Cell Line",
                         annotationName: "Cell Line",
                         description: "test",
-                        type: "text",
+                        type: AnnotationType.STRING,
                     }),
                 ],
             },
@@ -127,7 +128,7 @@ describe("<MetadataManifest />", () => {
                                 annotationDisplayName: c,
                                 annotationName: c,
                                 description: "test",
-                                type: "text",
+                                type: AnnotationType.STRING,
                             })
                     ),
                 },

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -17,7 +17,7 @@ export interface AnnotationResponse {
     annotationDisplayName: string;
     annotationName: string;
     description: string;
-    type: string | AnnotationType;
+    type: AnnotationType;
     isOpenFileLink?: boolean;
     units?: string;
 }

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -1,7 +1,10 @@
 import { get as _get, sortBy } from "lodash";
 
 import AnnotationName from "./AnnotationName";
-import annotationFormatterFactory, { AnnotationFormatter } from "../AnnotationFormatter";
+import annotationFormatterFactory, {
+    AnnotationFormatter,
+    AnnotationType,
+} from "../AnnotationFormatter";
 import FileDetail from "../FileDetail";
 import { AnnotationValue } from "../../services/AnnotationService";
 
@@ -14,7 +17,7 @@ export interface AnnotationResponse {
     annotationDisplayName: string;
     annotationName: string;
     description: string;
-    type: string;
+    type: string | AnnotationType;
     isOpenFileLink?: boolean;
     units?: string;
 }
@@ -60,7 +63,7 @@ export default class Annotation {
         return this.annotation.annotationName;
     }
 
-    public get type(): string {
+    public get type(): string | AnnotationType {
         return this.annotation.type;
     }
 

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -23,7 +23,7 @@ export interface AnnotationResponse {
 }
 
 /**
- * TODO: MMS queries return a different JSON structure than FES
+ * MMS queries return a different JSON structure than FES
  */
 export interface AnnotationResponseMms {
     annotationId: number;

--- a/packages/core/entity/Annotation/index.ts
+++ b/packages/core/entity/Annotation/index.ts
@@ -23,6 +23,16 @@ export interface AnnotationResponse {
 }
 
 /**
+ * TODO: MMS queries return a different JSON structure than FES
+ */
+export interface AnnotationResponseMms {
+    annotationId: number;
+    annotationTypeId: number;
+    description: "string";
+    name: string;
+}
+
+/**
  * Representation of an annotation available for filtering, grouping, or sorting files from FMS.
  */
 export default class Annotation {

--- a/packages/core/entity/Annotation/mocks.ts
+++ b/packages/core/entity/Annotation/mocks.ts
@@ -1,38 +1,40 @@
+import { AnnotationType } from "../AnnotationFormatter";
+
 export const annotationsJson = [
     {
         annotationDisplayName: "Date created",
         annotationName: "date_created",
         description: "Date and time file was created",
-        type: "Date/Time",
+        type: AnnotationType.DATETIME,
     },
     {
         annotationDisplayName: "Cell line",
         annotationName: "cell_line",
         description: "AICS cell line",
-        type: "Text",
+        type: AnnotationType.STRING,
     },
     {
         annotationDisplayName: "Cells are dead",
         annotationName: "cell_dead",
         description: "Does this field contain dead cells",
-        type: "Yes/No",
+        type: AnnotationType.BOOLEAN,
     },
     {
         annotationDisplayName: "Is matrigel hard?",
         annotationName: "matrigel_hardened",
         description: "Whether or not matrigel is hard.",
-        type: "Yes/No",
+        type: AnnotationType.BOOLEAN,
     },
     {
         annotationDisplayName: "Objective",
         annotationName: "objective",
         description: "Imaging objective",
-        type: "Number",
+        type: AnnotationType.NUMBER,
     },
     {
         annotationName: "Local File Path",
         annotationDisplayName: "Local File Path",
         description: "Path to file in on-premises storage.",
-        type: "Text",
+        type: AnnotationType.STRING,
     },
 ];

--- a/packages/core/entity/AnnotationFormatter/index.ts
+++ b/packages/core/entity/AnnotationFormatter/index.ts
@@ -15,6 +15,18 @@ export enum AnnotationType {
     DROPDOWN = "Dropdown",
 }
 
+// ID table source via Labkey server: executeQuery.view?schemaName=filemetadata&query.queryName=AnnotationType
+export const AnnotationTypeIdMap = {
+    [AnnotationType.STRING]: 1,
+    [AnnotationType.NUMBER]: 2,
+    [AnnotationType.BOOLEAN]: 3,
+    [AnnotationType.DATETIME]: 4,
+    [AnnotationType.DROPDOWN]: 5,
+    // [AnnotationType.LOOKUP]: 6, // Not currently supported
+    [AnnotationType.DATE]: 7,
+    [AnnotationType.DURATION]: 8,
+};
+
 export interface AnnotationFormatter {
     displayValue(value: any, unit?: string): string;
     valueOf(value: any): string | number | boolean;

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -1,4 +1,4 @@
-import { isNil, noop, uniq } from "lodash";
+import { isNil, uniq } from "lodash";
 
 import AnnotationService, { AnnotationValue } from "..";
 import DatabaseService from "../../DatabaseService";
@@ -141,10 +141,12 @@ export default class DatabaseAnnotationService implements AnnotationService {
             .filter((annotation) => !annotationSet.has(annotation));
     }
 
-    public async createAnnotation(
-        _annotation: Annotation,
-        _annotationOptions?: string[]
-    ): Promise<any> {
-        return noop;
+    public async createAnnotation(annotation: Annotation): Promise<any> {
+        const tableName = this.dataSourceNames.sort().join(", ");
+        return await this.databaseService.addNewColumn(
+            tableName,
+            annotation.name,
+            annotation?.description
+        );
     }
 }

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -1,4 +1,4 @@
-import { isNil, uniq } from "lodash";
+import { isNil, noop, uniq } from "lodash";
 
 import AnnotationService, { AnnotationValue } from "..";
 import DatabaseService from "../../DatabaseService";
@@ -139,5 +139,12 @@ export default class DatabaseAnnotationService implements AnnotationService {
                 return annotations;
             }, [] as string[])
             .filter((annotation) => !annotationSet.has(annotation));
+    }
+
+    public async createAnnotation(
+        _annotation: Annotation,
+        _annotationOptions?: string[]
+    ): Promise<any> {
+        return noop;
     }
 }

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -141,12 +141,12 @@ export default class DatabaseAnnotationService implements AnnotationService {
             .filter((annotation) => !annotationSet.has(annotation));
     }
 
-    public createAnnotation(annotation: Annotation): Promise<any> {
-        const tableName = this.dataSourceNames.sort().join(", ");
+    public createAnnotation(annotation: Annotation): Promise<void> {
+        const tableName = this.dataSourceNames.sort().join(DatabaseService.LIST_DELIMITER);
         return this.databaseService.addNewColumn(
             tableName,
             annotation.name,
-            annotation?.description
+            annotation.description
         );
     }
 }

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -141,9 +141,9 @@ export default class DatabaseAnnotationService implements AnnotationService {
             .filter((annotation) => !annotationSet.has(annotation));
     }
 
-    public async createAnnotation(annotation: Annotation): Promise<any> {
+    public createAnnotation(annotation: Annotation): Promise<any> {
         const tableName = this.dataSourceNames.sort().join(", ");
-        return await this.databaseService.addNewColumn(
+        return this.databaseService.addNewColumn(
             tableName,
             annotation.name,
             annotation?.description

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -129,7 +129,7 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
         annotationOptions: string[] = []
     ): Promise<AnnotationResponseMms[]> {
         const requestUrl = `${this.metadataManagementServiceBaseURl}/${HttpAnnotationService.BASE_MMS_ANNOTATION_URL}`;
-        const annotationType = (annotation.type as AnnotationType) || AnnotationType.STRING;
+        const annotationType = annotation.type as AnnotationType;
         const requestBody = {
             annotationTypeId: AnnotationTypeIdMap[annotationType],
             annotationOptions,

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -2,7 +2,7 @@ import { map } from "lodash";
 
 import AnnotationService, { AnnotationValue } from "..";
 import HttpServiceBase from "../../HttpServiceBase";
-import Annotation, { AnnotationResponse } from "../../../entity/Annotation";
+import Annotation, { AnnotationResponse, AnnotationResponseMms } from "../../../entity/Annotation";
 import { AnnotationType, AnnotationTypeIdMap } from "../../../entity/AnnotationFormatter";
 import FileFilter from "../../../entity/FileFilter";
 import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../../constants";
@@ -127,7 +127,7 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
     public async createAnnotation(
         annotation: Annotation,
         annotationOptions: string[] = []
-    ): Promise<string[]> {
+    ): Promise<AnnotationResponseMms[]> {
         const requestUrl = `${this.metadataManagementServiceBaseURl}/${HttpAnnotationService.BASE_MMS_ANNOTATION_URL}`;
         const annotationType = (annotation.type as AnnotationType) || AnnotationType.STRING;
         const requestBody = {
@@ -136,7 +136,10 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
             description: annotation.description,
             name: annotation.name,
         };
-        const response = await this.post<string>(requestUrl, JSON.stringify(requestBody));
+        const response = await this.post<AnnotationResponseMms>(
+            requestUrl,
+            JSON.stringify(requestBody)
+        );
         return response.data;
     }
 }

--- a/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/HttpAnnotationService/index.ts
@@ -3,6 +3,7 @@ import { map } from "lodash";
 import AnnotationService, { AnnotationValue } from "..";
 import HttpServiceBase from "../../HttpServiceBase";
 import Annotation, { AnnotationResponse } from "../../../entity/Annotation";
+import { AnnotationType, AnnotationTypeIdMap } from "../../../entity/AnnotationFormatter";
 import FileFilter from "../../../entity/FileFilter";
 import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../../constants";
 
@@ -25,6 +26,7 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
     public static readonly BASE_ANNOTATION_HIERARCHY_ROOT_URL = `${HttpAnnotationService.BASE_ANNOTATION_URL}/hierarchy/root`;
     public static readonly BASE_ANNOTATION_HIERARCHY_UNDER_PATH_URL = `${HttpAnnotationService.BASE_ANNOTATION_URL}/hierarchy/under-path`;
     public static readonly BASE_AVAILABLE_ANNOTATIONS_UNDER_HIERARCHY = `${HttpAnnotationService.BASE_ANNOTATION_URL}/hierarchy/available`;
+    public static readonly BASE_MMS_ANNOTATION_URL = `metadata-management-service/1.0/annotation/`;
 
     /**
      * Fetch all annotations.
@@ -115,5 +117,26 @@ export default class HttpAnnotationService extends HttpServiceBase implements An
 
     private buildQueryParams(param: QueryParam, values: string[]): string {
         return values.map((value) => `${param}=${value}`).join("&");
+    }
+
+    /**
+     * Creates a new annotation via the metadata-management-service
+     * @param annotation The new annotation to create
+     * @param annotationOptions If not empty, pre-set options for annotations of type Dropdown
+     */
+    public async createAnnotation(
+        annotation: Annotation,
+        annotationOptions: string[] = []
+    ): Promise<string[]> {
+        const requestUrl = `${this.metadataManagementServiceBaseURl}/${HttpAnnotationService.BASE_MMS_ANNOTATION_URL}`;
+        const annotationType = (annotation.type as AnnotationType) || AnnotationType.STRING;
+        const requestBody = {
+            annotationTypeId: AnnotationTypeIdMap[annotationType],
+            annotationOptions,
+            description: annotation.description,
+            name: annotation.name,
+        };
+        const response = await this.post<string>(requestUrl, JSON.stringify(requestBody));
+        return response.data;
     }
 }

--- a/packages/core/services/AnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/index.ts
@@ -4,6 +4,7 @@ import FileFilter from "../../entity/FileFilter";
 export type AnnotationValue = string | number | boolean | Date;
 
 export default interface AnnotationService {
+    createAnnotation(annotation: Annotation, annotationOptions?: string[]): Promise<string[]>;
     fetchValues(annotation: string): Promise<AnnotationValue[]>;
     fetchAnnotations(): Promise<Annotation[]>;
     fetchRootHierarchyValues(hierarchy: string[], filters: FileFilter[]): Promise<string[]>;

--- a/packages/core/services/AnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/index.ts
@@ -7,7 +7,7 @@ export default interface AnnotationService {
     createAnnotation(
         annotation: Annotation,
         annotationOptions?: string[]
-    ): Promise<AnnotationResponseMms[]>;
+    ): Promise<AnnotationResponseMms[] | void>;
     fetchValues(annotation: string): Promise<AnnotationValue[]>;
     fetchAnnotations(): Promise<Annotation[]>;
     fetchRootHierarchyValues(hierarchy: string[], filters: FileFilter[]): Promise<string[]>;

--- a/packages/core/services/AnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/index.ts
@@ -1,10 +1,13 @@
-import Annotation from "../../entity/Annotation";
+import Annotation, { AnnotationResponseMms } from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
 
 export type AnnotationValue = string | number | boolean | Date;
 
 export default interface AnnotationService {
-    createAnnotation(annotation: Annotation, annotationOptions?: string[]): Promise<string[]>;
+    createAnnotation(
+        annotation: Annotation,
+        annotationOptions?: string[]
+    ): Promise<AnnotationResponseMms[]>;
     fetchValues(annotation: string): Promise<AnnotationValue[]>;
     fetchAnnotations(): Promise<Annotation[]>;
     fetchRootHierarchyValues(hierarchy: string[], filters: FileFilter[]): Promise<string[]>;

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -529,4 +529,23 @@ export default abstract class DatabaseService {
             throw err;
         }
     }
+
+    public async addNewColumn(datasourceName: string, columnName: string, description?: string) {
+        try {
+            await this.execute(
+                `ALTER TABLE "${datasourceName}" ADD COLUMN "${columnName}" VARCHAR;`
+            );
+
+            // Cache is now invalid since we added a column
+            this.dataSourceToAnnotationsMap.delete(datasourceName);
+
+            if (description?.trim() && this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+                await this
+                    .execute(`INSERT INTO "${this.SOURCE_METADATA_TABLE}" ("Column Name", "Description")
+                        VALUES ('${columnName}', '${description}');`);
+            }
+        } catch (err) {
+            throw err;
+        }
+    }
 }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -55,7 +55,7 @@ export default abstract class DatabaseService {
 
     public abstract execute(_sql: string): Promise<void>;
 
-    private static columnTypeToAnnotationType(columnType: string): string {
+    private static columnTypeToAnnotationType(columnType: string): AnnotationType {
         switch (columnType) {
             case "INTEGER":
             case "BIGINT":
@@ -456,7 +456,7 @@ export default abstract class DatabaseService {
                             annotationNameToTypeMap[row["column_name"]] ===
                             DatabaseService.OPEN_FILE_LINK_TYPE
                                 ? AnnotationType.STRING
-                                : annotationNameToTypeMap[row["column_name"]] ||
+                                : (annotationNameToTypeMap[row["column_name"]] as AnnotationType) ||
                                   DatabaseService.columnTypeToAnnotationType(row["data_type"]),
                     })
             );

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -530,7 +530,11 @@ export default abstract class DatabaseService {
         }
     }
 
-    public async addNewColumn(datasourceName: string, columnName: string, description?: string) {
+    public async addNewColumn(
+        datasourceName: string,
+        columnName: string,
+        description?: string
+    ): Promise<void> {
         await this.execute(`ALTER TABLE "${datasourceName}" ADD COLUMN "${columnName}" VARCHAR;`);
 
         // Cache is now invalid since we added a column

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -531,21 +531,15 @@ export default abstract class DatabaseService {
     }
 
     public async addNewColumn(datasourceName: string, columnName: string, description?: string) {
-        try {
-            await this.execute(
-                `ALTER TABLE "${datasourceName}" ADD COLUMN "${columnName}" VARCHAR;`
-            );
+        await this.execute(`ALTER TABLE "${datasourceName}" ADD COLUMN "${columnName}" VARCHAR;`);
 
-            // Cache is now invalid since we added a column
-            this.dataSourceToAnnotationsMap.delete(datasourceName);
+        // Cache is now invalid since we added a column
+        this.dataSourceToAnnotationsMap.delete(datasourceName);
 
-            if (description?.trim() && this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
-                await this
-                    .execute(`INSERT INTO "${this.SOURCE_METADATA_TABLE}" ("Column Name", "Description")
-                        VALUES ('${columnName}', '${description}');`);
-            }
-        } catch (err) {
-            throw err;
+        if (description?.trim() && this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+            await this
+                .execute(`INSERT INTO "${this.SOURCE_METADATA_TABLE}" ("Column Name", "Description")
+                    VALUES ('${columnName}', '${description}');`);
         }
     }
 }

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -575,18 +575,6 @@ const editFilesLogic = createLogic({
                                     resolve();
                                 })
                                 .catch((err) => reject(err));
-                            // try {
-                            //     await fileService.editFile(
-                            //         fileId,
-                            //         annotations,
-                            //         annotationNameToAnnotationMap
-                            //     );
-                            //     totalFileEdited += 1;
-                            //     onProgress();
-                            //     resolve();
-                            // } catch (err) {
-                            //     reject(err);
-                            // }
                         })
                 );
 

--- a/packages/core/state/interaction/test/logics.test.ts
+++ b/packages/core/state/interaction/test/logics.test.ts
@@ -707,14 +707,14 @@ describe("Interaction logics", () => {
                 annotationDisplayName: AnnotationName.KIND,
                 annotationName: AnnotationName.KIND,
                 description: "",
-                type: "Text",
+                type: AnnotationType.STRING,
                 annotationId: 0,
             }),
             new Annotation({
                 annotationDisplayName: "Cell Line",
                 annotationName: "Cell Line",
                 description: "",
-                type: "Text",
+                type: AnnotationType.STRING,
                 annotationId: 1,
             }),
         ];

--- a/packages/core/state/metadata/actions.ts
+++ b/packages/core/state/metadata/actions.ts
@@ -1,6 +1,6 @@
 import { makeConstant } from "@aics/redux-utils";
 
-import Annotation from "../../entity/Annotation";
+import Annotation, { AnnotationResponseMms } from "../../entity/Annotation";
 import { DataSource } from "../../services/DataSourceService";
 
 const STATE_BRANCH_NAME = "metadata";
@@ -148,5 +148,25 @@ export function receiveDatasetManifest(name: string, uri: string): ReceiveDatase
     return {
         payload: { name, uri },
         type: RECEIVE_DATASET_MANIFEST,
+    };
+}
+
+/**
+ * STORE_NEW_ANNOTATION
+ * Temporarily cache a newly created annotation before it is ingested to FES
+ */
+export const STORE_NEW_ANNOTATION = makeConstant(STATE_BRANCH_NAME, "store-new-annotation");
+
+export interface StoreNewAnnotationAction {
+    payload: {
+        annotation: AnnotationResponseMms;
+    };
+    type: string;
+}
+
+export function storeNewAnnotation(annotation: AnnotationResponseMms): StoreNewAnnotationAction {
+    return {
+        payload: { annotation },
+        type: STORE_NEW_ANNOTATION,
     };
 }

--- a/packages/core/state/metadata/actions.ts
+++ b/packages/core/state/metadata/actions.ts
@@ -43,6 +43,31 @@ export function requestAnnotations(): RequestAnnotationAction {
 }
 
 /**
+ * CREATE_ANNOTATION
+ *
+ * Intention to create a new annotation in the data service that will become available for grouping, filtering, and sorting files.
+ */
+export const CREATE_ANNOTATION = makeConstant(STATE_BRANCH_NAME, "create-annotation");
+
+export interface CreateAnnotationAction {
+    payload: {
+        annotation: Annotation;
+        annotationOptions?: string[];
+    };
+    type: string;
+}
+
+export function createAnnotation(
+    annotation: Annotation,
+    annotationOptions?: string[]
+): CreateAnnotationAction {
+    return {
+        payload: { annotation, annotationOptions },
+        type: CREATE_ANNOTATION,
+    };
+}
+
+/**
  * RECEIVE_DATA_SOURCES
  *
  * Intention to store listing of data sources returned from data service. These are sets of file metadata

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -135,7 +135,8 @@ const createNewAnnotationLogic = createLogic({
             annotationService.setHttpClient(httpClient);
         }
 
-        return new Promise<AnnotationResponseMms[]>(async (resolve, reject) => {
+        // HTTP returns the annotation, DB does not
+        await new Promise<AnnotationResponseMms[] | void>((resolve, reject) => {
             annotationService
                 .createAnnotation(annotation, annotationOptions)
                 .then((res) => {

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -236,7 +236,7 @@ const storeNewAnnotationLogic = createLogic({
             annotationDisplayName: annotation.name,
             annotationId: annotation.annotationId,
             description: annotation.description,
-            type,
+            type: type as AnnotationType,
         });
         dispatch(receiveAnnotations([...annotations, newMmsAnnotation]));
         done();

--- a/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
+++ b/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import { PersistedConfigKeys } from "../../../../core/services";
+import { AnnotationType } from "../../../../core/entity/AnnotationFormatter";
 import { Environment, RUN_IN_RENDERER } from "../../util/constants";
 import PersistentConfigServiceElectron from "../PersistentConfigServiceElectron";
 
@@ -127,7 +128,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                         annotationDisplayName: "Foo",
                         annotationName: "foo",
                         description: "foo-long",
-                        type: "string",
+                        type: AnnotationType.STRING,
                         units: "string",
                     },
                 ],


### PR DESCRIPTION
This adds the redux & endpoint logic for creating new annotations (via MMS for FMS and in DuckDB for non-FMS sources), with some supporting UI modifications.

There are a couple tricky logistical choices here that I am NOT attached to and very open to changing.

### 1. Reporting status of network call
We need to wait to send the file edit request until after the annotation creation request is successfully completed. We can't return the results of dispatches directly (e.g., can't pass the response from createNewAnnotationLogic directly to NewAnnotationPathway) since we aren't using thunk (and can't with our current dependencies)
Instead, we report the status from dispatch to our store. The component watches the store property, and then sends the file edit request when it sees success.

### 2. Making the new annotation available for file editing
Our editing logic checks if annotations exist before allowing the edit to go through, but it checks FES, not MMS. FES will not register/report a new MMS annotation until a file exists that uses that annotation.
I'm currently getting around this by temporarily adding the results of the annotation post to our store. This is messy for a few reasons, but one is that the annotation response from MMS looks * slightly * different than the response from FES and needs to be converted.

### 3. Annotation types
FMS doesn't have an endpoint for requesting the full list of annotation types & their IDs, so currently using a hardcoded map.

## Screenshots of UI changes
Added a description text input
<img width="381" alt="Screenshot 2025-02-06 at 11 24 15 AM" src="https://github.com/user-attachments/assets/8662ef9b-6803-4f50-856c-8e7dc294a57c" />

Messages to report status of annotation creation
<img width="400" alt="image" src="https://github.com/user-attachments/assets/eb2ea0ce-fd5f-4dc0-bb1f-245c038ed718" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4ad69f68-d6fa-4082-a7c8-0781f9894550" />

resolves #371 