### PR TITLE
restrict names for new annotations and update error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",
         "@aics/redux-utils": "0.6.0",
-        "@fluentui/react": "^8.122.9",
+        "@fluentui/react": "8.67.x",
         "@tippyjs/react": "4.2.x",
         "axios": "0.21.x",
         "classnames": "2.2.x",
@@ -2479,31 +2479,30 @@
       "license": "0BSD"
     },
     "node_modules/@fluentui/react": {
-      "version": "8.122.9",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.122.9.tgz",
-      "integrity": "sha512-sjVAx/YeU/xtr9fqEEGeOeA2MVoFU3PU3lxYGtqUtoW7P/dsRjf/LCV7w9Y3ywKcDrStO4lJMsYamJSKO+T90w==",
+      "version": "8.67.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.67.4.tgz",
+      "integrity": "sha512-iBbSyOmsuxRJkn1P4rMrvN5uAyORrtNAXLk9qXzpI7h9ohXZPfGCImHXn7GyrVON0zGtjNEYevkW5VS/M2hDww==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/date-time-utilities": "^8.6.9",
-        "@fluentui/font-icons-mdl2": "^8.5.57",
-        "@fluentui/foundation-legacy": "^8.4.23",
-        "@fluentui/merge-styles": "^8.6.13",
-        "@fluentui/react-focus": "^8.9.20",
-        "@fluentui/react-hooks": "^8.8.16",
-        "@fluentui/react-portal-compat-context": "^9.0.13",
-        "@fluentui/react-window-provider": "^2.2.28",
-        "@fluentui/set-version": "^8.2.23",
-        "@fluentui/style-utilities": "^8.11.6",
-        "@fluentui/theme": "^2.6.64",
-        "@fluentui/utilities": "^8.15.19",
+        "@fluentui/date-time-utilities": "^8.5.0",
+        "@fluentui/font-icons-mdl2": "^8.3.2",
+        "@fluentui/foundation-legacy": "^8.2.6",
+        "@fluentui/merge-styles": "^8.5.1",
+        "@fluentui/react-focus": "^8.5.7",
+        "@fluentui/react-hooks": "^8.5.4",
+        "@fluentui/react-window-provider": "^2.2.0",
+        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/style-utilities": "^8.6.6",
+        "@fluentui/theme": "^2.6.5",
+        "@fluentui/utilities": "^8.8.2",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <19.0.0",
-        "@types/react-dom": ">=16.8.0 <19.0.0",
-        "react": ">=16.8.0 <19.0.0",
-        "react-dom": ">=16.8.0 <19.0.0"
+        "@types/react": ">=16.8.0 <18.0.0",
+        "@types/react-dom": ">=16.8.0 <18.0.0",
+        "react": ">=16.8.0 <18.0.0",
+        "react-dom": ">=16.8.0 <18.0.0"
       }
     },
     "node_modules/@fluentui/react-focus": {
@@ -2551,19 +2550,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/@fluentui/react-portal-compat-context": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
-      "integrity": "sha512-N+c6Qs775jnr/4WIzsQuNaRu4v16fa+gGsOCzzU1bqxX0IR9BSjjO2oLGC6luaAOqlQP+JIwn/aumOIJICKXkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <19.0.0",
-        "react": ">=16.14.0 <19.0.0"
-      }
     },
     "node_modules/@fluentui/react-window-provider": {
       "version": "2.2.28",
@@ -3301,21 +3287,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -21899,22 +21870,21 @@
       }
     },
     "@fluentui/react": {
-      "version": "8.122.9",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.122.9.tgz",
-      "integrity": "sha512-sjVAx/YeU/xtr9fqEEGeOeA2MVoFU3PU3lxYGtqUtoW7P/dsRjf/LCV7w9Y3ywKcDrStO4lJMsYamJSKO+T90w==",
+      "version": "8.67.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.67.4.tgz",
+      "integrity": "sha512-iBbSyOmsuxRJkn1P4rMrvN5uAyORrtNAXLk9qXzpI7h9ohXZPfGCImHXn7GyrVON0zGtjNEYevkW5VS/M2hDww==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.6.9",
-        "@fluentui/font-icons-mdl2": "^8.5.57",
-        "@fluentui/foundation-legacy": "^8.4.23",
-        "@fluentui/merge-styles": "^8.6.13",
-        "@fluentui/react-focus": "^8.9.20",
-        "@fluentui/react-hooks": "^8.8.16",
-        "@fluentui/react-portal-compat-context": "^9.0.13",
-        "@fluentui/react-window-provider": "^2.2.28",
-        "@fluentui/set-version": "^8.2.23",
-        "@fluentui/style-utilities": "^8.11.6",
-        "@fluentui/theme": "^2.6.64",
-        "@fluentui/utilities": "^8.15.19",
+        "@fluentui/date-time-utilities": "^8.5.0",
+        "@fluentui/font-icons-mdl2": "^8.3.2",
+        "@fluentui/foundation-legacy": "^8.2.6",
+        "@fluentui/merge-styles": "^8.5.1",
+        "@fluentui/react-focus": "^8.5.7",
+        "@fluentui/react-hooks": "^8.5.4",
+        "@fluentui/react-window-provider": "^2.2.0",
+        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/style-utilities": "^8.6.6",
+        "@fluentui/theme": "^2.6.5",
+        "@fluentui/utilities": "^8.8.2",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
@@ -21962,14 +21932,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
           "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
-      }
-    },
-    "@fluentui/react-portal-compat-context": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
-      "integrity": "sha512-N+c6Qs775jnr/4WIzsQuNaRu4v16fa+gGsOCzzU1bqxX0IR9BSjjO2oLGC6luaAOqlQP+JIwn/aumOIJICKXkA==",
-      "requires": {
-        "@swc/helpers": "^0.5.1"
       }
     },
     "@fluentui/react-window-provider": {
@@ -22530,21 +22492,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "requires": {
-        "tslib": "^2.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-        }
-      }
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",
         "@aics/redux-utils": "0.6.0",
-        "@fluentui/react": "8.67.x",
+        "@fluentui/react": "^8.122.9",
         "@tippyjs/react": "4.2.x",
         "axios": "0.21.x",
         "classnames": "2.2.x",
@@ -2375,182 +2375,215 @@
       }
     },
     "node_modules/@fluentui/date-time-utilities": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.0.tgz",
