### PR TITLE
Update scroll styling for file lists

### DIFF
--- a/packages/core/components/DirectoryTree/DirectoryTree.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTree.module.css
@@ -32,6 +32,11 @@
     list-style: none;
 }
 
+/* Add padding to emphasize at end of list */
+.scroll-container li:last-of-type {
+    padding-bottom: 30px;
+}
+
 .error-message {
     position: absolute;
     top: 50%;
@@ -45,4 +50,15 @@
 
 .error-message p {
     margin: 0;
+}
+
+.vertical-overflow {
+    background-image: linear-gradient(to bottom, transparent, var(--secondary-background-color));
+    position: absolute;
+    height: 60px;
+    width: calc(100% - var(--scrollbar-size) - 2px);
+    pointer-events: none;
+    opacity: 1;
+    z-index: 100;
+    bottom: 0;
 }

--- a/packages/core/components/DirectoryTree/DirectoryTree.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTree.module.css
@@ -52,13 +52,14 @@
     margin: 0;
 }
 
-.vertical-overflow {
+.vertical-gradient {
     background-image: linear-gradient(to bottom, transparent, var(--secondary-background-color));
     position: absolute;
     height: 60px;
-    width: calc(100% - var(--scrollbar-size) - 2px);
+    width: 100%;
     pointer-events: none;
     opacity: 1;
-    z-index: 100;
+    /* Should cover FileList gradient (10) but not file count (99) or aggregate info (999)*/
+    z-index: 50;
     bottom: 0;
 }

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -75,7 +75,7 @@ export default function DirectoryTree(props: FileListProps) {
     return (
         <div className={classNames(props.className, styles.container)}>
             <RootLoadingIndicator visible={isLoading} />
-            <div className={styles.verticalOverflow} />
+            <div className={styles.verticalGradient} />
             <ul
                 className={styles.scrollContainer}
                 role="tree"

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -75,6 +75,7 @@ export default function DirectoryTree(props: FileListProps) {
     return (
         <div className={classNames(props.className, styles.container)}>
             <RootLoadingIndicator visible={isLoading} />
+            <div className={styles.verticalOverflow} />
             <ul
                 className={styles.scrollContainer}
                 role="tree"

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -1,7 +1,6 @@
 .container {
     --row-count-margin-top: 0.05em;
     --row-count-intrisic-height: 12px; /* margin values are relative to this because it is used in font-size declaration */
-    --scrollbar-padded: calc(var(--scrollbar-size) + 2px);
 
     width: 100%;
     height: calc(100% - var(--margin));
@@ -26,10 +25,10 @@
     margin-block-end: 0;
 }
 
-.horizontal-overflow {
+.horizontal-gradient {
     background-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9));
     position: absolute;
-    height: calc(100% - var(--scrollbar-padded));
+    height: calc(100% - var(--scrollbar-size));
     width: 60px;
     pointer-events: none;
     opacity: 1;
@@ -37,25 +36,49 @@
     right: 0;
 }
 
-.horizontal-overflow-adjusted {
-    /* override default class to avoid overlapping scrollbar */
-    right: calc(var(--scrollbar-padded)) !important;
-    pointer-events: none;
+/* For browsers that always show scrollbar, adjust shadow to avoid covering */
+@supports selector(::-webkit-scrollbar) {
+    .vertical-gradient {
+        background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.9));
+        position: absolute;
+        height: 50px;
+        width: calc(100% - var(--scrollbar-size));
+        pointer-events: none;
+        opacity: 1;
+        z-index: 10;
+        bottom: 0;
+    }
+
+    .vertical-gradient-cropped {
+        bottom: var(--scrollbar-size) !important;
+    }
+
+    .horizontal-gradient-cropped {
+        right: calc(var(--scrollbar-size)) !important;
+    }
 }
 
-.vertical-overflow {
-    background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.9));
-    position: absolute;
-    height: 50px;
-    width: calc(100% - var(--scrollbar-padded));
-    pointer-events: none;
-    opacity: 1;
-    z-index: 10;
-    bottom: 0;
-}
+@supports (scrollbar-color: auto) {
+    .vertical-gradient {
+        background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.9));
+        position: absolute;
+        height: 50px;
+        width: 100%;
+        pointer-events: none;
+        opacity: 1;
+        z-index: 10;
+        bottom: 0;
+    }
 
