### PR TITLE
(Tiny) Fix JSON formatting for metadata downloads

### DIFF
--- a/packages/web/src/services/DatabaseServiceWeb.ts
+++ b/packages/web/src/services/DatabaseServiceWeb.ts
@@ -38,7 +38,8 @@ export default class DatabaseServiceWeb extends DatabaseService {
         }
 
         const resultName = `${destination}.${format}`;
-        const finalSQL = `COPY (${sql}) TO '${resultName}' (FORMAT '${format}');`;
+        const formatOptions = format === "json" ? ", ARRAY true" : "";
+        const finalSQL = `COPY (${sql}) TO '${resultName}' (FORMAT '${format}'${formatOptions});`;
         const connection = await this.database.connect();
         try {
             await connection.send(finalSQL);


### PR DESCRIPTION
## Context
"Save metadata as JSON" was creating improperly formatted JSON files (used new lines instead of array format)
closes #423 

## Changes
Adds DuckDB's format option to the SQL

## Testing
Manually tested by downloading JSON files from the Variance dataset, and verified that csv and parquet still work correctly