-      "integrity": "sha512-SddqPNEA5PBxZLvRY9ej2//iTzNWFqBt9kZ9rjieBlRtFPjztnDV10Zq3xlR6ss79dwkiP+S+SP4SmI2xuckHA==",
+      "version": "8.6.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.6.9.tgz",
+      "integrity": "sha512-dgOlVm4nXBWDLqijmvn4iAtyv1hVpQZjN6p0So74BW+7ASUTkQGe3lf8PHV/OjBiXfZa4qwONvmTQBGCheNU0w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/date-time-utilities/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/dom-utilities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.0.tgz",
-      "integrity": "sha512-M4SmXu428wwQLu1iw6ST07iACjdKY5HiU+xpcgD3IQMMQazgN616GDzc6KZ1ebuBsF7B4TyQS7KZh9mfxnnldg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.3.9.tgz",
+      "integrity": "sha512-8PPzv31VXnyMvZrzK7iSGPRx8piJjas0xV+qaNQ1tzAXHuTaLXPeADJK/gEDH1XA/e9Vaakb3lPUpRVa8tal+w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/dom-utilities/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/font-icons-mdl2": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.3.2.tgz",
-      "integrity": "sha512-yC9+Gzc6JDKkiwxpa0l1fgjy0yTxlO5Afk1Y/gQkeZFCdJh8jhUVKCZMcgZijwu+bZCJ2DbhayKGiqOjHVrFAA==",
+      "version": "8.5.57",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.57.tgz",
+      "integrity": "sha512-HYB+deey6wt6qHtTKdrhPhTZi7ZZVI2IwlguabK+22LzixgSdeJ0sg5Hhau5IKFwrn8ExEFOwfoaZ6KCSbcMwQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/font-icons-mdl2/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/foundation-legacy": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.6.tgz",
-      "integrity": "sha512-exjlFBqtxoFdz9gAg106iTtYhdtvztUHWcpxENwBGfSyFdQNKBuitQPvR5V5xO2snWxJCo/UNK3YWjgTm7UB/A==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.4.23.tgz",
+      "integrity": "sha512-lWFouH1+vku2LgKaZUhuBNyoXJ7DByUIMXHF7Osgq/miN8ewHt5uez8LuuSHDgCytxksCY4usCMIIL2zJD0I6w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/foundation-legacy/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/keyboard-key": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.0.tgz",
-      "integrity": "sha512-2jcD23FzOPaSXqWtfOSCzopkKtxTXUFuHZyVt4aqVRDEjPbkQ/7p37O1WL95xweWTR/9fEPO/gPtv9kOnXrJcA==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.23.tgz",
+      "integrity": "sha512-9GXeyUqNJUdg5JiQUZeGPiKnRzMRi9YEUn1l9zq6X/imYdMhxHrxpVZS12129cBfgvPyxt9ceJpywSfmLWqlKA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/keyboard-key/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/merge-styles": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.1.tgz",
-      "integrity": "sha512-jzTyqhockpunkFKbEK+8sBP2cbgLllcmcWdTkCrxb+8CxLXD5bMWGMgUiI99Xz7+G/01QBMgAHOngKC05dVS7A==",
+      "version": "8.6.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.13.tgz",
+      "integrity": "sha512-IWgvi2CC+mcQ7/YlCvRjsmHL2+PUz7q+Pa2Rqk3a+QHN0V1uBvgIbKk5y/Y/awwDXy1yJHiqMCcDHjBNmS1d4A==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/merge-styles/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/react": {
-      "version": "8.67.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.67.2.tgz",
-      "integrity": "sha512-QzDa4gXcVacBsUfXKRQV+tL7NwBJZpzgJU/lRlI4zjeC9pqiBxh6ZmxtHu0XXXIKFXa0DyesgnAKBbyqGsENmw==",
+      "version": "8.122.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.122.9.tgz",
+      "integrity": "sha512-sjVAx/YeU/xtr9fqEEGeOeA2MVoFU3PU3lxYGtqUtoW7P/dsRjf/LCV7w9Y3ywKcDrStO4lJMsYamJSKO+T90w==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/date-time-utilities": "^8.5.0",
-        "@fluentui/font-icons-mdl2": "^8.3.2",
-        "@fluentui/foundation-legacy": "^8.2.6",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/react-focus": "^8.5.7",
-        "@fluentui/react-hooks": "^8.5.4",
-        "@fluentui/react-window-provider": "^2.2.0",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/theme": "^2.6.5",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/date-time-utilities": "^8.6.9",
+        "@fluentui/font-icons-mdl2": "^8.5.57",
+        "@fluentui/foundation-legacy": "^8.4.23",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/react-focus": "^8.9.20",
+        "@fluentui/react-hooks": "^8.8.16",
+        "@fluentui/react-portal-compat-context": "^9.0.13",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/theme": "^2.6.64",
+        "@fluentui/utilities": "^8.15.19",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "@types/react-dom": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0",
-        "react-dom": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/react-focus": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.5.7.tgz",
-      "integrity": "sha512-5pL5Tbtu5eGtKMNYSHpZ7pNd/gR+Ge2Ye9r8UjphX2X3xYm0/Q0ktjRO1xdPDi7KW20I3GgLDviCW2atSxqIBw==",
+      "version": "8.9.20",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.9.20.tgz",
+      "integrity": "sha512-eOYKohP5v82jUAeEj7Mscqy5Tt4DhgTsVwf+cejj3AGhvLfFfmUbJFmVClooqXFdMgm1vvPGdub8SHA02REVkg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/keyboard-key": "^0.4.0",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/keyboard-key": "^0.4.23",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/react-focus/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/react-hooks": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.5.4.tgz",
-      "integrity": "sha512-WEU+NCrc080v631KFetcqNfXUBReX91cPbDyo8gi3M5babObs/m913SeV/m2llLKVCAelLVEIGw33QlQsGAK3g==",
+      "version": "8.8.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.8.16.tgz",
+      "integrity": "sha512-PQ1BeOp+99mdO0g7j6QLtChfXG1LxXeHG0q5CtUeD1OUGR+vUDK84h60sw7e7qU9sSmvPmHO7jn69Lg3CS+DXw==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/react-window-provider": "^2.2.0",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/react-hooks/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@fluentui/react-portal-compat-context": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
+      "integrity": "sha512-N+c6Qs775jnr/4WIzsQuNaRu4v16fa+gGsOCzzU1bqxX0IR9BSjjO2oLGC6luaAOqlQP+JIwn/aumOIJICKXkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
     },
     "node_modules/@fluentui/react-window-provider": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.0.tgz",
