### PR TITLE
(Small) Bugfix/Filtering on dates crashes for any/none

### DIFF
--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -141,11 +141,15 @@ export const getGroupedByFilterName = createSelector(
         const annotationNameToInstanceMap = keyBy(annotations, "name");
         const filters = map(globalFilters, (filter: FileFilter) => {
             const annotation = annotationNameToInstanceMap[filter.name];
+            const displayValue =
+                filter.type === FilterType.ANY || filter.type === FilterType.EXCLUDE
+                    ? ""
+                    : annotation?.getDisplayValue(filter.value);
             return {
                 displayName: annotation?.displayName,
                 name: filter.name,
                 value: filter.value,
-                displayValue: annotation?.getDisplayValue(filter.value),
+                displayValue,
                 type: filter?.type || FilterType.DEFAULT,
             };
         }).filter((filter) => filter.displayValue !== undefined);

--- a/packages/core/state/selection/test/selectors.test.ts
+++ b/packages/core/state/selection/test/selectors.test.ts
@@ -1,0 +1,51 @@
+import { mergeState } from "@aics/redux-utils";
+import { expect } from "chai";
+
+import selection from "..";
+import { initialState } from "../..";
+import { TOP_LEVEL_FILE_ANNOTATIONS } from "../../../constants";
+import Annotation from "../../../entity/Annotation";
+import AnnotationName from "../../../entity/Annotation/AnnotationName";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
+import ExcludeFilter from "../../../entity/FileFilter/ExcludeFilter";
+import IncludeFilter from "../../../entity/FileFilter/IncludeFilter";
+
+describe("Selection selectors", () => {
+    describe("getGroupedByFilterName", () => {
+        it("leaves display value blank for any/none filters regardless of type", () => {
+            // arrange
+            const annotations = [
+                ...TOP_LEVEL_FILE_ANNOTATIONS, // includes string, date and number types
+                // Add a boolean-type annotation for testing
+                new Annotation({
+                    annotationDisplayName: "IsTestAnnotation",
+                    annotationName: "IsTestAnnotation",
+                    description: "A test annotation of type boolean",
+                    type: AnnotationType.BOOLEAN,
+                }),
+            ];
+            const filters = [
+                new ExcludeFilter("IsTestAnnotation"), // boolean
+                new IncludeFilter(AnnotationName.UPLOADED), // date
+                new ExcludeFilter(AnnotationName.FILE_SIZE), // number
+                new IncludeFilter(AnnotationName.FILE_NAME), // string
+            ];
+            const state = mergeState(initialState, {
+                metadata: {
+                    annotations,
+                },
+                selection: {
+                    filters,
+                },
+            });
+
+            // act
+            const groupedFilters = selection.selectors.getGroupedByFilterName(state);
+
+            // assert
+            Object.values(groupedFilters).forEach((entry) =>
+                expect(entry[0].displayValue).to.equal("")
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Context
Filtering on date fields for any/no value causes BFF to crash
closes #472 
Related: boolean fields showed "False" instead of nothing as the value in the query panel for any/no value filters
<img width="333" alt="image" src="https://github.com/user-attachments/assets/e6666ebd-089f-4883-8236-ec0e2a447e4b" />

## Changes
Check if we're doing an any/none filter and then don't try to format the display value (since there shouldn't be one)

## Testing
Added single unit test to verify not trying to format non-existent display values
Manual testing: 
- Filtered on various date fields for any value/no value
- Filtered on boolean fields
- Made sure other field types aren't affected
