### PR TITLE
Fix SQL for groupings and csv downloads

### DIFF
--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -211,7 +211,7 @@ export default class FileSet {
 
         Object.entries(filtersGroupedByAnnotation).forEach(([_, appliedFilters]) => {
             sqlBuilder.where(
-                appliedFilters.map((filter) => filter.toSQLWhereString()).join(") OR (")
+                appliedFilters.map((filter) => filter.toSQLWhereString()).join(" OR ")
             );
         });
 

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -127,7 +127,7 @@ describe("FileSet", () => {
                 'WHERE (REGEXP_MATCHES("scientist"'
             );
             expect(fileSet.toQuerySQLBuilder().from(mockDatasource).toString()).to.contain(
-                'OR (REGEXP_MATCHES("scientist"'
+                'OR REGEXP_MATCHES("scientist"'
             );
         });
     });

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -169,11 +169,9 @@ export default class DatabaseFileService implements FileService {
     public static applyFiltersAndSorting(subQuery: SQLBuilder, selection: Selection): void {
         if (!isEmpty(selection.filters)) {
             subQuery.where(
-                Object.entries(selection.filters)
-                    .flatMap(([column, values]) =>
-                        values.map((v) => SQLBuilder.regexMatchValueInList(column, v))
-                    )
-                    .join(") OR (")
+                Object.entries(selection.filters).flatMap(([column, values]) =>
+                    values.map((v) => SQLBuilder.regexMatchValueInList(column, v)).join(" OR ")
+                )
             );
         }
         if (selection.sort) {


### PR DESCRIPTION
## Context
Addresses two issues: 
- #442 : Groupings include incorrect values when filters are also applied (see [this query](https://staging.bff.allencell.org/app?c=File+ID%3A0.25%2CFile+Name%3A0.25%2CCell+Line%3A0.25%2CStructure%3A0.25&group=Cell+Line&filter=%7B%22name%22%3A%22Structure%22%2C%22value%22%3A%22Actin+filaments%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22Structure%22%2C%22value%22%3A%22Mitochondria%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22AICS-11%22%5D&openFolder=%5B%22AICS-16%22%5D&openFolder=%5B%22AICS-7%22%5D&source=%7B%22name%22%3A%22Variance%2BPaper%2BDataset.csv+%282%2F24%2F2025+4%3A53%3A15+PM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fbiofile-finder-datasets.s3.us-west-2.amazonaws.com%2FVariance%2BPaper%2BDataset.csv%22%7D&sort=%7B%22annotationName%22%3A%22File+ID%22%2C%22order%22%3A%22DESC%22%7D) on staging for an example; note that AICS-11 appears in every group)
- For csv metadata downloads, the wrong file(s) are occasionally processed; e.g., if I selected files from the AICS-16 group, files in AICS-7 might be processed instead (can replicate by going [here](https://staging.bff.allencell.org/app?c=File+ID%3A0.25%2CFile+Name%3A0.25%2CCell+Line%3A0.25%2CStructure%3A0.25&group=Cell+Line&filter=%7B%22name%22%3A%22Structure%22%2C%22value%22%3A%22Actin+filaments%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22Structure%22%2C%22value%22%3A%22Mitochondria%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22AICS-11%22%5D&source=%7B%22name%22%3A%22Variance%2BPaper%2BDataset.csv+%282%2F24%2F2025+4%3A53%3A15+PM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fbiofile-finder-datasets.s3.us-west-2.amazonaws.com%2FVariance%2BPaper%2BDataset.csv%22%7D) and downloading the metadata csv for File ID 1. Metadata for File ID 5226 is downloaded instead)

closes #442 

## Changes
In both cases, the issue was with "OR" syntax 
- For the groupings one: Using ") OR (" made the query over-select
- For downloads: "OR" was applied between different filter types instead of within the same filter type

## Testing
- Tested manually on both a smaller local testing dataset & on the online Variance dataset
- Added a unit test
