### PR TITLE
Bugfix/Improve FES network error visibility

### DIFF
--- a/packages/core/components/DirectoryTree/DirectoryTree.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTree.module.css
@@ -39,17 +39,18 @@
 
 .error-message {
     position: absolute;
-    top: 50%;
+    top: 30%;
     transform: translateY(-50%);
     width: 100%;
 
     color: var(--error-text-color); /* defined in App.module.css */
-    font-size: 2rem;
     text-align: center;
+    margin: var(--margin);
+    line-height: 1.5;
 }
 
-.error-message p {
-    margin: 0;
+.error-message h2 {
+    margin: 0 var(--margin);
 }
 
 .vertical-gradient {

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -86,8 +86,8 @@ export default function DirectoryTree(props: FileListProps) {
                 {!error && content}
                 {error && (
                     <aside className={styles.errorMessage}>
-                        <p>Whoops! Something went wrong:</p>
-                        <p>{error.message}</p>
+                        <h2>Whoops! Something went wrong:</h2>
+                        <h2>{error.message}</h2>
                     </aside>
                 )}
             </ul>

--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -138,7 +138,12 @@ const useDirectoryHierarchy = (
                 if (!cancel) {
                     dispatch(
                         receiveContent(
-                            <FileList fileSet={fileSet} isRoot={isRoot} sortOrder={sortOrder} />
+                            <FileList
+                                fileSet={fileSet}
+                                isRoot={isRoot}
+                                sortOrder={sortOrder}
+                                dispatch={dispatch}
+                            />
                         )
                     );
                 }

--- a/packages/core/components/FileList/test/FileList.test.tsx
+++ b/packages/core/components/FileList/test/FileList.test.tsx
@@ -1,6 +1,7 @@
 import { configureMockStore, mergeState } from "@aics/redux-utils";
 import { render } from "@testing-library/react";
 import { expect } from "chai";
+import { noop } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
 import { createSandbox } from "sinon";
@@ -23,7 +24,7 @@ describe("<FileList />", () => {
 
         const { findByText, queryByText } = render(
             <Provider store={store}>
-                <FileList fileSet={fileSet} isRoot={false} sortOrder={4} />
+                <FileList fileSet={fileSet} isRoot={false} sortOrder={4} dispatch={noop} />
             </Provider>
         );
 
@@ -46,7 +47,7 @@ describe("<FileList />", () => {
 
         const { findByText, queryByText } = render(
             <Provider store={store}>
-                <FileList fileSet={fileSet} isRoot={false} sortOrder={4} />
+                <FileList fileSet={fileSet} isRoot={false} sortOrder={4} dispatch={noop} />
             </Provider>
         );
 

--- a/packages/core/services/HttpServiceBase/index.ts
+++ b/packages/core/services/HttpServiceBase/index.ts
@@ -148,13 +148,25 @@ export default class HttpServiceBase {
 
         if (!this.urlToResponseDataCache.has(encodedUrl)) {
             // if this fails, bubble up exception
-            const response = await retry.execute(() => this.httpClient.get(encodedUrl));
+            try {
+                const response = await retry.execute(() => this.httpClient.get(encodedUrl));
 
-            if (response.status < 400 && response.data !== undefined) {
-                this.urlToResponseDataCache.set(encodedUrl, response.data);
-            } else {
-                // by default axios will reject if does not satisfy: status >= 200 && status < 300
-                throw new Error(`Request for ${encodedUrl} failed`);
+                if (response.status < 400 && response.data !== undefined) {
+                    this.urlToResponseDataCache.set(encodedUrl, response.data);
+                } else {
+                    // by default axios will reject if does not satisfy: status >= 200 && status < 300
+                    throw new Error(`Request for ${encodedUrl} failed`);
+                }
+            } catch (err) {
+                if (
+                    axios.isAxiosError(err) &&
+                    (err?.response?.data?.message || err?.response?.data?.error)
+                ) {
+                    throw new Error(
+                        JSON.stringify(err.response.data.message || err?.response?.data?.error)
+                    );
+                }
+                throw err;
             }
         }
 


### PR DESCRIPTION
## Context
closes #489 
For file and annotation fetching, when the request errored out, we'd sometimes either continue showing the loading state or not show an informative error

## Changes
- FileList: check for errors on fetchFileRange, and dispatch to the DirectoryTree state (separate from App state)
- HttpService: wrap the `get` request in a try/catch to get the more descriptive error response from Axios -- this matches the pattern we're already using for post/put/patch
- Error message in DirectoryTree: updated the styling to more closely match our current style 

## Testing
Test manually on a query with [a non-existent annotation](https://staging.bff.allencell.org/app?c=file_name%3A0.4%2Cfile_size%3A0.15%2Cfile_id%3A0.22499999999999998%2Cfile_path%3A0.22499999999999998&group=Clon&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-03-24T07%3A00%3A00.000Z%2C2025-03-25T06%3A59%3A59.889Z%29%22%2C%22type%22%3A%22default%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D) and the [failing staging file query](http://localhost:9001/app?c=file_name%3A0.4%2Cfile_size%3A0.15%2Cfile_id%3A0.22499999999999998%2Cfile_path%3A0.22499999999999998&filter=%7B%22name%22%3A%22Clone%22%2C%22value%22%3A%226%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-03-01T08%3A00%3A00.000Z%2C2025-03-22T06%3A59%3A59.430Z%29%22%2C%22type%22%3A%22default%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D) (this one will only be viewable when on localhost BFF pointing to FES staging).
Will add a unit test

## Screenshots
After (first) vs before (second) for [the non-existent annotation query](https://staging.bff.allencell.org/app?c=file_name%3A0.4%2Cfile_size%3A0.15%2Cfile_id%3A0.22499999999999998%2Cfile_path%3A0.22499999999999998&group=Clon&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-03-24T07%3A00%3A00.000Z%2C2025-03-25T06%3A59%3A59.889Z%29%22%2C%22type%22%3A%22default%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D)
<img width="539" alt="Screenshot 2025-03-26 at 5 24 20 PM" src="https://github.com/user-attachments/assets/9f04a465-4534-4270-a00f-ccd4d73d0a9d" />
<img width="535" alt="Screenshot 2025-03-26 at 4 45 20 PM" src="https://github.com/user-attachments/assets/7e59f548-b0b1-44ae-a0b0-657aee452b5d" />