### PR TITLE
Add 'Browser' as an open with option + fix some path bugs

### DIFF
--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -80,7 +80,7 @@ export default function FileAnnotationList(props: FileAnnotationListProps) {
 
             if (annotation.name === AnnotationName.FILE_PATH) {
                 // Display the full http://... URL
-                annotationValue = fileDetails.cloudPath;
+                annotationValue = fileDetails.path;
             }
 
             if (annotationValue === Annotation.MISSING_VALUE) {

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -141,7 +141,7 @@ export default function FileDetails(props: Props) {
                 ])
             );
         }, 1000); // 1s, in ms (arbitrary)
-    }, [dispatch, fileDetails]);
+    }, [dispatch, fileDetails, fileDownloadService.isFileSystemAccessible]);
 
     return (
         <div

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -99,9 +99,7 @@ export default function FileDetails(props: Props) {
                 if (fileDetails.size && fileDetails.size > 0) {
                     setCalculatedSize(fileDetails.size);
                 } else {
-                    const { hostname, key } = fileDownloadService.parseS3Url(
-                        fileDetails.downloadPath
-                    );
+                    const { hostname, key } = fileDownloadService.parseS3Url(fileDetails.path);
                     fileDownloadService
                         .calculateS3DirectorySize(hostname, key)
                         .then(setCalculatedSize);
@@ -136,7 +134,9 @@ export default function FileDetails(props: Props) {
                         id: fileDetails.uid,
                         name: fileDetails.name,
                         size: fileDetails.size,
-                        path: fileDetails.downloadPath,
+                        path: fileDownloadService.isFileSystemAccessible
+                            ? fileDetails.localPath || fileDetails.path
+                            : fileDetails.path,
                     },
                 ])
             );

