### PR TITLE
bugfix/modal-button-location

### DIFF
--- a/packages/core/components/Modal/BaseModal/BaseModal.module.css
+++ b/packages/core/components/Modal/BaseModal/BaseModal.module.css
@@ -42,7 +42,7 @@
 .footer {
     position: sticky;
     bottom: 0;
-    padding-top: 1em;
+    padding-top: 20px;
     z-index: 1000; /* float on top of everything*/
 
     /* flex parent */

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -32,7 +32,6 @@ export default function BaseModal(props: BaseModalProps) {
             onDismiss={onDismiss}
             containerClassName={styles.container}
             dragOptions={DRAG_OPTIONS}
-            scrollableContentClassName={styles.scrollableContainer}
             titleAriaId={titleId}
             overlay={{ className: styles.overlay }}
         >
@@ -44,7 +43,7 @@ export default function BaseModal(props: BaseModalProps) {
                 ) : null}
                 <TertiaryButton iconName="Cancel" onClick={onDismiss} title="" />
             </div>
-            {body}
+            <div className={styles.scrollableContent}>{body}</div>
             <div className={styles.footer}>{footer}</div>
         </Modal>
     );

--- a/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
+++ b/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
@@ -1,5 +1,8 @@
 .body-container {
+    padding: 0 1em 0 0;
     position: relative;
+    max-height: 55vh;
+    overflow-y: auto;
 }
 
 .note {

--- a/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
+++ b/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
@@ -1,3 +1,7 @@
+:root {
+    --file-size-column-width: 7em;
+}
+
 .modal-container {
     width: 100%;
     max-width: 40vw;
@@ -7,7 +11,7 @@
 
 .body-container {
     width: 100%;
-    padding: 0 1em 0 0;
+    padding: 0 0 0 0;
     position: relative;
     max-height: 55vh;
     overflow-y: hidden;
@@ -84,14 +88,14 @@
 
 .file-table th:last-child,
 .file-table td:last-child {
-    width: 10em;
-    min-width: 10em;
-    max-width: 10em;
+    width: var(--file-size-column-width);
+    min-width: var(--file-size-column-width);
+    max-width: var(--file-size-column-width);
 }
 
 .file-table th:first-child,
 .file-table td:first-child {
-    width: calc(100% - 10em);
+    width: calc(100% - var(--file-size-column-width));
 }
 
 

--- a/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
+++ b/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
@@ -1,8 +1,17 @@
+.modal-container {
+    width: 100%;
+    max-width: 40vw;
+    margin: 0 auto;
+    box-sizing: border-box;
+}
+
 .body-container {
+    width: 100%;
     padding: 0 1em 0 0;
     position: relative;
     max-height: 55vh;
     overflow-y: hidden;
+    box-sizing: border-box;
 }
 
 .note {
@@ -11,6 +20,7 @@
 }
 
 .table-container {
+    width: 100%;
     margin-bottom: 0;
 }
 
@@ -21,13 +31,17 @@
 }
 
 .table-wrapper {
+    width: 100%;
     position: relative;
+    overflow-x: hidden;
 }
 
 .file-table-container {
+    width: 100%;
     min-height: 45px;
     max-height: 15vh;
     overflow-y: auto;
+    overflow-x: hidden;
     background-color: var(--secondary-background-color);
     position: relative;
     z-index: 1;
@@ -46,6 +60,7 @@
 
 .file-table {
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     position: relative;
     z-index: 1;
@@ -67,9 +82,23 @@
     z-index: 3;
 }
 
+.file-table th:last-child,
+.file-table td:last-child {
+    width: 10em;
+    min-width: 10em;
+    max-width: 10em;
+}
+
+.file-table th:first-child,
+.file-table td:first-child {
+    width: calc(100% - 10em);
+}
+
+
 .file-table td:first-child {
     border-right: 1px solid var(--border-color);
 }
+
 
 .footer-buttons {
     display: flex;
@@ -94,4 +123,23 @@
 
 .file-count {
     text-align: right;
+}
+
+.fileName {
+    width: 100%;
+    display: flex;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.fileNameBase {
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fileNameExtension {
+    flex-shrink: 0;
+    margin-left: 0;
 }

--- a/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
+++ b/packages/core/components/Modal/CopyFileManifest/CopyFileManifest.module.css
@@ -2,7 +2,7 @@
     padding: 0 1em 0 0;
     position: relative;
     max-height: 55vh;
-    overflow-y: auto;
+    overflow-y: hidden;
 }
 
 .note {
@@ -11,7 +11,7 @@
 }
 
 .table-container {
-    margin-bottom: 2em;
+    margin-bottom: 0;
 }
 
 .table-title {
@@ -25,7 +25,8 @@
 }
 
 .file-table-container {
-    max-height: 300px;
+    min-height: 45px;
+    max-height: 15vh;
     overflow-y: auto;
     background-color: var(--secondary-background-color);
     position: relative;

--- a/packages/core/components/Modal/CopyFileManifest/index.tsx
+++ b/packages/core/components/Modal/CopyFileManifest/index.tsx
@@ -11,6 +11,19 @@ import { interaction, selection } from "../../../state";
 
 import styles from "./CopyFileManifest.module.css";
 
+function ResponsiveFileName({ fileName }: { fileName: string }) {
+    const lastDot = fileName.lastIndexOf(".");
+    const base = lastDot > 0 ? fileName.slice(0, lastDot) : fileName;
+    const extension = lastDot > 0 ? fileName.slice(lastDot) : "";
+
+    return (
+        <div className={styles.fileName}>
+            <span className={styles.fileNameBase}>{base}</span>
+            {extension && <span className={styles.fileNameExtension}>{extension}</span>}
+        </div>
+    );
+}
+
 /**
  * Table component for rendering file details.
  */
@@ -30,13 +43,6 @@ function FileTable({ files, title }: { files: FileDetail[]; title: string }) {
         window.addEventListener("resize", checkScroll);
         return () => window.removeEventListener("resize", checkScroll);
     }, [files]);
-
-    const clipFileName = (filename: string) => {
-        if (filename.length > 20) {
-            return filename.slice(0, 9) + "..." + filename.slice(-8);
-        }
-        return filename;
-    };
 
     const calculateTotalSize = (files: FileDetail[]) => {
         const totalBytes = files.reduce((acc, file) => acc + (file.size || 0), 0);
@@ -61,7 +67,9 @@ function FileTable({ files, title }: { files: FileDetail[]; title: string }) {
                         <tbody>
                             {files.map((file) => (
                                 <tr key={file.id}>
-                                    <td>{clipFileName(file.name)}</td>
+                                    <td>
+                                        <ResponsiveFileName fileName={file.name} />
+                                    </td>
                                     <td>{filesize(file.size || 0)}</td>
                                 </tr>
                             ))}

--- a/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
+++ b/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
@@ -6,7 +6,7 @@
     padding: 0 1em 0 0;
     position: relative;
     max-height: 55vh;
-    overflow-y: auto;
+    overflow-y: hidden;
     overflow-x: hidden;
 }
 
@@ -17,4 +17,6 @@
 
 .list-picker {
     padding: 0 0 0 0;
+    min-height: 45px;
+    max-height: 40vh;
 }

--- a/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
+++ b/packages/core/components/Modal/MetadataManifest/MetadataManifest.module.css
@@ -1,3 +1,20 @@
 .download-button {
     width: 135px;
 }
+
+.body-container {
+    padding: 0 1em 0 0;
+    position: relative;
+    max-height: 55vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.footer-buttons {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.list-picker {
+    padding: 0 0 0 0;
+}

--- a/packages/core/components/Modal/MetadataManifest/index.tsx
+++ b/packages/core/components/Modal/MetadataManifest/index.tsx
@@ -40,7 +40,7 @@ export default function MetadataManifest({ onDismiss }: ModalProps) {
     };
 
     const body = (
-        <>
+        <div className={styles.bodyContainer}>
             <p>
                 Select which annotations you would like included as columns in the downloaded file
             </p>
@@ -48,22 +48,25 @@ export default function MetadataManifest({ onDismiss }: ModalProps) {
                 hasSelectAllCapability
                 selections={selectedAnnotations}
                 setSelections={setSelectedAnnotations}
+                className={styles.listPicker}
             />
-        </>
+        </div>
     );
 
     return (
         <BaseModal
             body={body}
             footer={
-                <PrimaryButton
-                    className={styles.downloadButton}
-                    disabled={!selectedAnnotations.length}
-                    iconName="Download"
-                    onClick={onDownload}
-                    text="DOWNLOAD"
-                    title="Download"
-                />
+                <div className={styles.footerButtons}>
+                    <PrimaryButton
+                        className={styles.downloadButton}
+                        disabled={!selectedAnnotations.length}
+                        iconName="Download"
+                        onClick={onDownload}
+                        text="DOWNLOAD"
+                        title="Download"
+                    />
+                </div>
             }
             onDismiss={onDismiss}
             title="Download metadata manifest"


### PR DESCRIPTION
### Description 

The purpose of this PR is to propose a solution to our increasing size of body content for modals. We have seen #413 where the buttons overlay the content (Present for other modals as well). This PR adds a scroll bar to the body of all modals if it exceeds a certain size and limits the total body to 55% of the total modal. It could use some love around spacing...


### UPDATES:
[22c97f9](https://github.com/AllenInstitute/biofile-finder/pull/421/commits/22c97f98a94d26f89944348b6075d4f64e0041e9) and [ec58021](https://github.com/AllenInstitute/biofile-finder/pull/421/commits/ec58021d19b2730a38b31170a7dd186b1b672c30) resolve #413 
[1e72d98](https://github.com/AllenInstitute/biofile-finder/pull/421/commits/1e72d98b0e07e5ce8ba5c002e3f957527d572e8d) resolves #374
[ad84480](https://github.com/AllenInstitute/biofile-finder/pull/421/commits/ad844802bf98faafd4dabef90e7a71ecf2dcc125) resolves #418