-.vertical-overflow-adjusted {
-    /* override default class to avoid overlapping scrollbar */
-    bottom: var(--scrollbar-padded) !important;
-    pointer-events: none;
+    .vertical-gradient-cropped {
+        position: absolute;
+        bottom: 0 !important;
+        width: 100% !important;
+    }
+
+    .horizontal-gradient-cropped {
+        position: absolute;
+        right: 0 !important;
+        height: 100% !important;
+    }
 }

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -1,6 +1,7 @@
 .container {
     --row-count-margin-top: 0.05em;
     --row-count-intrisic-height: 12px; /* margin values are relative to this because it is used in font-size declaration */
+    --scrollbar-padded: calc(var(--scrollbar-size) + 2px);
 
     width: 100%;
     height: calc(100% - var(--margin));
@@ -8,18 +9,7 @@
 
 .list {
     height: calc(100% - 3px);
-}
-
-.horizontal-overflow::after {
-    background-image: linear-gradient(to right, transparent, var(--secondary-background-color));
-    bottom: 0;
-    content: " ";
-    height: 100%;
-    right: 0;
-    position: absolute;
-    pointer-events: none;
-    width: 60px;
-    z-index: 11;
+    position: relative;
 }
 
 .row-count-display {
@@ -34,4 +24,38 @@
     font-size: var(--row-count-intrisic-height);
     margin-top: var(--row-count-margin-top);
     margin-block-end: 0;
+}
+
+.horizontal-overflow {
+    background-image: linear-gradient(to right, transparent, rgba(0, 0, 0, 0.9));
+    position: absolute;
+    height: calc(100% - var(--scrollbar-padded));
+    width: 60px;
+    pointer-events: none;
+    opacity: 1;
+    z-index: 10;
+    right: 0;
+}
+
+.horizontal-overflow-adjusted {
+    /* override default class to avoid overlapping scrollbar */
+    right: calc(var(--scrollbar-padded)) !important;
+    pointer-events: none;
+}
+
+.vertical-overflow {
+    background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.9));
+    position: absolute;
+    height: 50px;
+    width: calc(100% - var(--scrollbar-padded));
+    pointer-events: none;
+    opacity: 1;
+    z-index: 10;
+    bottom: 0;
+}
+
+.vertical-overflow-adjusted {
+    /* override default class to avoid overlapping scrollbar */
+    bottom: var(--scrollbar-padded) !important;
+    pointer-events: none;
 }

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -74,6 +74,12 @@ export default function FileList(props: FileListProps) {
     const calculatedHeight = Math.min(MAX_NON_ROOT_HEIGHT, dataDrivenHeight);
     const height = isRoot ? measuredHeight : calculatedHeight;
 
+    // complement to isColumnWidthOverflowing
+    const totalRows =
+        (totalCount || DEFAULT_TOTAL_COUNT) /
+        (fileView === FileView.LIST ? 1 : fileGridColumnCount);
+    const isRowHeightOverflowing = totalRows * rowHeight > height;
+
     const listRef = React.useRef<FixedSizeList | null>(null);
     const gridRef = React.useRef<FixedSizeGrid | null>(null);
     const outerRef = React.useRef<HTMLDivElement | null>(null);
@@ -262,14 +268,24 @@ export default function FileList(props: FileListProps) {
     return (
         <div className={classNames(styles.container, className)}>
             <div
-                className={classNames(styles.list, {
-                    [styles.horizontalOverflow]: isColumnWidthOverflowing,
-                })}
+                className={classNames(styles.list)}
                 style={{
                     height: isRoot ? undefined : `${calculatedHeight}px`,
                 }}
                 ref={measuredNodeRef}
             >
+                <div
+                    className={classNames({
+                        [styles.horizontalOverflow]: isColumnWidthOverflowing,
+                        [styles.horizontalOverflowAdjusted]: isRowHeightOverflowing,
+                    })}
+                ></div>
+                <div
+                    className={classNames({
+                        [styles.verticalOverflow]: isRowHeightOverflowing,
+                        [styles.verticalOverflowAdjusted]: isColumnWidthOverflowing,
+                    })}
+                ></div>
                 {content}
             </div>
             <p className={styles.rowCountDisplay}>

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -283,14 +283,14 @@ export default function FileList(props: FileListProps) {
             >
                 <div
                     className={classNames({
-                        [styles.horizontalOverflow]: isColumnWidthOverflowing,
-                        [styles.horizontalOverflowAdjusted]: isRowHeightOverflowing,
+                        [styles.horizontalGradient]: isColumnWidthOverflowing,
+                        [styles.horizontalGradientCropped]: isRowHeightOverflowing,
                     })}
                 ></div>
                 <div
                     className={classNames({
-                        [styles.verticalOverflow]: isRowHeightOverflowing && !atEndOfList,
-                        [styles.verticalOverflowAdjusted]: isColumnWidthOverflowing,
+                        [styles.verticalGradient]: isRowHeightOverflowing && !atEndOfList,
+                        [styles.verticalGradientCropped]: isColumnWidthOverflowing,
                     })}
                 ></div>
                 {content}

--- a/packages/core/styles/global.css
+++ b/packages/core/styles/global.css
@@ -42,7 +42,7 @@ main {
     }
     body *::-webkit-scrollbar-thumb {
         background-color: var(--medium-grey);
-        border-radius: 8px
+        border-radius: 8px;
     }
 }
 

--- a/packages/core/styles/global.css
+++ b/packages/core/styles/global.css
@@ -34,8 +34,8 @@ main {
 @supports selector(::-webkit-scrollbar) {
     body *::-webkit-scrollbar {
         background-color: var(--accent-dark);
-        width: 12px;
-        height: 12px;
+        width: var(--scrollbar-size);
+        height: var(--scrollbar-size);
     }
     body *::-webkit-scrollbar-corner {
         background-color: var(--accent-dark);
@@ -94,6 +94,7 @@ body {
     --margin: 12px;
     --transition-duration: 0.5s;
     --font-family: 'Open Sans', sans-serif;
+    --scrollbar-size: 12px;
 }
 
 h1 {


### PR DESCRIPTION
## Context
Adds gradient overlays per the [recommended styling](https://www.figma.com/design/oNQvOAK11YINcbPvNmkgwO/Public-File-Explorer?node-id=3573-21439&node-type=frame&t=3MLreBhpvESyg2XI-0) for making it clearer when file lists are scrollable
closes #335 

## Changes
Added overlays to the FileLists and to the root DirectoryTree
Needed to do some funky css to account for the disappearing scrollbars in Chrome/Firefox vs permanently visible scrollbars in Safari/Chromium

### NOT addressed
The styling guide includes recommendations for when to show or hide scrollbars. Unfortunately, we generally don't have control over this since it's determined by the browser settings

## Testing
Visual checks on different browsers and web vs desktop

## Screenshots
Apologies for weirdly annotated screenshots

### Chrome/Firefox: (scrollbars disappear)

<img width="1148" alt="Screenshot 2025-02-27 at 12 50 58 PM" src="https://github.com/user-attachments/assets/e45af959-286b-4e4f-9a0c-963fbf93e585" />
<img width="1046" alt="Screenshot 2025-02-27 at 12 54 24 PM" src="https://github.com/user-attachments/assets/7ff328a5-d396-4563-af0b-7a36a2a045de" />
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/e95b9359-5a99-43ef-bf0c-239de26b0f49" />

### Safari/Desktop: (scrollbars always visible)

<img width="1057" alt="Screenshot 2025-02-27 at 12 59 32 PM" src="https://github.com/user-attachments/assets/83187157-2ab9-479e-94dc-5e56ce276fb9" />