--- a/packages/core/entity/FileDetail/test/FileDetail.test.ts
+++ b/packages/core/entity/FileDetail/test/FileDetail.test.ts
@@ -4,32 +4,7 @@ import FileDetail from "..";
 import { Environment } from "../../../constants";
 
 describe("FileDetail", () => {
-    describe("file path representation", () => {
-        it("creates downloadPath from /allen path", () => {
-            // Arrange
-            const file_name = "MyFile.txt";
-            const file_id = "c32e3eed66e4416d9532d369ffe1636f";
-
-            // Act
-            const fileDetail = new FileDetail(
-                {
-                    file_path: `production.files.allencell.org/${file_name}`,
-                    file_name: file_name,
-                    file_id: file_id,
-                    annotations: [{ name: "Cache Eviction Date", values: ["SOME DATE"] }],
-                },
-                Environment.PRODUCTION
-            );
-
-            // Assert
-            expect(fileDetail.downloadPath).to.equal(
-                // The downloadPath is HTTP, but will get redirected to HTTPS
-                `http://aics.corp.alleninstitute.org/labkey/fmsfiles/image/allen/programs/allencell/data/proj0/${file_name}`
-            );
-        });
-    });
-
-    describe("getLocalPath", () => {
+    describe("localPath", () => {
         it("creates localPath correctly for production environment", () => {
             // Arrange
             const file_name = "ProdFile.czi";
@@ -48,7 +23,7 @@ describe("FileDetail", () => {
             );
 
             // Assert
-            expect(fileDetail.getLocalPath()).to.equal(
+            expect(fileDetail.localPath).to.equal(
                 `/allen/programs/allencell/data/proj0/${file_name}`
             );
         });
@@ -71,7 +46,7 @@ describe("FileDetail", () => {
             );
 
             // Assert
-            expect(fileDetail.getLocalPath()).to.equal(
+            expect(fileDetail.localPath).to.equal(
                 `/allen/aics/software/apps/staging/fss/data/${file_name}`
             );
         });

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -11,6 +11,7 @@ import styles from "./useOpenWithMenuItems.module.css";
 
 enum AppKeys {
     AGAVE = "agave",
+    BROWSER = "browser",
     NEUROGLANCER = "neuroglancer",
     SIMULARIUM = "simularium",
     VOLE = "vole",
@@ -19,6 +20,7 @@ enum AppKeys {
 
 interface Apps {
     [AppKeys.AGAVE]: IContextualMenuItem;
+    [AppKeys.BROWSER]: IContextualMenuItem;
     [AppKeys.NEUROGLANCER]: IContextualMenuItem;
     [AppKeys.SIMULARIUM]: IContextualMenuItem;
     [AppKeys.VOLE]: IContextualMenuItem;
@@ -72,11 +74,27 @@ const APPS = (fileDetails?: FileDetail): Apps => ({
             );
         },
     } as IContextualMenuItem,
+    [AppKeys.BROWSER]: {
+        key: AppKeys.BROWSER,
+        text: "Browser",
+        title: `Open files in the current browser in a new tab`,
+        href: fileDetails?.path,
+        disabled: !fileDetails?.path,
+        target: "_blank",
+        onRenderContent(props, defaultRenders) {
+            return (
+                <>
+                    {defaultRenders.renderItemName(props)}
+                    <span className={styles.secondaryText}>Web</span>
+                </>
+            );
+        },
+    } as IContextualMenuItem,
     [AppKeys.NEUROGLANCER]: {
         key: AppKeys.NEUROGLANCER,
         text: "Neuroglancer",
         title: `Open files with Neuroglancer`,
-        href: `https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22zarr://${fileDetails?.cloudPath}%22,%22name%22:%22${fileDetails?.name}%22}]}`,
+        href: `https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22zarr://${fileDetails?.path}%22,%22name%22:%22${fileDetails?.name}%22}]}`,
         disabled: !fileDetails?.path,
         target: "_blank",
         onRenderContent(props, defaultRenders) {
@@ -92,7 +110,7 @@ const APPS = (fileDetails?: FileDetail): Apps => ({
         key: AppKeys.SIMULARIUM,
         text: "Simularium",
         title: `Open files with Simularium`,
-        href: `https://simularium.allencell.org/viewer?trajUrl=${fileDetails?.cloudPath}`,
+        href: `https://simularium.allencell.org/viewer?trajUrl=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
         target: "_blank",
         onRenderContent(props, defaultRenders) {
@@ -108,7 +126,7 @@ const APPS = (fileDetails?: FileDetail): Apps => ({
         key: AppKeys.VOLE,
         text: "Vol-E",
         title: `Open files with Vol-E`,
-        href: `https://volumeviewer.allencell.org/viewer?url=${fileDetails?.cloudPath}/`,
+        href: `https://volumeviewer.allencell.org/viewer?url=${fileDetails?.path}/`,
         disabled: !fileDetails?.path,
         target: "_blank",
         onRenderContent(props, defaultRenders) {
@@ -124,7 +142,7 @@ const APPS = (fileDetails?: FileDetail): Apps => ({
         key: AppKeys.VOLVIEW,
         text: "VolView",
         title: `Open files with VolView`,
-        href: `https://volview.kitware.app/?urls=[${fileDetails?.cloudPath}]`,
+        href: `https://volview.kitware.app/?urls=[${fileDetails?.path}]`,
         disabled: !fileDetails?.path,
         target: "_blank",
         onRenderContent(props, defaultRenders) {
@@ -149,6 +167,17 @@ function getSupportedApps(fileDetails?: FileDetail): IContextualMenuItem[] {
     const fileExt = fileDetails.path.slice(fileDetails.path.lastIndexOf(".") + 1).toLowerCase();
     const apps = APPS(fileDetails);
     switch (fileExt) {
+        case "bmp":
+        case "html":
+        case "gif":
+        case "jpg":
+        case "jpeg":
+        case "pdf":
+        case "png":
+        case "svg":
+        case "txt":
+        case "xml":
+            return [apps.browser];
         case "simularium":
             return [apps.simularium];
         case "dcm":

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -218,7 +218,9 @@ const downloadFilesLogic = createLogic({
                 id: file.uid,
                 name: file.name,
                 size: file.size,
-                path: file.downloadPath,
+                path: fileDownloadService.isFileSystemAccessible
+                    ? file.localPath || file.path
+                    : file.path,
             }));
         }
 

--- a/packages/core/state/interaction/test/logics.test.ts
+++ b/packages/core/state/interaction/test/logics.test.ts
@@ -1234,9 +1234,9 @@ describe("Interaction logics", () => {
     });
 
     describe("openWith", () => {
-        const files: { file_path: string }[] = [];
+        const files: { file_path: string; annotations: any[] }[] = [];
         for (let i = 0; i <= 100; i++) {
-            files.push({ file_path: `/allen/file_${i}.ext` });
+            files.push({ file_path: `/allen/file_${i}.ext`, annotations: [] });
         }
         const fileExplorerServiceBaseUrl = FESBaseUrl.TEST;
         const responseStub = {


### PR DESCRIPTION
## Context
AIBS requested we add the Browser as an option for opening files with since they discovered this will happen (sometimes) to .png files that you click "Download" for (that aspect we can't really control)

## Changes
* Adds "Browser" as an option with option
* Cleans up path properties and getter to be simpler - also there was some buggy stuff happening to our internal paths due to being linked to the NGINX server unnecessarily + to external thumbnails since we were checking for the name not the path

## Testing
Tested using our data & some makeshift datasets pointing to random txt, png, and gifs on the web

