### PR TITLE
bugfix/cache-modal-performance

### DIFF
--- a/packages/core/components/Modal/CopyFileManifest/index.tsx
+++ b/packages/core/components/Modal/CopyFileManifest/index.tsx
@@ -90,6 +90,7 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
 
     const [fileDetails, setFileDetails] = React.useState<FileDetail[]>([]);
     const [loading, setLoading] = React.useState<boolean>(true);
+    const [error, setError] = React.useState<string | null>(null);
 
     React.useEffect(() => {
         async function fetchFiles() {
@@ -97,7 +98,8 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                 const details = await fileSelection.fetchAllDetails();
                 setFileDetails(details);
             } catch (err: any) {
-                throw new Error(err.message || "Error fetching file details.");
+                console.error("Error fetching file details:", err);
+                setError(err.message || "Error fetching file details.");
             } finally {
                 setLoading(false);
             }
@@ -137,7 +139,13 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                             <p>Loading file details...</p>
                         </div>
                     )}
-                    {!loading && (
+                    {error && (
+                        <div className={styles.errorContainer}>
+                            <h3>Error</h3>
+                            <p>{error}</p>
+                        </div>
+                    )}
+                    {!loading && !error && (
                         <>
                             <p className={styles.note}>
                                 Files copied to the local storage (VAST) are stored with a 180-day
@@ -170,7 +178,7 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                     />
                     <PrimaryButton
                         className={styles.confirmButton}
-                        disabled={loading}
+                        disabled={loading || !!error}
                         onClick={onMove}
                         text="CONFIRM"
                         title=""

--- a/packages/core/components/Modal/CopyFileManifest/index.tsx
+++ b/packages/core/components/Modal/CopyFileManifest/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import filesize from "filesize";
+import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { ModalProps } from "..";
@@ -39,15 +39,9 @@ function FileTable({ files, title }: { files: FileDetail[]; title: string }) {
     };
 
     const calculateTotalSize = (files: FileDetail[]) => {
-        if (files.length === 0) return "";
         const totalBytes = files.reduce((acc, file) => acc + (file.size || 0), 0);
         return totalBytes ? filesize(totalBytes) : "Calculating...";
     };
-
-    // Check for bad files
-    if (files.length === 0 || files.some((file) => !file)) {
-        throw new Error("No file details available or invalid file details encountered.");
-    }
 
     return (
         <div className={styles.tableContainer}>
@@ -94,56 +88,21 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
         FileSelection.selectionsAreEqual
     );
 
-    // State for file details, loading status, and errors.
     const [fileDetails, setFileDetails] = React.useState<FileDetail[]>([]);
     const [loading, setLoading] = React.useState<boolean>(true);
-    const [error, setError] = React.useState<string | null>(null);
 
-    // Progressive fetching of file details.
     React.useEffect(() => {
-        async function fetchDetailsIncrementally() {
+        async function fetchFiles() {
             try {
-                // Group file ranges by file set.
-                const fileRangesByFileSets = fileSelection.groupByFileSet();
-
-                // Array to hold promises that resolve to FileDetail[]
-                const promises: Promise<FileDetail[]>[] = [];
-
-                // For each file range, fetch details and update state as soon as they're available.
-                fileRangesByFileSets.forEach((ranges, fileSet) => {
-                    ranges.forEach((range) => {
-                        const promise: Promise<FileDetail[]> = fileSet
-                            .fetchFileRange(range.from, range.to)
-                            .then((details) => {
-                                details.forEach((file) => {
-                                    if (!file.id) {
-                                        throw new Error("File ID is not defined");
-                                    }
-                                });
-                                setFileDetails((prev) => [...prev, ...details]);
-                                return details;
-                            })
-                            .catch((err) => {
-                                throw new Error(
-                                    `Error fetching files with range ${range.from}-${range.to}: ${err.message}`
-                                );
-                            });
-                        promises.push(promise);
-                    });
-                });
-
-                // Wait for all the fetch promises to settle.
-                await Promise.allSettled(promises);
+                const details = await fileSelection.fetchAllDetails();
+                setFileDetails(details);
             } catch (err: any) {
-                setError(
-                    err.message ||
-                        "An error occurred while fetching file details. Please try again. If this issue persists try a smaller query."
-                );
+                throw new Error(err.message || "Error fetching file details.");
             } finally {
                 setLoading(false);
             }
         }
-        fetchDetailsIncrementally();
+        fetchFiles();
     }, [fileSelection]);
 
     const onMove = () => {
@@ -178,13 +137,7 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                             <p>Loading file details...</p>
                         </div>
                     )}
-                    {error && (
-                        <div className={styles.errorContainer}>
-                            <h3>Error</h3>
-                            <p>{error}</p>
-                        </div>
-                    )}
-                    {!loading && !error && (
+                    {!loading && (
                         <>
                             <p className={styles.note}>
                                 Files copied to the local storage (VAST) are stored with a 180-day
@@ -217,7 +170,7 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                     />
                     <PrimaryButton
                         className={styles.confirmButton}
-                        disabled={loading || !!error || fileDetails.length === 0}
+                        disabled={loading || fileDetails.length === 0}
                         onClick={onMove}
                         text="CONFIRM"
                         title=""

--- a/packages/core/components/Modal/CopyFileManifest/index.tsx
+++ b/packages/core/components/Modal/CopyFileManifest/index.tsx
@@ -59,8 +59,8 @@ function FileTable({ files, title }: { files: FileDetail[]; title: string }) {
                             </tr>
                         </thead>
                         <tbody>
-                            {files.map((file, index) => (
-                                <tr key={file.id || index}>
+                            {files.map((file) => (
+                                <tr key={file.id}>
                                     <td>{clipFileName(file.name)}</td>
                                     <td>{filesize(file.size || 0)}</td>
                                 </tr>
@@ -170,7 +170,7 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                     />
                     <PrimaryButton
                         className={styles.confirmButton}
-                        disabled={loading || fileDetails.length === 0}
+                        disabled={loading}
                         onClick={onMove}
                         text="CONFIRM"
                         title=""

--- a/packages/core/entity/FileSelection/index.ts
+++ b/packages/core/entity/FileSelection/index.ts
@@ -210,27 +210,13 @@ export default class FileSelection {
      * Fetch metadata for all items selected.
      */
     public async fetchAllDetails(): Promise<FileDetail[]> {
-        const fileRangesByFileSets = this.groupByFileSet();
-        // Load file metadata for every file selected (however do to some performance enhancements
-        // the fetch will overshoot)
         const fileRangePromises: Promise<FileDetail[]>[] = [];
-        fileRangesByFileSets.forEach((ranges, fileSet) => {
+        this.groupByFileSet().forEach((ranges, fileSet) => {
             ranges.forEach((range) => {
                 fileRangePromises.push(fileSet.fetchFileRange(range.from, range.to));
             });
         });
-        await Promise.all(fileRangePromises);
-
-        // Collect the desired files from the fetched files
-        const files: FileDetail[] = [];
-        fileRangesByFileSets.forEach((ranges, fileSet) => {
-            ranges.forEach((range) => {
-                for (let i = range.from; i <= range.to; i++) {
-                    files.push(fileSet.getFileByIndex(i) as FileDetail);
-                }
-            });
-        });
-        return files;
+        return (await Promise.all(fileRangePromises)).flat();
     }
 
     /**

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -143,7 +143,7 @@ describe("FileSet", () => {
 
         it("returns slices of the file list represented by the FileSet, specified by index position", async () => {
             const fileService = new HttpFileService();
-            sandbox.replace(fileService, "getFiles", () => Promise.resolve(files.slice(1, 4)));
+            sandbox.replace(fileService, "getFiles", () => Promise.resolve(files.slice(0, 4)));
             const fileSet = new FileSet({ fileService });
             expect(await fileSet.fetchFileRange(1, 3)).to.deep.equal(files.slice(1, 4)); // Array.prototype.slice is exclusive of end bound
         });

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -145,7 +145,7 @@ describe("FileSet", () => {
             const fileService = new HttpFileService();
             sandbox.replace(fileService, "getFiles", () => Promise.resolve(files.slice(0, 4)));
             const fileSet = new FileSet({ fileService });
-            expect(await fileSet.fetchFileRange(1, 3)).to.deep.equal(files.slice(1, 4)); // Array.prototype.slice is exclusive of end bound
+            expect(await fileSet.fetchFileRange(1, 3)).to.deep.equal(files.slice(1, 4));
         });
 
         it("turns indicies for requested data into a properly formed pagination query", async () => {


### PR DESCRIPTION
### Description 

The purpose of this PR is to resolve #409 and make the copy to local cache performant for 10,000+ files. This pr add a chunked response, waiting state and error handling around this process to make it smoother for users.


### Testing
I tested this with the startup query date range that BFF has (with about 7,500 files) with no issues. Still investigating larger selections.