-      "integrity": "sha512-1iZzfVQHZQn6IJSJD1pxnXi5H8T3vrZYi9aqKyVIPZ12DCTVE2gw8W3mnOjsfVuXMGdv1sA7dgd6v4xi9erBow==",
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.28.tgz",
+      "integrity": "sha512-YdZ74HTaoDwlvLDzoBST80/17ExIl93tLJpTxnqK5jlJOAUVQ+mxLPF2HQEJq+SZr5IMXHsQ56w/KaZVRn72YA==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/react-window-provider/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/react/node_modules/tslib": {
       "version": "2.4.0",
@@ -2558,75 +2591,84 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@fluentui/set-version": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.0.tgz",
-      "integrity": "sha512-bqjpfhqaIkBy16vdYzdc7tER9Td7BTcmC+kCXuqkHOQVuG9LJfqVGRV0DA857KLhOxiy0GXwKMeDbNV5jJf6qQ==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.23.tgz",
+      "integrity": "sha512-VPXaBsiaa3Xn/AY40nLU9bvDQ62lpMVnFzFTlQ8CbpdwrjxNlRxDUY5vRToNzp1+Zu5gD/+CgsXqIZGcry5L5w==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/set-version/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/style-utilities": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.6.6.tgz",
-      "integrity": "sha512-axMN7sq4W/YLuk0LiYPrg23e45Tkv89w9w6FCRnhj6JWja+inlK/IPh/qR2egOBkXU0iJY3g03KP0GMqqm5eWg==",
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.11.6.tgz",
+      "integrity": "sha512-bVFu/ONP2+GZ/JzR6NhN7+1fuMHvi+LjOfgo21HQoDakY/KwFaitLiQBQFlRpbRUVcZXQDqe4Ur6EDFAlb2I7Q==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/theme": "^2.6.5",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/theme": "^2.6.64",
+        "@fluentui/utilities": "^8.15.19",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fluentui/style-utilities/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/theme": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.5.tgz",
-      "integrity": "sha512-P22JpZSZoDjIWO5AxdPNjuDixqlhHvj8eEQB4Ilf/aYKXXzMI8HTc6eBcm9vQt3NKutzHsat3h+Jrstkw9H2YA==",
+      "version": "2.6.64",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.64.tgz",
+      "integrity": "sha512-cjzwPgq3Zsw4F6Xy7A7yN8WCeEXKTwk9lfJzEr5b00euJRuPMxkxesBbAWW43+/1l1eWVYmSm4GcEMDVD4BfXQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/theme/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@fluentui/utilities": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.8.2.tgz",
-      "integrity": "sha512-hmPS0NiKT1QfBHRX8hM9V179jlM1nt4JxBuzkb+52+XPYwcwBYZJfb4UaX0UhMJH7Em5xwc5Dy2AjNqPCOvnIg==",
+      "version": "8.15.19",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.15.19.tgz",
+      "integrity": "sha512-20WoYz0wW7pkmur+7qxTwRfvkdAnHfylLdCYSm91WLupb0cwQ1wWZWIuyo+e0cjcvem1T9TC1+NjWs0kavTWBg==",
+      "license": "MIT",
       "dependencies": {
-        "@fluentui/dom-utilities": "^2.2.0",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/dom-utilities": "^2.3.9",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8.0 <18.0.0",
-        "react": ">=16.8.0 <18.0.0"
+        "@types/react": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/utilities/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3067,9 +3109,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@microsoft/load-themed-styles": {
-      "version": "1.10.260",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.260.tgz",
-      "integrity": "sha512-fW6YvdNMrMVQ6LY8Ckl72dtUDdxY/wxgq8o9UKSoC+3sCN2vaSxB6rlmxaSCaR79BWVaxl6oIeQKKDX3UbPg5Q=="
+      "version": "1.10.295",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz",
+      "integrity": "sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==",
+      "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -3258,6 +3301,21 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -3776,6 +3834,15 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -16148,6 +16215,15 @@
         "react-dom": "^16.8.5 || ^17.0.0"
       }
     },
