### PR TITLE
Bugfix/empty csv for manually selected files

### DIFF
--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -202,6 +202,8 @@ export default class DatabaseFileService implements FileService {
         sql: string,
         format: "csv" | "json" | "parquet"
     ): Promise<DownloadResult> {
+        // If the file system is accessible we can just have DuckDB write the
+        // output query directly to the system rather than to a buffer then the file
         if (this.downloadService.isFileSystemAccessible) {
             const downloadDir = await this.downloadService.getDefaultDownloadDirectory();
             const separator = navigator.userAgent.toLowerCase().includes("windows") ? "\\" : "/";

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -143,7 +143,7 @@ export default class DatabaseFileService implements FileService {
         selections: Selection[],
         dataSourceNames: string[]
     ): void {
-        const subQuerys: string[] = [];
+        const subQueries: string[] = [];
 
         selections.forEach((selection) => {
             selection.indexRanges.forEach((indexRange) => {
@@ -154,11 +154,13 @@ export default class DatabaseFileService implements FileService {
                     .limit(indexRange.end - indexRange.start + 1);
 
                 DatabaseFileService.applyFiltersAndSorting(subQuery, selection);
-                subQuerys.push(`${DatabaseService.HIDDEN_UID_ANNOTATION} IN (${subQuery.toSQL()})`);
+                subQueries.push(
+                    `${DatabaseService.HIDDEN_UID_ANNOTATION} IN (${subQuery.toSQL()})`
+                );
             });
         });
         // sqlBuilder whereOr isnt implemented, so we add our own "OR"
-        sqlBuilder.where(subQuerys.join(" OR "));
+        sqlBuilder.where(subQueries.join(" OR "));
     }
 
     /**

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -4,6 +4,7 @@ import DatabaseService from "../../../DatabaseService";
 import FileSelection from "../../../../entity/FileSelection";
 import FileSet from "../../../../entity/FileSet";
 import NumericRange from "../../../../entity/NumericRange";
+import SQLBuilder from "../../../../entity/SQLBuilder";
 import DatabaseServiceNoop from "../../../DatabaseService/DatabaseServiceNoop";
 import FileDownloadServiceNoop from "../../../FileDownloadService/FileDownloadServiceNoop";
 
@@ -98,6 +99,67 @@ describe("DatabaseFileService", () => {
             const fileSet = new FileSet();
             const count = await fileService.getCountOfMatchingFiles(fileSet);
             expect(count).to.equal(6);
+        });
+    });
+
+    describe("applySelectionFilters", () => {
+        // Setup
+        let databaseFileService: DatabaseFileService;
+        let sqlBuilder: SQLBuilder;
+
+        beforeEach(() => {
+            databaseFileService = new DatabaseFileService({
+                dataSourceNames: ["mock_source"],
+                databaseService,
+                downloadService: new FileDownloadServiceNoop(),
+            });
+
+            sqlBuilder = new SQLBuilder().select("*").from("mock_source");
+        });
+
+        // the sql we produce has new lines that mess up comparison
+        function normalizeSQL(sql: string): string {
+            return sql.replace(/\s+/g, " ").trim();
+        }
+
+        it("correctly modifies SQLBuilder for single index selections (CTRL selection)", () => {
+            // Arrange
+            const selections = [
+                {
+                    indexRanges: [
+                        { start: 0, end: 0 },
+                        { start: 2, end: 2 },
+                    ], // Two uniqe files
+                    filters: {},
+                    sort: undefined,
+                },
+            ];
+
+            // Act
+            databaseFileService["applySelectionFilters"](sqlBuilder, selections);
+            const modifiedSQL = normalizeSQL(sqlBuilder.toSQL());
+
+            // Assert
+            expect(modifiedSQL).to.include("OFFSET 0 LIMIT 1");
+            expect(modifiedSQL).to.include("OFFSET 2 LIMIT 1");
+        });
+
+        it("correctly modifies SQLBuilder for contiguous range selections (Shift selection)", () => {
+            // Arrange
+            const selections = [
+                {
+                    indexRanges: [{ start: 0, end: 2 }], // File range
+                    filters: {},
+                    sort: undefined,
+                },
+            ];
+
+            // Act
+            databaseFileService["applySelectionFilters"](sqlBuilder, selections);
+            const modifiedSQL = normalizeSQL(sqlBuilder.toSQL());
+
+            // Assert
+            expect(modifiedSQL).to.include("OFFSET 0 LIMIT 3");
         });
     });
 });

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -104,16 +104,9 @@ describe("DatabaseFileService", () => {
 
     describe("applySelectionFilters", () => {
         // Setup
-        let databaseFileService: DatabaseFileService;
         let sqlBuilder: SQLBuilder;
 
         beforeEach(() => {
-            databaseFileService = new DatabaseFileService({
-                dataSourceNames: ["mock_source"],
-                databaseService,
-                downloadService: new FileDownloadServiceNoop(),
-            });
-
             sqlBuilder = new SQLBuilder().select("*").from("mock_source");
         });
 
@@ -136,7 +129,7 @@ describe("DatabaseFileService", () => {
             ];
 
             // Act
-            databaseFileService["applySelectionFilters"](sqlBuilder, selections);
+            DatabaseFileService.applySelectionFilters(sqlBuilder, selections, ["mock_source"]);
             const modifiedSQL = normalizeSQL(sqlBuilder.toSQL());
 
             // Assert
@@ -155,7 +148,7 @@ describe("DatabaseFileService", () => {
             ];
 
             // Act
-            databaseFileService["applySelectionFilters"](sqlBuilder, selections);
+            DatabaseFileService.applySelectionFilters(sqlBuilder, selections, ["mock_source"]);
             const modifiedSQL = normalizeSQL(sqlBuilder.toSQL());
 
             // Assert

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -129,7 +129,7 @@ describe("DatabaseFileService", () => {
                     indexRanges: [
                         { start: 0, end: 0 },
                         { start: 2, end: 2 },
-                    ], // Two uniqe files
+                    ], // Two unique files
                     filters: {},
                     sort: undefined,
                 },


### PR DESCRIPTION
### Description 

The purpose of this pr is to resolve #415. We have a situation with imported data where the query we build to download a csv does not account for single selected files ie. (CTRL + Select) this is because we pass it a list of index ranges. which might look like:
```
                    indexRanges: [
                        { start: 0, end: 0 },
                        { start: 2, end: 2 },
                    ],
```
When we build a query it does not register these ranges since they're not inclusive. However if we pass it `indexRanges: [{ start: 0, end: 2 }]` it works correctly. 


### Changes

- Add conditional to handle single index files 
- Seperate the download method which has gotten quite heavy
- Add tests for this case (Comparing the query)


