### PR TITLE
Feature/optional params on components

### DIFF
--- a/packages/core/components/Buttons/BaseButton.tsx
+++ b/packages/core/components/Buttons/BaseButton.tsx
@@ -62,7 +62,7 @@ export default function BaseButton(props: Props) {
                     [styles.disabled]: props.disabled,
                     [styles.selected]: props.isSelected,
                 })}
-                data-testid={`base-button-${props.title}`}
+                data-testid={`base-button-${props.id}`}
                 ariaLabel={props.title}
                 disabled={props.disabled}
                 id={props.id}

--- a/packages/core/components/Buttons/BaseButton.tsx
+++ b/packages/core/components/Buttons/BaseButton.tsx
@@ -17,7 +17,9 @@ interface Props {
     menuItems?: IContextualMenuItem[];
     onClick?: () => void;
     text?: string;
-    title: string;
+    // title is only required if tooltip would be different from button text
+    // or if button does not have text (e.g., icon only)
+    title?: string;
 }
 
 /**

--- a/packages/core/components/Buttons/PrimaryButton.tsx
+++ b/packages/core/components/Buttons/PrimaryButton.tsx
@@ -15,7 +15,7 @@ interface Props {
     menuItems?: IContextualMenuItem[];
     onClick?: () => void;
     text?: string;
-    title: string;
+    title?: string;
 }
 
 /**

--- a/packages/core/components/Buttons/SecondaryButton.tsx
+++ b/packages/core/components/Buttons/SecondaryButton.tsx
@@ -15,7 +15,7 @@ interface Props {
     menuItems?: IContextualMenuItem[];
     onClick?: () => void;
     text?: string;
-    title: string;
+    title?: string;
 }
 
 /**

--- a/packages/core/components/Buttons/test/BaseButton.test.tsx
+++ b/packages/core/components/Buttons/test/BaseButton.test.tsx
@@ -8,20 +8,21 @@ describe("<BaseButton />", () => {
     it("does not perform click when disabled", () => {
         // Arrange
         const title = "Mock";
+        const testId = "mock-id";
         let wasClicked = false;
         const onClick = () => {
             wasClicked = true;
         };
 
         const { getByTestId } = render(
-            <BaseButton disabled onClick={onClick} iconName="Download" title={title} />
+            <BaseButton disabled onClick={onClick} iconName="Download" title={title} id={testId} />
         );
 
         // (sanity-check) no click
         expect(wasClicked).to.be.false;
 
         // Act
-        fireEvent.click(getByTestId(`base-button-${title}`));
+        fireEvent.click(getByTestId(`base-button-${testId}`));
 
         // Assert
         expect(wasClicked).to.be.false;
@@ -30,20 +31,21 @@ describe("<BaseButton />", () => {
     it("performs click when not disabled", () => {
         // Arrange
         const title = "Mock";
+        const testId = "mock-id";
         let wasClicked = false;
         const onClick = () => {
             wasClicked = true;
         };
 
         const { getByTestId } = render(
-            <BaseButton onClick={onClick} iconName="Download" title={title} />
+            <BaseButton onClick={onClick} iconName="Download" title={title} id={testId} />
         );
 
         // (sanity-check) no click
         expect(wasClicked).to.be.false;
 
         // Act
-        fireEvent.click(getByTestId(`base-button-${title}`));
+        fireEvent.click(getByTestId(`base-button-${testId}`));
 
         // Assert
         expect(wasClicked).to.be.true;

--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -74,13 +74,12 @@ export default function FilePrompt(props: Props) {
             <form>
                 <label
                     aria-label="Browse for a file on your machine"
-                    title="Browse for a file on your machine"
                     htmlFor="data-source-selector"
                 >
                     <SecondaryButton
                         iconName="DocumentSearch"
                         text="Choose file"
-                        title="Choose file"
+                        title="Browse for a file on your machine"
                     />
                 </label>
                 <input

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -193,12 +193,9 @@ export default function DataSourcePrompt(props: Props) {
                 </DefaultButton>
             )}
             <div className={styles.loadButtonContainer}>
-                {props.hideTitle && (
-                    <SecondaryButton title="Cancel" text="CANCEL" onClick={() => onDismiss()} />
-                )}
+                {props.hideTitle && <SecondaryButton text="CANCEL" onClick={() => onDismiss()} />}
                 <PrimaryButton
                     disabled={!dataSource}
-                    title="Load"
                     text="LOAD"
                     onClick={() => dataSource && onSubmit(dataSource, metadataSource)}
                 />

--- a/packages/core/components/DateRangePicker/index.tsx
+++ b/packages/core/components/DateRangePicker/index.tsx
@@ -99,6 +99,7 @@ export default function DateRangePicker(props: DateRangePickerProps) {
                     iconName="Clear"
                     onClick={onReset}
                     title="Reset"
+                    id="reset-date"
                 />
             </div>
         </div>

--- a/packages/core/components/DateRangePicker/test/DateRangePicker.test.tsx
+++ b/packages/core/components/DateRangePicker/test/DateRangePicker.test.tsx
@@ -63,7 +63,7 @@ describe("<DateRangePicker />", () => {
 
         // Hit reset
         expect(onReset.called).to.equal(false);
-        fireEvent.click(getByTestId("base-button-Reset"));
+        fireEvent.click(getByTestId("base-button-reset-date"));
         expect(onReset.called).to.equal(true);
     });
 });

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -181,7 +181,7 @@ export default function FileDetails(props: Props) {
                                         disabled={isDownloadDisabled}
                                         iconName="Download"
                                         text="Download"
-                                        title="Download"
+                                        title="Download file to local system"
                                         onClick={onDownload}
                                     />
                                 </StackItem>
@@ -190,7 +190,7 @@ export default function FileDetails(props: Props) {
                                         className={styles.primaryButton}
                                         iconName="OpenInNewWindow"
                                         text="Open file"
-                                        title="Open file"
+                                        title="Open file by selected method"
                                         menuItems={openWithMenuItems}
                                     />
                                 </StackItem>

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -8,6 +8,7 @@ import { TertiaryButton } from "../../Buttons";
 interface BaseModalProps {
     body: React.ReactNode;
     footer?: React.ReactNode;
+    isDraggable?: boolean;
     onDismiss?: () => void;
     title?: string;
 }
@@ -23,7 +24,7 @@ const DRAG_OPTIONS: IDragOptions = {
  * for plugging content into.
  */
 export default function BaseModal(props: BaseModalProps) {
-    const { body, footer, title, onDismiss } = props;
+    const { body, footer, isDraggable, title, onDismiss } = props;
 
     const titleId = "base-modal-title";
     return (
@@ -31,7 +32,7 @@ export default function BaseModal(props: BaseModalProps) {
             isOpen
             onDismiss={onDismiss}
             containerClassName={styles.container}
-            dragOptions={DRAG_OPTIONS}
+            dragOptions={isDraggable ? DRAG_OPTIONS : undefined}
             titleAriaId={titleId}
             overlay={{ className: styles.overlay }}
         >

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -1,4 +1,4 @@
-import { ContextualMenu, IDragOptions, Modal } from "@fluentui/react";
+import { Modal } from "@fluentui/react";
 import { noop } from "lodash";
 import * as React from "react";
 
@@ -8,23 +8,16 @@ import { TertiaryButton } from "../../Buttons";
 interface BaseModalProps {
     body: React.ReactNode;
     footer?: React.ReactNode;
-    isDraggable?: boolean;
     onDismiss?: () => void;
     title?: string;
 }
-
-const DRAG_OPTIONS: IDragOptions = {
-    moveMenuItemText: "Move",
-    closeMenuItemText: "Close",
-    menu: ContextualMenu,
-};
 
 /**
  * Wrapper around @fluent-ui/react Modal with consistent defaults applied and some layout scaffolding
  * for plugging content into.
  */
 export default function BaseModal(props: BaseModalProps) {
-    const { body, footer, isDraggable, title, onDismiss } = props;
+    const { body, footer, title, onDismiss } = props;
 
     const titleId = "base-modal-title";
     return (
@@ -32,7 +25,6 @@ export default function BaseModal(props: BaseModalProps) {
             isOpen
             onDismiss={onDismiss}
             containerClassName={styles.container}
-            dragOptions={isDraggable ? DRAG_OPTIONS : undefined}
             titleAriaId={titleId}
             overlay={{ className: styles.overlay }}
         >

--- a/packages/core/components/Modal/CodeSnippet/index.tsx
+++ b/packages/core/components/Modal/CodeSnippet/index.tsx
@@ -108,5 +108,5 @@ export default function CodeSnippet({ onDismiss }: ModalProps) {
         </>
     );
 
-    return <BaseModal body={body} onDismiss={onDismiss} title="Code snippet" isDraggable />;
+    return <BaseModal body={body} onDismiss={onDismiss} title="Code snippet" />;
 }

--- a/packages/core/components/Modal/CodeSnippet/index.tsx
+++ b/packages/core/components/Modal/CodeSnippet/index.tsx
@@ -108,5 +108,5 @@ export default function CodeSnippet({ onDismiss }: ModalProps) {
         </>
     );
 
-    return <BaseModal body={body} onDismiss={onDismiss} title="Code snippet" />;
+    return <BaseModal body={body} onDismiss={onDismiss} title="Code snippet" isDraggable />;
 }

--- a/packages/core/components/Modal/CopyFileManifest/index.tsx
+++ b/packages/core/components/Modal/CopyFileManifest/index.tsx
@@ -182,14 +182,12 @@ export default function CopyFileManifest({ onDismiss }: ModalProps) {
                         className={styles.cancelButton}
                         onClick={onDismiss}
                         text="CANCEL"
-                        title=""
                     />
                     <PrimaryButton
                         className={styles.confirmButton}
                         disabled={loading || !!error}
                         onClick={onMove}
                         text="CONFIRM"
-                        title=""
                     />
                 </div>
             }

--- a/packages/core/components/Modal/MetadataManifest/index.tsx
+++ b/packages/core/components/Modal/MetadataManifest/index.tsx
@@ -64,7 +64,6 @@ export default function MetadataManifest({ onDismiss }: ModalProps) {
                         iconName="Download"
                         onClick={onDownload}
                         text="DOWNLOAD"
-                        title="Download"
                     />
                 </div>
             }

--- a/packages/core/components/Modal/SmallScreenWarning/index.tsx
+++ b/packages/core/components/Modal/SmallScreenWarning/index.tsx
@@ -33,14 +33,7 @@ export default function SmallScreenWarning({ onDismiss }: ModalProps) {
     return (
         <BaseModal
             body={body}
-            footer={
-                <PrimaryButton
-                    className={styles.okButton}
-                    onClick={_onDismiss}
-                    title="OK"
-                    text="OK"
-                />
-            }
+            footer={<PrimaryButton className={styles.okButton} onClick={_onDismiss} text="OK" />}
             onDismiss={_onDismiss}
             title={title}
         />

--- a/packages/core/components/Modal/SmallScreenWarning/index.tsx
+++ b/packages/core/components/Modal/SmallScreenWarning/index.tsx
@@ -33,7 +33,14 @@ export default function SmallScreenWarning({ onDismiss }: ModalProps) {
     return (
         <BaseModal
             body={body}
-            footer={<PrimaryButton className={styles.okButton} onClick={_onDismiss} text="OK" />}
+            footer={
+                <PrimaryButton
+                    className={styles.okButton}
+                    onClick={_onDismiss}
+                    text="OK"
+                    id="small-screen-ok"
+                />
+            }
             onDismiss={_onDismiss}
             title={title}
         />

--- a/packages/core/components/Modal/SmallScreenWarning/test/SmallScreenWarning.test.tsx
+++ b/packages/core/components/Modal/SmallScreenWarning/test/SmallScreenWarning.test.tsx
@@ -45,7 +45,7 @@ describe("<SmallScreenWarning />", () => {
         fireEvent.click(checkbox);
         await logicMiddleware.whenComplete();
 
-        const closeButton = await findByTestId("base-button-OK");
+        const closeButton = await findByTestId("base-button-small-screen-ok");
         fireEvent.click(closeButton);
         await logicMiddleware.whenComplete();
 
@@ -76,7 +76,7 @@ describe("<SmallScreenWarning />", () => {
         fireEvent.click(checkbox); // uncheck
         await logicMiddleware.whenComplete();
 
-        const closeButton = await findByTestId("base-button-OK");
+        const closeButton = await findByTestId("base-button-small-screen-ok");
         fireEvent.click(closeButton);
         await logicMiddleware.whenComplete();
 

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -143,6 +143,7 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                             title="Reset filter"
                             onClick={onResetSearch}
                             iconName="Clear"
+                            id="reset-filter"
                         />
                     </div>
                 </div>

--- a/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
+++ b/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
@@ -64,7 +64,7 @@ describe("<NumberRangePicker />", () => {
 
         // Hit reset
         expect(onSearch.called).to.equal(false);
-        fireEvent.click(getByTestId("base-button-Reset filter"));
+        fireEvent.click(getByTestId("base-button-reset-filter"));
         expect(onSearch.called).to.equal(true);
 
         // Should reset to min and max values

--- a/packages/core/components/StatusMessage/index.tsx
+++ b/packages/core/components/StatusMessage/index.tsx
@@ -58,12 +58,7 @@ export default function StatusMessage() {
                     let cancelButton;
                     if (onCancel) {
                         cancelButton = (
-                            <SecondaryButton
-                                iconName=""
-                                title="Cancel"
-                                text="CANCEL"
-                                onClick={onCancel}
-                            />
+                            <SecondaryButton iconName="" text="CANCEL" onClick={onCancel} />
                         );
                     } else
                         onDismiss = () =>

--- a/packages/core/components/TutorialTooltip/index.tsx
+++ b/packages/core/components/TutorialTooltip/index.tsx
@@ -79,6 +79,7 @@ export default function TutorialTooltip() {
                         iconName="CaretSolidLeft"
                         onClick={() => setTutorialStepIndex(previousStepIndex)}
                         title="Previous step"
+                        id="tutorial-prev"
                     />
                     <TertiaryButton
                         className={classNames(
@@ -90,6 +91,7 @@ export default function TutorialTooltip() {
                         iconName={tutorial.hasStep(nextStepIndex) ? "CaretSolidRight" : "Checkmark"}
                         onClick={selectNextTutorial}
                         title={tutorial.hasStep(nextStepIndex) ? "Next step" : "Finished"}
+                        id="tutorial-next"
                     />
                 </div>
             </div>

--- a/packages/core/components/TutorialTooltip/test/TutorialTooltip.test.tsx
+++ b/packages/core/components/TutorialTooltip/test/TutorialTooltip.test.tsx
@@ -42,14 +42,14 @@ describe("<TutorialTooltip />", () => {
         expect(() => getByText(stepTwoMessage)).to.throw();
 
         // Act
-        fireEvent.click(getByTestId("base-button-Next step"));
+        fireEvent.click(getByTestId("base-button-tutorial-next"));
 
         // Assert
         expect(getByText(stepTwoMessage)).to.exist;
         expect(() => getByText(stepOneMessage)).to.throw();
 
         // Act
-        fireEvent.click(getByTestId("base-button-Previous step"));
+        fireEvent.click(getByTestId("base-button-tutorial-prev"));
 
         // Assert
         expect(getByText(stepOneMessage)).to.exist;
@@ -86,7 +86,7 @@ describe("<TutorialTooltip />", () => {
         expect(getByText(formattedTutorial)).to.exist;
 
         // Act
-        fireEvent.click(getByTestId("base-button-Finished"));
+        fireEvent.click(getByTestId("base-button-tutorial-next"));
 
         // Assert
         expect(() => getByText(formattedTutorial)).to.throw();

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -106,7 +106,7 @@ export default function DatasetDetails(props: DatasetDetailsProps) {
                     <PrimaryButton
                         className={styles.button}
                         iconName="Upload"
-                        title="Load dataset"
+                        title="Load dataset in the app"
                         text="LOAD DATASET"
                         onClick={() => props.onLoadDataset(datasetDetails)}
                     />

--- a/packages/web/src/components/DatasetDetails/test/DatasetDetails.test.tsx
+++ b/packages/web/src/components/DatasetDetails/test/DatasetDetails.test.tsx
@@ -253,11 +253,11 @@ describe("<DatasetDetails />", () => {
             );
 
             // consistency checks, button exists & no actions fired
-            expect(getByLabelText("Load dataset")).to.exist;
+            expect(getByLabelText(/^Load dataset/)).to.exist;
             expect(onLoadDataset.called).to.equal(false);
 
             // Act
-            fireEvent.click(getByLabelText("Load dataset"));
+            fireEvent.click(getByLabelText(/^Load dataset/));
 
             // Assert
             expect(onLoadDataset.called).to.equal(true);

--- a/packages/web/src/components/Header/index.tsx
+++ b/packages/web/src/components/Header/index.tsx
@@ -63,7 +63,7 @@ export default function Header() {
                             <Link to="app">
                                 <SecondaryButton
                                     className={styles.startButton}
-                                    title="Get started"
+                                    title="Get started in the app"
                                     text="GET STARTED"
                                 />
                             </Link>

--- a/packages/web/src/components/Home/index.tsx
+++ b/packages/web/src/components/Home/index.tsx
@@ -26,7 +26,7 @@ export default function Home() {
                     <PrimaryButton
                         className={styles.optionButton}
                         iconName="Checkmark"
-                        title="Get started"
+                        title="Get started with your own data"
                         text="GET STARTED"
                     />
                 </Link>
@@ -41,7 +41,7 @@ export default function Home() {
                     <PrimaryButton
                         className={styles.optionButton}
                         iconName="List"
-                        title="View datasets"
+                        title="Go to our datasets page"
                         text="VIEW DATASETS"
                     />
                 </Link>


### PR DESCRIPTION
## Context
Minor UX housekeeping: These component properties should be made optional to conform to UX recommendations:
1. Tooltips are only useful if they add info--should not be present if they would exactly match the button text
2. Most of our modals should not be movable/should not show the drag cursor

closes #348 and #349 

## Changes
- Made `title` (the tooltip) an optional property for `Base`, `Primary` and `Secondary` buttons. Still required on `Tertiary` since those are icon-only 
- Made modals non-draggable by default by adding an optional `isDraggable` property

## Testing
- Updated unit tests since the button `dataset-id` was previously constructed from `title`

## To do
- [x] Check with UX on which (if any) modals should still be draggable
    - edit: confirmed none need to be draggable atm, but can leave param in case we want it in the future
- I made some of the tooltips more descriptive instead of removing them, but am open to suggestions 