+    "node_modules/react-beautiful-dnd/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -16466,6 +16542,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
       "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
@@ -18054,6 +18131,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20037,7 +20115,7 @@
     },
     "packages/desktop": {
       "name": "fms-file-explorer-desktop",
-      "version": "7.0.0",
+      "version": "8.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",
@@ -21721,121 +21799,122 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.5.0.tgz",
-      "integrity": "sha512-SddqPNEA5PBxZLvRY9ej2//iTzNWFqBt9kZ9rjieBlRtFPjztnDV10Zq3xlR6ss79dwkiP+S+SP4SmI2xuckHA==",
+      "version": "8.6.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.6.9.tgz",
+      "integrity": "sha512-dgOlVm4nXBWDLqijmvn4iAtyv1hVpQZjN6p0So74BW+7ASUTkQGe3lf8PHV/OjBiXfZa4qwONvmTQBGCheNU0w==",
       "requires": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/dom-utilities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.2.0.tgz",
-      "integrity": "sha512-M4SmXu428wwQLu1iw6ST07iACjdKY5HiU+xpcgD3IQMMQazgN616GDzc6KZ1ebuBsF7B4TyQS7KZh9mfxnnldg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.3.9.tgz",
+      "integrity": "sha512-8PPzv31VXnyMvZrzK7iSGPRx8piJjas0xV+qaNQ1tzAXHuTaLXPeADJK/gEDH1XA/e9Vaakb3lPUpRVa8tal+w==",
       "requires": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/font-icons-mdl2": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.3.2.tgz",
-      "integrity": "sha512-yC9+Gzc6JDKkiwxpa0l1fgjy0yTxlO5Afk1Y/gQkeZFCdJh8jhUVKCZMcgZijwu+bZCJ2DbhayKGiqOjHVrFAA==",
+      "version": "8.5.57",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.57.tgz",
+      "integrity": "sha512-HYB+deey6wt6qHtTKdrhPhTZi7ZZVI2IwlguabK+22LzixgSdeJ0sg5Hhau5IKFwrn8ExEFOwfoaZ6KCSbcMwQ==",
       "requires": {
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/foundation-legacy": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.2.6.tgz",
-      "integrity": "sha512-exjlFBqtxoFdz9gAg106iTtYhdtvztUHWcpxENwBGfSyFdQNKBuitQPvR5V5xO2snWxJCo/UNK3YWjgTm7UB/A==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.4.23.tgz",
+      "integrity": "sha512-lWFouH1+vku2LgKaZUhuBNyoXJ7DByUIMXHF7Osgq/miN8ewHt5uez8LuuSHDgCytxksCY4usCMIIL2zJD0I6w==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.0.tgz",
-      "integrity": "sha512-2jcD23FzOPaSXqWtfOSCzopkKtxTXUFuHZyVt4aqVRDEjPbkQ/7p37O1WL95xweWTR/9fEPO/gPtv9kOnXrJcA==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.23.tgz",
+      "integrity": "sha512-9GXeyUqNJUdg5JiQUZeGPiKnRzMRi9YEUn1l9zq6X/imYdMhxHrxpVZS12129cBfgvPyxt9ceJpywSfmLWqlKA==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/merge-styles": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.5.1.tgz",
-      "integrity": "sha512-jzTyqhockpunkFKbEK+8sBP2cbgLllcmcWdTkCrxb+8CxLXD5bMWGMgUiI99Xz7+G/01QBMgAHOngKC05dVS7A==",
+      "version": "8.6.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.13.tgz",
+      "integrity": "sha512-IWgvi2CC+mcQ7/YlCvRjsmHL2+PUz7q+Pa2Rqk3a+QHN0V1uBvgIbKk5y/Y/awwDXy1yJHiqMCcDHjBNmS1d4A==",
       "requires": {
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/react": {
-      "version": "8.67.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.67.2.tgz",
-      "integrity": "sha512-QzDa4gXcVacBsUfXKRQV+tL7NwBJZpzgJU/lRlI4zjeC9pqiBxh6ZmxtHu0XXXIKFXa0DyesgnAKBbyqGsENmw==",
+      "version": "8.122.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.122.9.tgz",
+      "integrity": "sha512-sjVAx/YeU/xtr9fqEEGeOeA2MVoFU3PU3lxYGtqUtoW7P/dsRjf/LCV7w9Y3ywKcDrStO4lJMsYamJSKO+T90w==",
       "requires": {
-        "@fluentui/date-time-utilities": "^8.5.0",
-        "@fluentui/font-icons-mdl2": "^8.3.2",
-        "@fluentui/foundation-legacy": "^8.2.6",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/react-focus": "^8.5.7",
-        "@fluentui/react-hooks": "^8.5.4",
-        "@fluentui/react-window-provider": "^2.2.0",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/theme": "^2.6.5",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/date-time-utilities": "^8.6.9",
+        "@fluentui/font-icons-mdl2": "^8.5.57",
+        "@fluentui/foundation-legacy": "^8.4.23",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/react-focus": "^8.9.20",
+        "@fluentui/react-hooks": "^8.8.16",
+        "@fluentui/react-portal-compat-context": "^9.0.13",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/theme": "^2.6.64",
+        "@fluentui/utilities": "^8.15.19",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
@@ -21848,127 +21927,136 @@
       }
     },
     "@fluentui/react-focus": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.5.7.tgz",
-      "integrity": "sha512-5pL5Tbtu5eGtKMNYSHpZ7pNd/gR+Ge2Ye9r8UjphX2X3xYm0/Q0ktjRO1xdPDi7KW20I3GgLDviCW2atSxqIBw==",
+      "version": "8.9.20",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.9.20.tgz",
+      "integrity": "sha512-eOYKohP5v82jUAeEj7Mscqy5Tt4DhgTsVwf+cejj3AGhvLfFfmUbJFmVClooqXFdMgm1vvPGdub8SHA02REVkg==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.4.0",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/style-utilities": "^8.6.6",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/keyboard-key": "^0.4.23",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/style-utilities": "^8.11.6",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/react-hooks": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.5.4.tgz",
-      "integrity": "sha512-WEU+NCrc080v631KFetcqNfXUBReX91cPbDyo8gi3M5babObs/m913SeV/m2llLKVCAelLVEIGw33QlQsGAK3g==",
+      "version": "8.8.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.8.16.tgz",
+      "integrity": "sha512-PQ1BeOp+99mdO0g7j6QLtChfXG1LxXeHG0q5CtUeD1OUGR+vUDK84h60sw7e7qU9sSmvPmHO7jn69Lg3CS+DXw==",
       "requires": {
-        "@fluentui/react-window-provider": "^2.2.0",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
-    "@fluentui/react-window-provider": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.0.tgz",
-      "integrity": "sha512-1iZzfVQHZQn6IJSJD1pxnXi5H8T3vrZYi9aqKyVIPZ12DCTVE2gw8W3mnOjsfVuXMGdv1sA7dgd6v4xi9erBow==",
+    "@fluentui/react-portal-compat-context": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
+      "integrity": "sha512-N+c6Qs775jnr/4WIzsQuNaRu4v16fa+gGsOCzzU1bqxX0IR9BSjjO2oLGC6luaAOqlQP+JIwn/aumOIJICKXkA==",
       "requires": {
-        "@fluentui/set-version": "^8.2.0",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "@fluentui/react-window-provider": {
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.2.28.tgz",
+      "integrity": "sha512-YdZ74HTaoDwlvLDzoBST80/17ExIl93tLJpTxnqK5jlJOAUVQ+mxLPF2HQEJq+SZr5IMXHsQ56w/KaZVRn72YA==",
+      "requires": {
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/set-version": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.0.tgz",
-      "integrity": "sha512-bqjpfhqaIkBy16vdYzdc7tER9Td7BTcmC+kCXuqkHOQVuG9LJfqVGRV0DA857KLhOxiy0GXwKMeDbNV5jJf6qQ==",
+      "version": "8.2.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.23.tgz",
+      "integrity": "sha512-VPXaBsiaa3Xn/AY40nLU9bvDQ62lpMVnFzFTlQ8CbpdwrjxNlRxDUY5vRToNzp1+Zu5gD/+CgsXqIZGcry5L5w==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/style-utilities": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.6.6.tgz",
-      "integrity": "sha512-axMN7sq4W/YLuk0LiYPrg23e45Tkv89w9w6FCRnhj6JWja+inlK/IPh/qR2egOBkXU0iJY3g03KP0GMqqm5eWg==",
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.11.6.tgz",
+      "integrity": "sha512-bVFu/ONP2+GZ/JzR6NhN7+1fuMHvi+LjOfgo21HQoDakY/KwFaitLiQBQFlRpbRUVcZXQDqe4Ur6EDFAlb2I7Q==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/theme": "^2.6.5",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/theme": "^2.6.64",
+        "@fluentui/utilities": "^8.15.19",
         "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/theme": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.5.tgz",
-      "integrity": "sha512-P22JpZSZoDjIWO5AxdPNjuDixqlhHvj8eEQB4Ilf/aYKXXzMI8HTc6eBcm9vQt3NKutzHsat3h+Jrstkw9H2YA==",
+      "version": "2.6.64",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.6.64.tgz",
+      "integrity": "sha512-cjzwPgq3Zsw4F6Xy7A7yN8WCeEXKTwk9lfJzEr5b00euJRuPMxkxesBbAWW43+/1l1eWVYmSm4GcEMDVD4BfXQ==",
       "requires": {
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
-        "@fluentui/utilities": "^8.8.2",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/set-version": "^8.2.23",
+        "@fluentui/utilities": "^8.15.19",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@fluentui/utilities": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.8.2.tgz",
-      "integrity": "sha512-hmPS0NiKT1QfBHRX8hM9V179jlM1nt4JxBuzkb+52+XPYwcwBYZJfb4UaX0UhMJH7Em5xwc5Dy2AjNqPCOvnIg==",
+      "version": "8.15.19",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.15.19.tgz",
+      "integrity": "sha512-20WoYz0wW7pkmur+7qxTwRfvkdAnHfylLdCYSm91WLupb0cwQ1wWZWIuyo+e0cjcvem1T9TC1+NjWs0kavTWBg==",
       "requires": {
-        "@fluentui/dom-utilities": "^2.2.0",
-        "@fluentui/merge-styles": "^8.5.1",
-        "@fluentui/set-version": "^8.2.0",
+        "@fluentui/dom-utilities": "^2.3.9",
+        "@fluentui/merge-styles": "^8.6.13",
+        "@fluentui/react-window-provider": "^2.2.28",
+        "@fluentui/set-version": "^8.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -22294,9 +22382,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.10.260",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.260.tgz",
-      "integrity": "sha512-fW6YvdNMrMVQ6LY8Ckl72dtUDdxY/wxgq8o9UKSoC+3sCN2vaSxB6rlmxaSCaR79BWVaxl6oIeQKKDX3UbPg5Q=="
+      "version": "1.10.295",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz",
+      "integrity": "sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg=="
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -22442,6 +22530,21 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "requires": {
+        "tslib": "^2.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -22921,6 +23024,16 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+          "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "@types/react-syntax-highlighter": {
@@ -32280,6 +32393,16 @@
         "react-redux": "^7.2.0",
         "redux": "^4.0.4",
         "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+          "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@aics/frontend-insights": "0.2.x",
     "@aics/redux-utils": "0.6.0",
-    "@fluentui/react": "^8.122.9",
+    "@fluentui/react": "8.67.x",
     "@tippyjs/react": "4.2.x",
     "axios": "0.21.x",
     "classnames": "2.2.x",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@aics/frontend-insights": "0.2.x",
     "@aics/redux-utils": "0.6.0",
-    "@fluentui/react": "8.67.x",
+    "@fluentui/react": "^8.122.9",
     "@tippyjs/react": "4.2.x",
     "axios": "0.21.x",
     "classnames": "2.2.x",

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -1,5 +1,9 @@
+.root {
+  --edit-form-field-width: 350px
+}
+
 .combo-box {
-  width: 295px;
+  width: var(--edit-form-field-width);
   padding-bottom: var(--margin);
 }
 
@@ -13,7 +17,21 @@
 
 .error-message {
   color: var(--error-status-text-color);
-  line-height: 1.15;
+  line-height: 1.5;
+}
+
+.warning-message {
+  color: var(--warning-status-text-color);
+  line-height: 1.5;
+  font-size: 12px;
+  top: -5px;
+  position: relative;
+  margin-bottom: 5px;
+  max-width: var(--edit-form-field-width);
+}
+
+.warning-message-fields {
+  margin-block: 0;
 }
 
 .status-message {
@@ -99,7 +117,7 @@
 
 .text-field {
   padding-bottom: var(--margin);
-  width: 300px;
+  width: var(--edit-form-field-width);
 }
 
 .text-field > div > label, .text-field > div > label::after {
@@ -137,4 +155,9 @@
 
 .text-field > div > div:hover {
   border: 1px solid var(--border-color)
+}
+
+.text-field-error > div > div  {
+  border: 1px solid var(--error-status-text-color);
+  border-radius: 4px;
 }

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -144,7 +144,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
         }
     };
 
-    const getFieldNameValidationErrors = (value: string) => {
+    const validateFieldName = (value: string) => {
         const matchingAnnotation = similarExistingFields.find(
             (annotation) =>
                 annotation.key.toLocaleLowerCase().trim() === value.toLocaleLowerCase().trim()
@@ -247,7 +247,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                     [styles.textFieldError]: hasNameErrors,
                 })}
                 onChange={(ev, newValue) => onChangeAlphanumericField(ev, newValue)}
-                onGetErrorMessage={getFieldNameValidationErrors}
+                onGetErrorMessage={validateFieldName}
                 placeholder="Add a new field name..."
                 validateOnFocusOut
                 value={newFieldName}

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -8,6 +8,7 @@ import {
     TextField,
 } from "@fluentui/react";
 import classNames from "classnames";
+import Fuse from "fuse.js";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -32,6 +33,7 @@ enum EditStep {
 interface NewAnnotationProps {
     onDismiss: () => void;
     setHasUnsavedChanges: (arg: boolean) => void;
+    annotationOptions: { key: string; text: string; data: string }[];
     selectedFileCount: number;
 }
 
@@ -40,6 +42,15 @@ interface AnnotationStatus {
     status: ProcessStatus;
     message: string | undefined;
 }
+
+const FUZZY_SEARCH_OPTIONS = {
+    // which keys on FilterItem to search
+    keys: [{ name: "key", weight: 1.0 }],
+    // return resulting matches sorted
+    shouldSort: true,
+    // 0.0 requires a perfect match, 1.0 would match anything
+    threshold: 0.2,
+};
 
 /**
  * Component for submitting a new annotation
@@ -60,6 +71,17 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
     const [newDropdownOption, setNewDropdownOption] = React.useState<string>("");
     const [dropdownOptions, setDropdownOptions] = React.useState<IComboBoxOption[]>([]);
     const [submissionStatus, setSubmissionStatus] = React.useState<AnnotationStatus | undefined>();
+    // Distinguish between errors (blocking) and warnings
+    const [hasNameErrors, setHasNameErrors] = React.useState<boolean>(false);
+    const [nameWarnings, setNameWarnings] = React.useState<any[]>([]);
+
+    const fuse = React.useMemo(() => new Fuse(props.annotationOptions, FUZZY_SEARCH_OPTIONS), [
+        props.annotationOptions,
+    ]);
+    const similarExistingFields = React.useMemo(() => fuse.search(newFieldName), [
+        newFieldName,
+        fuse,
+    ]);
 
     const statuses = useSelector(interaction.selectors.getProcessStatuses);
     const annotationCreationStatus = React.useMemo(
@@ -88,7 +110,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                         } catch (e) {
                             setSubmissionStatus({
                                 status: ProcessStatus.ERROR,
-                                message: `Failed to create annotation: ${e}`,
+                                message: `Failed to edit selected files with new field: ${e}`,
                             });
                         } finally {
                             setHasUnsavedChanges(false);
@@ -120,6 +142,52 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
         } else {
             setNewFieldName(newValue || "");
         }
+    };
+
+    const getFieldNameValidationErrors = (value: string) => {
+        const matchingAnnotation = similarExistingFields.find(
+            (annotation) =>
+                annotation.key.toLocaleLowerCase().trim() === value.toLocaleLowerCase().trim()
+        );
+        // Exact match should be a blocking error
+        if (matchingAnnotation) {
+            setNameWarnings([]);
+            setHasNameErrors(true);
+            return (
+                <div className={styles.errorMessage}>
+                    Error: Metadata field name/key &quot;{matchingAnnotation.key}&quot; already
+                    exists.
+                    <br />
+                    Switch to <i>Existing field</i> to edit pre-existing or try an alternate field
+                    name.
+                </div>
+            );
+        } else if (similarExistingFields.length > 0) {
+            // Similar but not exact match, just warn for the 3 most similar (arbitrary small number)
+            setNameWarnings(similarExistingFields.slice(0, 3));
+            setHasNameErrors(false);
+        } else {
+            // Reset existing warnings & errors
+            setNameWarnings([]);
+            setHasNameErrors(false);
+        }
+    };
+
+    const nameWarningComponent = () => {
+        if (nameWarnings.length > 0) {
+            return (
+                <div className={styles.warningMessage}>
+                    Caution: Similar field name(s)/key(s) found.
+                    <ul className={styles.warningMessageFields}>
+                        {nameWarnings.map((name) => {
+                            return <li key={name.key}> {name.key} </li>;
+                        })}
+                    </ul>
+                    You may want to switch to <i>Existing field</i> to edit pre-existing or try an
+                    alternate field name.
+                </div>
+            );
+        } else <></>;
     };
 
     const addDropdownChip = (evt: React.FormEvent) => {
@@ -174,12 +242,17 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
             {/* TO DO: Prevent user from entering a name that collides with existing annotation */}
             <TextField
                 required
-                label="New metadata field name"
-                className={styles.textField}
+                label="New metadata field name (key)"
+                className={classNames(styles.textField, {
+                    [styles.textFieldError]: hasNameErrors,
+                })}
                 onChange={(ev, newValue) => onChangeAlphanumericField(ev, newValue)}
+                onGetErrorMessage={getFieldNameValidationErrors}
                 placeholder="Add a new field name..."
+                validateOnFocusOut
                 value={newFieldName}
             />
+            {nameWarningComponent()}
             {step === EditStep.CREATE_FIELD && (
                 <>
                     <TextField
@@ -299,6 +372,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                 className={styles.primaryButton}
                                 disabled={
                                     !newFieldName ||
+                                    hasNameErrors ||
                                     (newFieldDataType === AnnotationType.DROPDOWN &&
                                         !dropdownOptions.length)
                                 }
@@ -312,6 +386,7 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                 className={styles.primaryButton}
                                 disabled={
                                     !newFieldName ||
+                                    hasNameErrors ||
                                     (newFieldDataType === AnnotationType.DROPDOWN &&
                                         !dropdownOptions.length) ||
                                     !newValues

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import * as React from "react";
 import { useSelector } from "react-redux";
 
@@ -68,7 +69,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
     }, [fileSelection]);
 
     return (
-        <div className={props.className}>
+        <div className={classNames(props.className, styles.root)}>
             <ChoiceGroup
                 className={styles.choiceGroup}
                 defaultSelectedKey={editPathway}
@@ -102,6 +103,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
                     <NewAnnotationPathway
                         onDismiss={props.onDismiss}
                         setHasUnsavedChanges={(arg) => props.setHasUnsavedChanges(arg)}
+                        annotationOptions={annotationOptions}
                         selectedFileCount={fileCount}
                     />
                 )}

--- a/packages/core/services/HttpServiceBase/index.ts
+++ b/packages/core/services/HttpServiceBase/index.ts
@@ -251,8 +251,13 @@ export default class HttpServiceBase {
             response = await retry.execute(() => this.httpClient.post(encodedUrl, body, config));
         } catch (err) {
             // Specific errors about the failure from services will be in this path
-            if (axios.isAxiosError(err) && err?.response?.data?.message) {
-                throw new Error(JSON.stringify(err.response.data.message));
+            if (
+                axios.isAxiosError(err) &&
+                (err?.response?.data?.message || err?.response?.data?.error)
+            ) {
+                throw new Error(
+                    JSON.stringify(err.response.data.message || err.response.data.error)
+                );
             }
             throw err;
         }

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -122,7 +122,7 @@ const createNewAnnotationLogic = createLogic({
         dispatch(
             interaction.actions.processStart(
                 annotationProcessId,
-                `Creating annotation ${annotation.name}...`
+                `Creating new field "${annotation.name}"...`
             )
         );
 
@@ -149,18 +149,18 @@ const createNewAnnotationLogic = createLogic({
                     dispatch(
                         interaction.actions.processSuccess(
                             annotationProcessId,
-                            `Successfully created annotation ${annotation.name}`
+                            `Successfully created new field "${annotation.name}"`
                         )
                     );
                     resolve(res);
                 })
                 .catch((err) => {
-                    dispatch(
-                        interaction.actions.processError(
-                            annotationProcessId,
-                            `Failed to create annotation: ${err.message}`
-                        )
-                    );
+                    const msg = `Sorry, creation of field name/key "${annotation.name}" failed${
+                        err?.message
+                            ? `: ${err.message}`
+                            : ". Please try again later or contact the support team for further assistance."
+                    }`;
+                    dispatch(interaction.actions.processError(annotationProcessId, msg));
                     reject(err);
                 })
                 .finally(() => done());


### PR DESCRIPTION
NOTE: I'm not sure why there are package.json/package-lock changes. Will look into it when I'm back

When users create new annotations ("fields" in the UI), we first want to check if the name is already in use and provide user feedback.
- For exact matches: show an error and prevent submission 
- For similar but non-exact: show a warning but allow submission 

When users click submit, we first try to create the annotation and if that succeeds, send the file metadata edit request
- Updates messages at bottom of modal to inform about annotation creation status

Styling/phrasing per UX discussions in [this Google doc](https://docs.google.com/document/d/16EfIcEzoSdg7UE7fPn88WQWtmh6fDCOVj9_XsD8J4go/edit?tab=t.0).


### Screenshots
#### Field name overlap errors & warnings
<img width="472" alt="Screenshot 2025-02-13 at 10 08 47 AM" src="https://github.com/user-attachments/assets/3147e82c-a5f2-4a5d-b1a6-b65404fb3c4b" />
<img width="524" alt="Screenshot 2025-02-13 at 10 06 59 AM" src="https://github.com/user-attachments/assets/2fcb033f-0e60-4dab-ae12-a5dee11cf76a" />

#### Status message for annotation creation request
Warning message currently has a width restriction bc of nested components, but can change if needed
<img width="783" alt="Screenshot 2025-02-12 at 4 31 17 PM" src="https://github.com/user-attachments/assets/64076060-37cd-45f4-ba3a-0575cf1340f2" />
<img width="759" alt="Screenshot 2025-02-13 at 10 07 22 AM" src="https://github.com/user-attachments/assets/c1300252-58bc-4fdc-a055-0d0fed4690f0" />
