### PR TITLE
Thumbnail fixes

### DIFF
--- a/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
+++ b/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
@@ -103,7 +103,14 @@ export async function renderZarrThumbnailURL(zarrUrl: string): Promise<string | 
                 // Determine a slice of the image that has the best chance at being a good thumbnail.
                 // X and Y will have full range, while Z will be the middle integer.
                 // Non-spatial dims will default to None.
-                const axes = transformAxes(multiscales[0].axes);
+                const defaultAxes = [
+                    { name: "t", type: "time" },
+                    { name: "c", type: "channel" },
+                    { name: "z", type: "space" },
+                    { name: "y", type: "space" },
+                    { name: "x", type: "space" },
+                ];
+                const axes = transformAxes(multiscales[0].axes || defaultAxes);
                 const zIndex = axes.findIndex((item) => item.name === "z");
                 if (zIndex !== -1) {
                     // if size Z is 1, use Math.floor so we get slice of 0

--- a/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
+++ b/packages/core/entity/FileDetail/RenderZarrThumbnailURL.ts
@@ -106,7 +106,8 @@ export async function renderZarrThumbnailURL(zarrUrl: string): Promise<string | 
                 const axes = transformAxes(multiscales[0].axes);
                 const zIndex = axes.findIndex((item) => item.name === "z");
                 if (zIndex !== -1) {
-                    const zSliceIndex = Math.ceil(lowestResolution.shape[zIndex] / 2);
+                    // if size Z is 1, use Math.floor so we get slice of 0
+                    const zSliceIndex = Math.floor(lowestResolution.shape[zIndex] / 2);
                     axes[zIndex].value = zSliceIndex;
                 }
 
@@ -119,11 +120,17 @@ export async function renderZarrThumbnailURL(zarrUrl: string): Promise<string | 
                 const u16data = lowestResolutionView.data as Uint16Array;
 
                 // Normalize Data to improve image visibility.
-                const min = Math.min(...u16data);
-                const max = Math.max(...u16data);
+                let min = Infinity;
+                let max = -Infinity;
+                const dlength = u16data.length;
+                for (let i = 0; i < dlength; i++) {
+                    min = Math.min(min, u16data[i]);
+                    max = Math.max(max, u16data[i]);
+                }
                 const normalizedData = new Uint8Array(u16data.length);
                 for (let i = 0; i < u16data.length; i++) {
-                    normalizedData[i] = Math.round((255 * (u16data[i] - min)) / (max - min));
+                    // use bitwise shift to truncate decimal
+                    normalizedData[i] = ((255 * (u16data[i] - min)) / (max - min)) << 0;
                 }
 
                 // Build a canvas to put image data onto.

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -262,7 +262,7 @@ export default class FileDetail {
             if (isFileRenderableImage) {
                 return this.downloadPath;
             }
-            if (this.path.endsWith(".zarr")) {
+            if (this.path.includes(".zarr")) {
                 return await renderZarrThumbnailURL(this.downloadPath);
             }
         }


### PR DESCRIPTION
This might address some of the issues on #282.
Main fixes:

 - Avoids `Math.min(...u16data)` and `Math.max(...u16data)` as these were exceeding max call stack size.
 - Make sure the Z slice is valid where the size of Z is 1

Minor fix:
 - I added handling of missing multiscales.axes as these are not present in OME-Zarr v0.2 data (which I happened to be testing with). I don't know if you want to support this as there's not much of this version "in the wild". I didn't handle OME-Zarr v0.3 yet, where `axes` is `{"t", "c", "z", "y", "x"}`.
 
Suggested change:
 - Quite a lot of zarr data (e.g. generated by `bioformats2raw`) has the zarr image at `path/to/image.zarr/0` so the path doesn't end with `.zarr`. Hopefully not too many non-zarr images have `.zarr` in the path, so it shouldn't get many false positives.