### PR TITLE
(Tiny) Prevent autofocused tooltip

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -91,3 +91,10 @@
     /* flex child */
     flex: 0 0 var(--file-details-width);
 }
+
+.hidden {
+    /* arbitrarily large to move input off-screen */
+    left: -100;
+    top: -100;
+    position: absolute;
+}

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -104,6 +104,8 @@ export default function App(props: AppProps) {
             })}
             ref={measuredNodeRef}
         >
+            {/* hidden input to capture autofocus on mount */}
+            <input className={styles.hidden} autoFocus />
             <div className={styles.coreAndFileDetails}>
                 <div className={styles.querySidebarAndCenter}>
                     <QuerySidebar className={styles.querySidebar} />


### PR DESCRIPTION
## Context
For desktop, when the app is initially started, it renders with the "+ ADD" button already focused, which causes the ghost tooltip to reappear. This would occur with any first element on the page; e.g., if we completely get rid of the button, the query title would autofocus & be highlighted.
closes #301 

## Changes
This adds a hidden input element (off-screen) that will capture the autofocus instead.

Other things I tried that didn't work: 
- Using `display: hidden` on the input instead of absolute positioning: This prevents autofocusing so doesn't do the job
- Moving the input further down in the code so it's a little more discreet. It apparently has to be the first element on the page
- Setting `autofocus` (or `autoFocus`) on other elements so it's not the ADD button: That property doesn't exist on custom components or divs by default, so we'd need to do a little more legwork to use it elsewhere
- Setting `autoFocus={false}` on our button component
- Intercepting/preventing focus on initial render: This isn't recommended for accessibility/keyboard usage reasons

## Testing
Tested manually on local dev build

## Screenshots (if relevant) 
Auto tooltip on initial render: 
<img width="502" alt="image" src="https://github.com/user-attachments/assets/6e9e92f7-598e-4fb3-b9fc-b67e3a5baea5" />
