### PR TITLE
Add "Save as" option for full query

### DIFF
--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -231,7 +231,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                         },
                         {
                             key: FilterType.EXCLUDE,
-                            text: "No value (blank)",
+                            text: "No value",
                         },
                     ]}
                     onChange={(_, option) => onFilterTypeOptionChange(option)}

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -178,6 +178,8 @@ export default function Query(props: QueryProps) {
                 isDeletable={queries.length > 1}
                 onQueryDelete={onQueryDelete}
                 query={props.query}
+                groups={queryComponents.hierarchy}
+                filters={queryComponents.filters}
             />
         </div>
     );

--- a/packages/core/components/QuerySidebar/QueryFooter.tsx
+++ b/packages/core/components/QuerySidebar/QueryFooter.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TertiaryButton } from "../Buttons";
+import { ContextualMenuItemType } from "../ContextMenu";
 import { ModalType } from "../Modal";
 import Tutorial from "../../entity/Tutorial";
 import { interaction, selection } from "../../state";
@@ -23,6 +24,8 @@ interface Props {
 export default function QueryFooter(props: Props) {
     const dispatch = useDispatch();
 
+    const fileFilters = useSelector(selection.selectors.getFileFilters);
+    const isQueryingAicsFms = useSelector(selection.selectors.isQueryingAicsFms);
     const url = useSelector(selection.selectors.getEncodedFileExplorerUrl);
 
     const isEmptyQuery = !props.query.parts.sources.length;
@@ -69,6 +72,47 @@ export default function QueryFooter(props: Props) {
             onClick: props.onQueryDelete,
         },
     ];
+    const saveQueryAsOptions: IContextualMenuItem[] = [
+        {
+            key: "Save query header",
+            text: "DATA SOURCE TYPES",
+            title: "Types of data sources available for export",
+            itemType: ContextualMenuItemType.Header,
+        },
+        {
+            key: "csv",
+            text: "CSV",
+            title: "Download a CSV containing the results of the current query",
+            onClick() {
+                dispatch(interaction.actions.showManifestDownloadDialog("csv", fileFilters));
+            },
+        },
+        // Can't download JSON or Parquet files when querying AICS FMS
+        ...(isQueryingAicsFms
+            ? []
+            : [
+                  {
+                      key: "json",
+                      text: "JSON",
+                      title: "Download a JSON file containing the result of the current query",
+                      onClick() {
+                          dispatch(
+                              interaction.actions.showManifestDownloadDialog("json", fileFilters)
+                          );
+                      },
+                  },
+                  {
+                      key: "parquet",
+                      text: "Parquet",
+                      title: "Download a Parquet file containing the result of the current query",
+                      onClick() {
+                          dispatch(
+                              interaction.actions.showManifestDownloadDialog("parquet", fileFilters)
+                          );
+                      },
+                  },
+              ]),
+    ];
 
     const onRefresh = throttle(
         () => {
@@ -80,6 +124,13 @@ export default function QueryFooter(props: Props) {
 
     return (
         <div className={styles.container}>
+            <TertiaryButton
+                invertColor
+                disabled={isEmptyQuery}
+                iconName="Saveas"
+                menuItems={saveQueryAsOptions}
+                title="Save query result as..."
+            />
             <TertiaryButton
                 invertColor
                 disabled={isEmptyQuery}

--- a/packages/core/components/QuerySidebar/QueryFooter.tsx
+++ b/packages/core/components/QuerySidebar/QueryFooter.tsx
@@ -127,13 +127,6 @@ export default function QueryFooter(props: Props) {
             <TertiaryButton
                 invertColor
                 disabled={isEmptyQuery}
-                iconName="Saveas"
-                menuItems={saveQueryAsOptions}
-                title="Save query result as..."
-            />
-            <TertiaryButton
-                invertColor
-                disabled={isEmptyQuery}
                 iconName="Delete"
                 menuItems={deleteQueryOptions}
                 title="Delete query"
@@ -151,6 +144,13 @@ export default function QueryFooter(props: Props) {
                 iconName="Copy"
                 onClick={() => dispatch(selection.actions.addQuery(props.query))}
                 title="Duplicate query"
+            />
+            <TertiaryButton
+                invertColor
+                disabled={isEmptyQuery}
+                iconName="Save"
+                menuItems={saveQueryAsOptions}
+                title="Save query result as..."
             />
             <TertiaryButton
                 invertColor

--- a/packages/core/components/QuerySidebar/QueryFooter.tsx
+++ b/packages/core/components/QuerySidebar/QueryFooter.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TertiaryButton } from "../Buttons";
-import { ContextualMenuItemType } from "../ContextMenu";
 import { ModalType } from "../Modal";
 import Tooltip from "../Tooltip";
 import Tutorial from "../../entity/Tutorial";
 import FileFilter from "../../entity/FileFilter";
 import IncludeFilter from "../../entity/FileFilter/IncludeFilter";
 import FileSet from "../../entity/FileSet";
+import useSaveMetadataOptions from "../../hooks/useSaveMetadataOptions";
 import { interaction, selection } from "../../state";
 import { Query } from "../../state/selection/actions";
 
@@ -32,7 +32,6 @@ interface Props {
 export default function QueryFooter(props: Props) {
     const dispatch = useDispatch();
 
-    const isQueryingAicsFms = useSelector(selection.selectors.isQueryingAicsFms);
     const url = useSelector(selection.selectors.getEncodedFileExplorerUrl);
     const fileService = useSelector(interaction.selectors.getFileService);
     const [totalFileCount, setTotalFileCount] = React.useState(0);
@@ -110,53 +109,7 @@ export default function QueryFooter(props: Props) {
             onClick: props.onQueryDelete,
         },
     ];
-    const saveQueryAsOptions: IContextualMenuItem[] = [
-        {
-            key: "Save query header",
-            text: "DATA SOURCE TYPES",
-            title: "Types of data sources available for export",
-            itemType: ContextualMenuItemType.Header,
-        },
-        {
-            key: "csv",
-            text: "CSV",
-            title: "Download a CSV containing the results of the current query",
-            onClick() {
-                dispatch(interaction.actions.showManifestDownloadDialog("csv", combinedFilters));
-            },
-        },
-        // Can't download JSON or Parquet files when querying AICS FMS
-        ...(isQueryingAicsFms
-            ? []
-            : [
-                  {
-                      key: "json",
-                      text: "JSON",
-                      title: "Download a JSON file containing the result of the current query",
-                      onClick() {
-                          dispatch(
-                              interaction.actions.showManifestDownloadDialog(
-                                  "json",
-                                  combinedFilters
-                              )
-                          );
-                      },
-                  },
-                  {
-                      key: "parquet",
-                      text: "Parquet",
-                      title: "Download a Parquet file containing the result of the current query",
-                      onClick() {
-                          dispatch(
-                              interaction.actions.showManifestDownloadDialog(
-                                  "parquet",
-                                  combinedFilters
-                              )
-                          );
-                      },
-                  },
-              ]),
-    ];
+    const saveQueryAsOptions = useSaveMetadataOptions(combinedFilters, true);
 
     const onRefresh = throttle(
         () => {

--- a/packages/core/entity/FileSelection/index.ts
+++ b/packages/core/entity/FileSelection/index.ts
@@ -496,7 +496,8 @@ export default class FileSelection {
     public toCompactSelectionList(): Selection[] {
         return [...this.groupByFileSet().entries()].map(([fileSet, selectedRanges]) => ({
             filters: fileSet.filters.reduce((accum, filter) => {
-                if (filter.type === FilterType.DEFAULT) {
+                // Include values for fuzzy filters if present
+                if (filter.type === FilterType.DEFAULT || filter.type === FilterType.FUZZY) {
                     return {
                         ...accum,
                         [filter.name]: [...(accum[filter.name] || []), filter.value],

--- a/packages/core/entity/FileSelection/test/FileSelection.test.ts
+++ b/packages/core/entity/FileSelection/test/FileSelection.test.ts
@@ -678,14 +678,15 @@ describe("FileSelection", () => {
         it("produces array of selections grouped by fileset", () => {
             // Arrange
             const fuzzyFilterNames: string[] = ["fuzzyFilterName1", "fuzzyFilterName2"];
+            const fuzzyFilterValues: string[] = ["fuzzyFilterValue0", "fuzzyFilterValue1"];
             const includeFilterName = "includeFilterName";
             const excludeFilterName = "excludeFilterName";
             const fileSet1 = new FileSet();
             const fileSet2 = new FileSet({
                 filters: [
                     new FileFilter("filterName", "filterValue"),
-                    new FuzzyFilter(fuzzyFilterNames[0]),
-                    new FuzzyFilter(fuzzyFilterNames[1]),
+                    new FuzzyFilter(fuzzyFilterNames[0], fuzzyFilterValues[0]),
+                    new FuzzyFilter(fuzzyFilterNames[1], fuzzyFilterValues[1]),
                     new IncludeFilter(includeFilterName),
                     new ExcludeFilter(excludeFilterName),
                 ],
@@ -706,7 +707,11 @@ describe("FileSelection", () => {
                 new NumericRange(3).toJSON(),
                 new NumericRange(12, 15).toJSON(),
             ]);
-            expect(selections[1].filters).to.deep.equal({ filterName: ["filterValue"] });
+            expect(selections[1].filters).to.deep.equal({
+                filterName: ["filterValue"],
+                [fuzzyFilterNames[0]]: [fuzzyFilterValues[0]],
+                [fuzzyFilterNames[1]]: [fuzzyFilterValues[1]],
+            });
             expect(selections[1].fuzzy).to.deep.equal([fuzzyFilterNames[0], fuzzyFilterNames[1]]);
             expect(selections[1].include).to.deep.equal([includeFilterName]);
             expect(selections[1].exclude).to.deep.equal([excludeFilterName]);

--- a/packages/core/hooks/useFileAccessContextMenu.ts
+++ b/packages/core/hooks/useFileAccessContextMenu.ts
@@ -1,8 +1,9 @@
-import { ContextualMenuItemType, IContextualMenuItem } from "@fluentui/react";
+import { IContextualMenuItem } from "@fluentui/react";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import useOpenWithMenuItems from "./useOpenWithMenuItems";
+import useSaveMetadataOptions from "./useSaveMetadataOptions";
 import FileDetail from "../entity/FileDetail";
 import FileFilter from "../entity/FileFilter";
 import { interaction, selection } from "../state";
@@ -23,6 +24,7 @@ export default (folderFilters?: FileFilter[], onDismiss?: () => void) => {
     const [fileDetails, setFileDetails] = React.useState<FileDetail>();
 
     const openWithSubMenuItems = useOpenWithMenuItems(fileDetails, folderFilters);
+    const saveAsSubMenuItems = useSaveMetadataOptions(folderFilters);
 
     fileSelection.fetchFocusedItemDetails().then((fileDetails) => {
         setFileDetails(fileDetails);
@@ -100,63 +102,7 @@ export default (folderFilters?: FileFilter[], onDismiss?: () => void) => {
                         iconName: "Save",
                     },
                     subMenuProps: {
-                        items: [
-                            {
-                                key: "save-as-title",
-                                text: "DATA SOURCE TYPES",
-                                title: "Types of data sources available for export",
-                                itemType: ContextualMenuItemType.Header,
-                            },
-                            {
-                                key: "csv",
-                                text: "CSV",
-                                disabled: !folderFilters && fileSelection.count() === 0,
-                                title: "Download a CSV of the metadata of the selected files",
-                                onClick() {
-                                    dispatch(
-                                        interaction.actions.showManifestDownloadDialog(
-                                            "csv",
-                                            folderFilters
-                                        )
-                                    );
-                                },
-                            },
-                            // Can't download JSON or Parquet files when querying AICS FMS
-                            ...(isQueryingAicsFms
-                                ? []
-                                : [
-                                      {
-                                          key: "json",
-                                          text: "JSON",
-                                          disabled: !folderFilters && fileSelection.count() === 0,
-                                          title:
-                                              "Download a JSON file of the metadata of the selected files",
-                                          onClick() {
-                                              dispatch(
-                                                  interaction.actions.showManifestDownloadDialog(
-                                                      "json",
-                                                      folderFilters
-                                                  )
-                                              );
-                                          },
-                                      },
-                                      {
-                                          key: "parquet",
-                                          text: "Parquet",
-                                          disabled: !folderFilters && fileSelection.count() === 0,
-                                          title:
-                                              "Download a Parquet file of the metadata of the selected files",
-                                          onClick() {
-                                              dispatch(
-                                                  interaction.actions.showManifestDownloadDialog(
-                                                      "parquet",
-                                                      folderFilters
-                                                  )
-                                              );
-                                          },
-                                      },
-                                  ]),
-                        ],
+                        items: saveAsSubMenuItems,
                     },
                 },
                 ...(isQueryingAicsFms && !isOnWeb
@@ -200,6 +146,7 @@ export default (folderFilters?: FileFilter[], onDismiss?: () => void) => {
             isQueryingAicsFms,
             onDismiss,
             openWithSubMenuItems,
+            saveAsSubMenuItems,
         ]
     );
 };

--- a/packages/core/hooks/useFileAccessContextMenu.ts
+++ b/packages/core/hooks/useFileAccessContextMenu.ts
@@ -97,7 +97,7 @@ export default (folderFilters?: FileFilter[], onDismiss?: () => void) => {
                     text: "Save metadata as",
                     disabled: !folderFilters && fileSelection.count() === 0,
                     iconProps: {
-                        iconName: "Saveas",
+                        iconName: "Save",
                     },
                     subMenuProps: {
                         items: [

--- a/packages/core/hooks/useSaveMetadataOptions.ts
+++ b/packages/core/hooks/useSaveMetadataOptions.ts
@@ -1,0 +1,57 @@
+import { ContextualMenuItemType, IContextualMenuItem } from "@fluentui/react";
+import { useDispatch, useSelector } from "react-redux";
+
+import FileFilter from "../entity/FileFilter";
+import { interaction, selection } from "../state";
+
+export default function useSaveMetadataOptions(
+    filters?: FileFilter[],
+    isSavingFullQuery?: boolean
+): IContextualMenuItem[] {
+    const dispatch = useDispatch();
+    const isQueryingAicsFms = useSelector(selection.selectors.isQueryingAicsFms);
+
+    const descriptor = !!isSavingFullQuery
+        ? "containing the result of the current query"
+        : "of the metadata of the selected files";
+
+    return [
+        {
+            key: "save-as-header",
+            text: "DATA SOURCE TYPES",
+            title: "Types of data sources available for export",
+            itemType: ContextualMenuItemType.Header,
+        },
+        {
+            key: "csv",
+            text: "CSV",
+            title: `Download a CSV ${descriptor}`,
+            onClick() {
+                dispatch(interaction.actions.showManifestDownloadDialog("csv", filters));
+            },
+        },
+        // Can't download JSON or Parquet files when querying AICS FMS
+        ...(isQueryingAicsFms
+            ? []
+            : [
+                  {
+                      key: "json",
+                      text: "JSON",
+                      title: `Download a JSON file ${descriptor}`,
+                      onClick() {
+                          dispatch(interaction.actions.showManifestDownloadDialog("json", filters));
+                      },
+                  },
+                  {
+                      key: "parquet",
+                      text: "Parquet",
+                      title: `Download a Parquet file ${descriptor}`,
+                      onClick() {
+                          dispatch(
+                              interaction.actions.showManifestDownloadDialog("parquet", filters)
+                          );
+                      },
+                  },
+              ]),
+    ];
+}

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -5,6 +5,8 @@ import DatabaseService from "../../DatabaseService";
 import DatabaseServiceNoop from "../../DatabaseService/DatabaseServiceNoop";
 import FileDownloadService, { DownloadResolution, DownloadResult } from "../../FileDownloadService";
 import FileDownloadServiceNoop from "../../FileDownloadService/FileDownloadServiceNoop";
+import IncludeFilter from "../../../entity/FileFilter/IncludeFilter";
+import ExcludeFilter from "../../../entity/FileFilter/ExcludeFilter";
 import FileSelection from "../../../entity/FileSelection";
 import FileSet from "../../../entity/FileSet";
 import FileDetail from "../../../entity/FileDetail";
@@ -164,7 +166,7 @@ export default class DatabaseFileService implements FileService {
     }
 
     /**
-     * Applies filters and sorting to a query. ie Column names, if none then use annotaitonName
+     * Applies filters and sorting to a query. ie Column names, if none then use annotationName
      */
     public static applyFiltersAndSorting(subQuery: SQLBuilder, selection: Selection): void {
         if (!isEmpty(selection.filters)) {
@@ -172,6 +174,20 @@ export default class DatabaseFileService implements FileService {
                 Object.entries(selection.filters).flatMap(([column, values]) =>
                     values.map((v) => SQLBuilder.regexMatchValueInList(column, v)).join(" OR ")
                 )
+            );
+        }
+        if (selection.include && selection.include.length > 0) {
+            subQuery.where(
+                selection.include
+                    .map((annotationName) => new IncludeFilter(annotationName).toSQLWhereString())
+                    .join(" AND ")
+            );
+        }
+        if (selection.exclude && selection.exclude.length > 0) {
+            subQuery.where(
+                selection.exclude
+                    .map((annotationName) => new ExcludeFilter(annotationName).toSQLWhereString())
+                    .join(" AND ")
             );
         }
         if (selection.sort) {

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -108,7 +108,8 @@ const downloadManifest = createLogic({
         const filters = interactionSelectors.getFileFiltersForVisibleModal(deps.getState());
 
         // If we have a specific path to get files from ignore selected files
-        if (filters.length) {
+        // or if no selections, assume downloading full result
+        if (filters.length || (filters.length === 0 && fileSelection.count() === 0)) {
             const fileSet = new FileSet({
                 filters,
                 fileService,
@@ -126,6 +127,7 @@ const downloadManifest = createLogic({
 
         const selections = fileSelection.toCompactSelectionList();
 
+        // if still empty result set, do nothing
         if (isEmpty(selections)) {
             done();
             return;


### PR DESCRIPTION
## Context
Allow users to save the full result of a query without individually selecting files
closes #462 

## Changes
Adds a button to the query panel that opens the same "Download metadata manifest" modal as from the file context menu.
Prevents metadata manifest downloads when more than 250,000 files (semi-arbitrarily chosen large number, open to change) are selected.

Also addresses a couple bugs: 
1. For FMS files: the **values** for fuzzy filters were not being included in the query logic for manifests via regular file selection (see packages/core/entity/FileSelection/index.ts)
   - To replicate: Go [here](https://staging.bff.allencell.org/app?c=file_name%3A0.4%2CKind%3A0.2%2CType%3A0.25%2Cfile_size%3A0.15&group=Cell+Line&filter=%7B%22name%22%3A%22file_name%22%2C%22value%22%3A%22CFTest%22%2C%22type%22%3A%22fuzzy%22%7D&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282025-01-01T08%3A00%3A00.000Z%2C2025-03-16T06%3A59%3A59.512Z%29%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22AICS-61%22%5D&openFolder=%5B%22AICS-0%22%5D&openFolder=%5B%22AAVS1-NDi-CRISPRi%22%5D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D) and try doing 'Save metadata as -> csv' for AICS-0/CFTest4.java. The metadata for the wrong file will be downloaded
2. For csv/duckdb data sources: include/exclude filters weren't included in the SQL for downloading metadata
   - To replicate: Go [here](https://staging.bff.allencell.org/app?c=File+Name%3A0.25%2CDrug+Concentration%3A0.25%2CCell+Line%3A0.25&filter=%7B%22name%22%3A%22Drug+Concentration%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22include%22%7D&source=%7B%22name%22%3A%22All%2BAICS%2BDatasets.csv+%283%2F14%2F2025+11%3A11%3A23+AM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fbiofile-finder-datasets.s3.us-west-2.amazonaws.com%2FAll%2BAICS%2BDatasets.csv%22%7D), select a few files, and save their metadata. The metadata for the wrong files will be downloaded

## Testing
Manually tested:
- Downloading csv for AICS with filters applied
- Downloading csv, json, and parquet for non-AICS data sources with filters applied
- Downloading without filters applied
- Disabling button when file selection >250,000

## Screenshots
<img width="291" alt="image" src="https://github.com/user-attachments/assets/25d30d25-585e-410f-80df-dd1a75f4a580" />

Uses same dropdown as context menu
<img width="386" alt="image" src="https://github.com/user-attachments/assets/e8e4eaa4-744c-4375-ad32-e4bec4cb8eab" />

Prevents downloading metadata for large file counts
<img width="387" alt="image" src="https://github.com/user-attachments/assets/772a37d7-403e-46f8-960c-1d351db0a14d" />

