### PR TITLE
Fix tooltip alignment [small]

### DIFF
--- a/packages/core/components/ListPicker/ListRow.module.css
+++ b/packages/core/components/ListPicker/ListRow.module.css
@@ -26,6 +26,7 @@
     justify-content: space-between;
     padding-left: 6px;
     width: 100%;
+    height: 35px;
 }
 
 .item-container:hover:not(.disabled) {

--- a/packages/web/src/components/DatasetDetails/DatasetDetails.module.css
+++ b/packages/web/src/components/DatasetDetails/DatasetDetails.module.css
@@ -87,16 +87,26 @@ hr {
   flex: 1 1 100%;
 }
 
+.button-wrapper {
+  width: fit-content;
+}
+
 .button {
   height: 33px;
-  width: fit-content;
   margin: var(--margin) 0;
 }
 
 .secondary-close-button {
   height: 33px;
   width: fit-content;
+}
+
+.footer {
+  width: 100%;
   position: absolute;
   bottom: 0;
-  right: 0;
+  
+  /* flex parent */
+  display: flex;
+  justify-content: flex-end;
 }

--- a/packages/web/src/components/DatasetDetails/DatasetDetails.module.css
+++ b/packages/web/src/components/DatasetDetails/DatasetDetails.module.css
@@ -20,7 +20,7 @@
   height: calc(100% - var(--margin) * 4);
 }
 
-.close-button {
+.header {
   position: absolute;
   top: 0;
   right: 0;

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -103,12 +103,13 @@ export default function DatasetDetails() {
             })}
         >
             <div className={styles.internalWrapper}>
-                <TertiaryButton
-                    className={styles.closeButton}
-                    iconName="Cancel"
-                    title=""
-                    onClick={() => dispatch(interaction.actions.hideDatasetDetailsPanel())}
-                />
+                <div className={styles.header}>
+                    <TertiaryButton
+                        iconName="Cancel"
+                        title="Close"
+                        onClick={() => dispatch(interaction.actions.hideDatasetDetailsPanel())}
+                    />
+                </div>
                 <div className={styles.title}>{datasetDetails?.name}</div>
                 <div className={styles.buttonWrapper}>
                     <PrimaryButton

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -106,17 +106,19 @@ export default function DatasetDetails() {
                 <TertiaryButton
                     className={styles.closeButton}
                     iconName="Cancel"
-                    title="Close"
+                    title=""
                     onClick={() => dispatch(interaction.actions.hideDatasetDetailsPanel())}
                 />
                 <div className={styles.title}>{datasetDetails?.name}</div>
-                <PrimaryButton
-                    className={styles.button}
-                    iconName="Upload"
-                    title="Load dataset"
-                    text="LOAD DATASET"
-                    onClick={loadDataset}
-                />
+                <div className={styles.buttonWrapper}>
+                    <PrimaryButton
+                        className={styles.button}
+                        iconName="Upload"
+                        title="Load dataset"
+                        text="LOAD DATASET"
+                        onClick={loadDataset}
+                    />
+                </div>
                 <hr></hr>
                 <div className={styles.content}>
                     <div
@@ -129,12 +131,14 @@ export default function DatasetDetails() {
                     </div>
                     {isLongDescription && toggleDescriptionButton}
                     <div className={styles.list}>{content}</div>
-                    <SecondaryButton
-                        className={styles.secondaryCloseButton}
-                        title="Close panel"
-                        text="CLOSE"
-                        onClick={() => dispatch(interaction.actions.hideDatasetDetailsPanel())}
-                    />
+                    <div className={styles.footer}>
+                        <SecondaryButton
+                            className={styles.secondaryCloseButton}
+                            title="Close panel"
+                            text="CLOSE"
+                            onClick={() => dispatch(interaction.actions.hideDatasetDetailsPanel())}
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
@@ -57,7 +57,7 @@
 /* Toggle overlay depending on screen size */
 @media screen and (max-width: 1070px) {
   .overlay {
-    top: 8px;
+    top: 16px;
     right: 0;
     background-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9));
     position: absolute;

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
@@ -57,11 +57,11 @@
 /* Toggle overlay depending on screen size */
 @media screen and (max-width: 1070px) {
   .overlay {
-    top: 16px;
+    top: 12px;
     right: 0;
     background-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9));
     position: absolute;
-    height: calc(100% - calc(4*var(--margin)));
+    height: calc(100% - calc(3*var(--margin)));
     pointer-events: none;
     width: 86px;
   }


### PR DESCRIPTION
resolves #400 

The width restrictions applied to the buttons were not interpreted by the tooltip host, so the tooltip was acting like the button was still 100% width. This adds a wrapper to those buttons to perform the width/position styling.

Unrelated changes: 
- The menu item buttons (list picker) were showing up as way too tall in my local dev env, so pre-emptively adding a height restriction in case this was going to propagate to prod. 
- Noticed that the overlay was misaligned in the open-source dataset table, so adjusted slightly

## Testing
Visual checks, including verifying that other buttons with tooltips aren't affected.

### Before: 
<img width="300" alt="Screenshot 2025-02-10 at 5 22 25 PM" src="https://github.com/user-attachments/assets/04291ce4-8be6-400b-be37-c894bfed1335" />

<img width="300" alt="Screenshot 2025-02-10 at 5 22 32 PM" src="https://github.com/user-attachments/assets/a81ae8a9-95f2-49cf-bf1c-4a21d7296739" />
<img width="294" alt="image" src="https://github.com/user-attachments/assets/2351ed83-ef3b-46dc-9d88-45cf9b0ce639" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/dda3e086-f078-4d11-8581-1825da44c028" />


### After
<img width="268" alt="image" src="https://github.com/user-attachments/assets/938eeaf1-8a81-4a03-b663-73bd775bec0f" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/dbb01caa-ed7f-41e5-b857-671d91797296" />
<img width="203" alt="image" src="https://github.com/user-attachments/assets/66147df1-6a30-4be8-a7ec-4340e5fc7b4f" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1ea350f0-1151-4f30-a13a-e6ea8749fd98" />
