### PR TITLE
[Tiny] Add code owners and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @SeanLeRoy @BrianWhitneyAI @aswallace

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Context
+<!-- Describe the issues or requests addressed by this PR. Link to any relevant issues. -->
+
+## Changes
+<!-- Describe the changes proposed in this PR. -->
+
+## Testing
+<!-- Describe testing steps used to validate these changes, including automated and/or manual testing. -->
+
+- [ ] GH Actions workflows pass
+
+<!-- ## Screenshots (if relevant) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,4 @@
 ## Testing
 <!-- Describe testing steps used to validate these changes, including automated and/or manual testing. -->
 
-- [ ] GH Actions workflows pass
-
 <!-- ## Screenshots (if relevant) -->


### PR DESCRIPTION
partially resolves #427 
This PR aims to make external contribution a little more streamlined.

- Adds code owners. This * should * make it so PRs are automatically assigned reviewers when opened, and should require at least one code owner to review
- Adds a PR template

To do: Issue templates?