### PR TITLE
Feature/update dataset table metadata

### DIFF
--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -43,7 +43,7 @@ export default function FilePrompt(props: Props) {
                 const { name, extensionGuess } = getNameAndTypeFromSourceUrl(dataSourceURL);
                 props.onSelectFile({
                     name,
-                    type: extensionGuess as "csv" | "json" | "parquet",
+                    type: extensionGuess,
                     uri: dataSourceURL,
                 });
             }

--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -13,9 +13,11 @@ export enum FileView {
     LARGE_THUMBNAIL = "3",
 }
 
+export const ACCEPTED_SOURCE_TYPES = ["csv", "json", "parquet"] as const;
+
 export interface Source {
     name: string;
-    type?: "csv" | "json" | "parquet";
+    type?: typeof ACCEPTED_SOURCE_TYPES[number];
     uri?: string | File;
 }
 
@@ -72,8 +74,11 @@ export const DEFAULT_AICS_FMS_QUERY: FileExplorerURLComponents = {
 export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
     const uriResource = dataSourceURL.substring(dataSourceURL.lastIndexOf("/") + 1).split("?")[0];
     const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
-    let extensionGuess = uriResource.split(".").pop();
-    if (!(extensionGuess === "csv" || extensionGuess === "json" || extensionGuess === "parquet")) {
+    // Returns undefined if can't find a match
+    let extensionGuess = ACCEPTED_SOURCE_TYPES.find(
+        (validSourcetype) => validSourcetype === uriResource.split(".").pop()
+    );
+    if (!extensionGuess) {
         console.warn("Assuming the source is csv since no extension was recognized");
         extensionGuess = "csv";
     }

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -47,11 +47,24 @@ export default function DatasetDetails() {
             if (datasetDetails.details.hasOwnProperty(fieldName)) {
                 datasetFieldValue = _get(datasetDetails.details, fieldName);
                 if (
-                    (fieldName === DatasetAnnotations.RELATED_PUBLICATON.name ||
-                        fieldName === DatasetAnnotations.DOI.name) &&
-                    datasetDetails.details.hasOwnProperty(DatasetAnnotations.DOI.name)
-                )
+                    fieldName === DatasetAnnotations.DOI.name ||
+                    fieldName === DatasetAnnotations.RELATED_PUBLICATON.name
+                ) {
+                    // Start by using the DOI for both links
                     link = _get(datasetDetails.details, DatasetAnnotations.DOI.name);
+                }
+                if (
+                    fieldName === DatasetAnnotations.RELATED_PUBLICATON.name &&
+                    datasetDetails.details.hasOwnProperty(
+                        DatasetAnnotations.RELATED_PUBLICATION_LINK.name
+                    )
+                ) {
+                    // If RELATED_PUBLICATON has its own link other than the DOI, prioritize that
+                    link = _get(
+                        datasetDetails.details,
+                        DatasetAnnotations.RELATED_PUBLICATION_LINK.name
+                    );
+                }
             } else datasetFieldValue = "--"; // Still display field, just indicate no value provided
             const ret = [
                 ...accum,

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -2,26 +2,27 @@ import classNames from "classnames";
 import { get as _get } from "lodash";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
 
 import DatasetDetailsRow from "./DatasetDetailsRow";
 import PublicDataset, {
     DATASET_DISPLAY_FIELDS,
     DatasetAnnotations,
 } from "../../entity/PublicDataset";
-import { interaction, selection } from "../../../../core/state";
+import { interaction } from "../../../../core/state";
 import {
     PrimaryButton,
     SecondaryButton,
     TertiaryButton,
 } from "../../../../core/components/Buttons";
-import { getNameAndTypeFromSourceUrl, Source } from "../../../../core/entity/FileExplorerURL";
 
 import styles from "./DatasetDetails.module.css";
 
-export default function DatasetDetails() {
+interface DatasetDetailsProps {
+    onLoadDataset: (datasetDetails: PublicDataset | undefined) => void;
+}
+
+export default function DatasetDetails(props: DatasetDetailsProps) {
     const dispatch = useDispatch();
-    const navigate = useNavigate();
     const isDetailsPanelVisible = useSelector(interaction.selectors.getDatasetDetailsVisibility);
     const datasetDetails: PublicDataset | undefined = useSelector(
         interaction.selectors.getSelectedPublicDataset
@@ -80,29 +81,6 @@ export default function DatasetDetails() {
         }, [] as JSX.Element[]);
     }, [datasetDetails]);
 
-    const openDatasetInApp = (source: Source) => {
-        navigate("/app");
-        dispatch(
-            selection.actions.addQuery({
-                name: `New ${source.name} Query on ${
-                    datasetDetails?.name || "open-source dataset"
-                }`,
-                parts: { sources: [source] },
-            })
-        );
-    };
-
-    const loadDataset = () => {
-        const dataSourceURL = datasetDetails?.path;
-        if (!dataSourceURL) throw new Error("No path provided to dataset");
-        const { name, extensionGuess } = getNameAndTypeFromSourceUrl(dataSourceURL);
-        openDatasetInApp({
-            name,
-            type: extensionGuess as "csv" | "json" | "parquet",
-            uri: dataSourceURL,
-        });
-    };
-
     const toggleDescriptionButton = (
         <a className={styles.link} onClick={() => setShowLongDescription(!showLongDescription)}>
             Read {showLongDescription ? "less" : "more"}
@@ -130,7 +108,7 @@ export default function DatasetDetails() {
                         iconName="Upload"
                         title="Load dataset"
                         text="LOAD DATASET"
-                        onClick={loadDataset}
+                        onClick={() => props.onLoadDataset(datasetDetails)}
                     />
                 </div>
                 <hr></hr>

--- a/packages/web/src/components/DatasetDetails/test/DatasetDetails.test.tsx
+++ b/packages/web/src/components/DatasetDetails/test/DatasetDetails.test.tsx
@@ -1,15 +1,16 @@
 import { configureMockStore, mergeState } from "@aics/redux-utils";
 import { fireEvent, render } from "@testing-library/react";
 import { expect } from "chai";
-import { get as _get } from "lodash";
+import { get as _get, noop } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
+import { spy } from "sinon";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import DatasetDetails from "../";
 import PublicDataset, { DATASET_DISPLAY_FIELDS } from "../../../entity/PublicDataset";
 import { makePublicDatasetMock } from "../../../entity/PublicDataset/mocks";
-import { initialState, selection } from "../../../../../core/state";
+import { initialState } from "../../../../../core/state";
 import DatabaseServiceNoop from "../../../../../core/services/DatabaseService/DatabaseServiceNoop";
 
 describe("<DatasetDetails />", () => {
@@ -17,7 +18,7 @@ describe("<DatasetDetails />", () => {
         const mockRouter = createBrowserRouter([
             {
                 path: "/",
-                element: <DatasetDetails />,
+                element: <DatasetDetails onLoadDataset={noop} />,
             },
         ]);
         it("renders correct dataset field names and values for a fully defined dataset", () => {
@@ -139,7 +140,7 @@ describe("<DatasetDetails />", () => {
         const mockRouter = createBrowserRouter([
             {
                 path: "/",
-                element: <DatasetDetails />,
+                element: <DatasetDetails onLoadDataset={noop} />,
             },
         ]);
         const mockDescriptionShort = "This is a string that has 40 characters.";
@@ -227,27 +228,20 @@ describe("<DatasetDetails />", () => {
         });
     });
     describe("loadDataset", () => {
+        const onLoadDataset = spy();
         const mockRouter = createBrowserRouter([
             {
                 path: "/",
-                element: <DatasetDetails />,
-            },
-            {
-                path: "/app",
-                element: <></>,
+                element: <DatasetDetails onLoadDataset={onLoadDataset} />,
             },
         ]);
-        it("calls dispatch", () => {
+        it("calls loadDataset with data", () => {
             const mockDataset = makePublicDatasetMock("test-id");
 
             // Arrange
-            const { store, actions } = configureMockStore({
+            const { store } = configureMockStore({
                 state: mergeState(initialState, {
                     interaction: {
-                        isOnWeb: true,
-                        platformDependentServices: {
-                            databaseService: new DatabaseServiceNoop(),
-                        },
                         selectedPublicDataset: mockDataset,
                     },
                 }),
@@ -260,18 +254,14 @@ describe("<DatasetDetails />", () => {
 
             // consistency checks, button exists & no actions fired
             expect(getByLabelText("Load dataset")).to.exist;
-            expect(actions.list.length).to.equal(0);
+            expect(onLoadDataset.called).to.equal(false);
 
             // Act
             fireEvent.click(getByLabelText("Load dataset"));
 
             // Assert
-            expect(actions.list.length).to.equal(1);
-            expect(
-                actions.includesMatch({
-                    type: selection.actions.ADD_QUERY,
-                })
-            ).to.equal(true);
+            expect(onLoadDataset.called).to.equal(true);
+            expect(onLoadDataset.getCalls()[0].args).to.contain(mockDataset);
         });
     });
 });

--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.tsx
@@ -1,12 +1,10 @@
 import { IDetailsRowProps, IRenderFunction } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 import PublicDataset from "../../entity/PublicDataset";
-import { interaction, selection } from "../../../../core/state";
-import { getNameAndTypeFromSourceUrl, Source } from "../../../../core/entity/FileExplorerURL";
+import { interaction } from "../../../../core/state";
 import { PrimaryButton } from "../../../../core/components/Buttons";
 
 import styles from "./DatasetRow.module.css";
@@ -14,42 +12,17 @@ import styles from "./DatasetRow.module.css";
 interface DatasetRowProps {
     rowProps: IDetailsRowProps;
     defaultRender: IRenderFunction<IDetailsRowProps>;
+    onLoadDataset: (dataset: PublicDataset) => void;
 }
 
 export default function DatasetRow(props: DatasetRowProps) {
     const dispatch = useDispatch();
-    const navigate = useNavigate();
     const [showActions, setShowActions] = React.useState(true);
     const dataset = new PublicDataset(props.rowProps.item);
-    const currentGlobalURL = useSelector(selection.selectors.getEncodedFileExplorerUrl);
 
     const selectDataset = () => {
         dispatch(interaction.actions.setSelectedPublicDataset(dataset));
         dispatch(interaction.actions.showDatasetDetailsPanel());
-    };
-
-    const openDatasetInApp = (source: Source) => {
-        dispatch(
-            selection.actions.addQuery({
-                name: `New ${source.name} Query on ${dataset?.name || "open-source dataset"}`,
-                parts: { sources: [source] },
-            })
-        );
-        navigate({
-            pathname: "/app",
-            search: `?${currentGlobalURL}`,
-        });
-    };
-
-    const loadDataset = () => {
-        const dataSourceURL = dataset?.path;
-        if (!dataSourceURL) throw new Error("No path provided to dataset");
-        const { name, extensionGuess } = getNameAndTypeFromSourceUrl(dataSourceURL);
-        openDatasetInApp({
-            name,
-            type: extensionGuess as "csv" | "json" | "parquet",
-            uri: dataSourceURL,
-        });
     };
 
     return (
@@ -75,7 +48,7 @@ export default function DatasetRow(props: DatasetRowProps) {
                     iconName="Upload"
                     title="Load dataset"
                     text="LOAD"
-                    onClick={loadDataset}
+                    onClick={() => props.onLoadDataset(dataset)}
                 />
             </div>
         </div>

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
@@ -75,11 +75,14 @@ export default function DatasetTable(props: DatasetTableProps) {
     ) {
         const fieldContent = item[column?.fieldName as keyof PublicDatasetProps] as string;
         if (!fieldContent) return <>--</>;
-        if (column?.fieldName === DatasetAnnotations.RELATED_PUBLICATON.name && item?.doi) {
+        if (
+            column?.fieldName === DatasetAnnotations.RELATED_PUBLICATON.name &&
+            (item?.related_publication_link || item?.doi)
+        ) {
             return (
                 <a
                     className={classNames(styles.link, styles.doubleLine)}
-                    href={item.doi}
+                    href={item.related_publication_link || item.doi}
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 
 import DatasetRow from "./DatasetRow";
 import useDatasetDetails from "./useDatasetDetails";
-import {
+import PublicDataset, {
     PublicDatasetProps,
     DATASET_TABLE_FIELDS,
     DatasetAnnotations,
@@ -25,6 +25,7 @@ import styles from "./DatasetTable.module.css";
 
 interface DatasetTableProps {
     filters?: FileFilter[];
+    onLoadDataset: (dataset: PublicDataset) => void;
 }
 
 export default function DatasetTable(props: DatasetTableProps) {
@@ -53,7 +54,13 @@ export default function DatasetTable(props: DatasetTableProps) {
         defaultRender: IRenderFunction<IDetailsRowProps> | undefined
     ): JSX.Element => {
         if (rowProps && defaultRender) {
-            return <DatasetRow rowProps={rowProps} defaultRender={defaultRender} />;
+            return (
+                <DatasetRow
+                    rowProps={rowProps}
+                    defaultRender={defaultRender}
+                    onLoadDataset={props.onLoadDataset}
+                />
+            );
         }
         return <></>;
     };

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -1,14 +1,20 @@
 import * as React from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import DatasetTable from "./DatasetTable";
 import DatasetDetails from "../DatasetDetails";
 import { DatasetManifestUrl } from "../../constants";
-import { DatasetAnnotations } from "../../entity/PublicDataset";
-import { metadata } from "../../../../core/state";
+import PublicDataset, { DatasetAnnotations } from "../../entity/PublicDataset";
+import { metadata, selection } from "../../../../core/state";
 import FileFilter from "../../../../core/entity/FileFilter";
 
 import styles from "./OpenSourceDatasets.module.css";
+import {
+    FileExplorerURLComponents,
+    getNameAndTypeFromSourceUrl,
+    Source,
+} from "../../../../core/entity/FileExplorerURL";
 
 /**
  * Page for displaying public-facing datasets
@@ -16,6 +22,9 @@ import styles from "./OpenSourceDatasets.module.css";
  */
 export default function OpenSourceDatasets() {
     const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const currentGlobalURL = useSelector(selection.selectors.getEncodedFileExplorerUrl);
+
     // Begin request action so dataset manifest is ready for table child component
     React.useEffect(() => {
         dispatch(
@@ -25,6 +34,40 @@ export default function OpenSourceDatasets() {
             )
         );
     }, [dispatch]);
+
+    const openDatasetInApp = (
+        datasetName: string,
+        source: Source,
+        url?: Partial<FileExplorerURLComponents>
+    ) => {
+        dispatch(
+            selection.actions.addQuery({
+                name: `New ${source.name} Query on ${datasetName || "open-source dataset"}`,
+                parts: { ...url, sources: [source] },
+            })
+        );
+        navigate({
+            pathname: "/app",
+            search: `?${currentGlobalURL}`,
+        });
+    };
+
+    const loadDataset = (datasetDetails?: PublicDataset) => {
+        if (!datasetDetails) throw new Error("No dataset provided");
+
+        const dataSourceURL = datasetDetails.path;
+        const { name, extensionGuess } = getNameAndTypeFromSourceUrl(dataSourceURL);
+        const url = datasetDetails?.presetQuery;
+        openDatasetInApp(
+            datasetDetails.name,
+            {
+                name,
+                type: extensionGuess as "csv" | "json" | "parquet",
+                uri: dataSourceURL,
+            },
+            url
+        );
+    };
 
     const internalDatasetFilter = new FileFilter(
         DatasetAnnotations.SOURCE.displayLabel,
@@ -57,9 +100,9 @@ export default function OpenSourceDatasets() {
                     <div className={styles.tableTitle}>
                         Datasets from the Allen Institute for Cell Science
                     </div>
-                    <DatasetTable filters={[internalDatasetFilter]} />
+                    <DatasetTable filters={[internalDatasetFilter]} onLoadDataset={loadDataset} />
                     <div className={styles.tableTitle}>Additional contributed datasets</div>
-                    <DatasetTable filters={[externalDatasetFilter]} />
+                    <DatasetTable filters={[externalDatasetFilter]} onLoadDataset={loadDataset} />
                     <p>
                         Want to include your dataset? Send us a request on
                         <a
@@ -84,7 +127,7 @@ export default function OpenSourceDatasets() {
                     </p>
                 </div>
             </div>
-            <DatasetDetails />
+            <DatasetDetails onLoadDataset={loadDataset} />
         </>
     );
 }

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -62,7 +62,7 @@ export default function OpenSourceDatasets() {
             datasetDetails.name,
             {
                 name,
-                type: extensionGuess as "csv" | "json" | "parquet",
+                type: extensionGuess,
                 uri: dataSourceURL,
             },
             url

--- a/packages/web/src/components/OpenSourceDatasets/test/DatasetTable.test.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/test/DatasetTable.test.tsx
@@ -1,6 +1,7 @@
 import { configureMockStore, mergeState } from "@aics/redux-utils";
 import { fireEvent, render } from "@testing-library/react";
 import { expect } from "chai";
+import { noop } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
@@ -19,7 +20,7 @@ describe("<DatasetTable />", () => {
     const mockRouter = createBrowserRouter([
         {
             path: "/",
-            element: <DatasetTable />,
+            element: <DatasetTable onLoadDataset={noop} />,
         },
         {
             path: "/app",

--- a/packages/web/src/entity/PublicDataset/index.ts
+++ b/packages/web/src/entity/PublicDataset/index.ts
@@ -1,3 +1,6 @@
+import FileExplorerURL, {
+    FileExplorerURLComponents,
+} from "../../../../core/entity/FileExplorerURL";
 import { FmsFileAnnotation } from "../../../../core/services/FileService";
 
 /**
@@ -17,6 +20,7 @@ export interface PublicDatasetProps {
     published?: string;
     related_publication?: string;
     related_publication_link?: string;
+    specific_query?: string; // A pre-set query that we will attempt to load by default
     version?: string;
     source?: string; // Indicate whether the dataset comes from internal (AICS) or external (other) source
 }
@@ -58,6 +62,7 @@ export const DatasetAnnotations = {
         "related_publication_link"
     ),
     SOURCE: new DatasetAnnotation("Source", "source"),
+    SPECIFIC_QUERY: new DatasetAnnotation("Specific query", "specific_query"),
     VERSION: new DatasetAnnotation("Version", "version"),
 };
 
@@ -148,6 +153,14 @@ export default class PublicDataset {
             return "";
         }
         return description as string;
+    }
+
+    public get presetQuery(): FileExplorerURLComponents | undefined {
+        if (!this.datasetDetails.specific_query) {
+            return;
+        } else {
+            return FileExplorerURL.decode(this.datasetDetails.specific_query);
+        }
     }
 
     public getFirstAnnotationValue(annotationName: string): string | number | boolean | undefined {

--- a/packages/web/src/entity/PublicDataset/index.ts
+++ b/packages/web/src/entity/PublicDataset/index.ts
@@ -16,6 +16,7 @@ export interface PublicDatasetProps {
     created?: string;
     published?: string;
     related_publication?: string;
+    related_publication_link?: string;
     version?: string;
     source?: string; // Indicate whether the dataset comes from internal (AICS) or external (other) source
 }
@@ -52,6 +53,10 @@ export const DatasetAnnotations = {
     FILE_COUNT: new DatasetAnnotation("File count", "file_count", 89),
     PUBLICATION_DATE: new DatasetAnnotation("Publication date", "published", 128),
     RELATED_PUBLICATON: new DatasetAnnotation("Related publication", "related_publication", 178),
+    RELATED_PUBLICATION_LINK: new DatasetAnnotation(
+        "Related publication link",
+        "related_publication_link"
+    ),
     SOURCE: new DatasetAnnotation("Source", "source"),
     VERSION: new DatasetAnnotation("Version", "version"),
 };


### PR DESCRIPTION
## Context
New metadata properties + refactors of old code for our [Open Source Datasets page](https://bff.allencell.org/datasets).

## Changes
#### Old code refactors:
May look like a lot of changes, but it's actually mostly just moving around & consolidating duplicate code.
- DatasetRow and DatasetDetails were both using the same copy-pasted functions to load datasets and redirect the browser. I moved these to their shared parent component.

#### New features:
- The 'Related publication' column defaulted to using the DOI as the link, but our new dataset uses a non-DOI link (and it's likely others will as well), so added a new prop and logic to handle
- Added a new 'Specific query' property & logic (rename welcome) in anticipation of allowing users to provide default query args that will load when the dataset is loaded