### PR TITLE
(Small) Add local level error handling

### DIFF
--- a/packages/core/components/DirectoryTree/DirectoryTreeNode.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTreeNode.module.css
@@ -39,7 +39,7 @@
 }
 
 .error-icon {
-    fill: var(--error-background-color); /* defined in App.module.css */;
+    fill: var(--error-status-text-color);
 }
 
 .directory-name {

--- a/packages/core/components/DirectoryTree/DirectoryTreeNode.tsx
+++ b/packages/core/components/DirectoryTree/DirectoryTreeNode.tsx
@@ -78,7 +78,7 @@ export default function DirectoryTreeNode(props: DirectoryTreeNodeProps) {
             aria-level={ancestorNodes.length + 1} // aria-level is 1-indexed
         >
             <DirectoryTreeNodeHeader
-                collapsed={collapsed || Boolean(error)}
+                collapsed={collapsed}
                 error={error}
                 fileSet={fileSet}
                 isLeaf={isLeaf}
@@ -89,7 +89,7 @@ export default function DirectoryTreeNode(props: DirectoryTreeNodeProps) {
             />
             <ul
                 className={classNames(styles.children, {
-                    [styles.collapsed]: collapsed || Boolean(error),
+                    [styles.collapsed]: collapsed,
                     [styles.fileList]: isLeaf,
                 })}
                 style={{ paddingLeft: `${ICON_SIZE + 8}px` }}

--- a/packages/core/components/DirectoryTree/DirectoryTreeNodeHeader.tsx
+++ b/packages/core/components/DirectoryTree/DirectoryTreeNodeHeader.tsx
@@ -2,9 +2,8 @@ import classNames from "classnames";
 import { Spinner, SpinnerSize } from "@fluentui/react";
 import * as React from "react";
 import { useSelector } from "react-redux";
-import Tippy from "@tippyjs/react";
-import "tippy.js/dist/tippy.css"; // side-effect
 
+import Tooltip from "../Tooltip";
 import SvgIcon from "../../components/SvgIcon";
 import { selection } from "../../state";
 import FileSet from "../../entity/FileSet";
@@ -112,8 +111,8 @@ export default React.memo(function DirectoryTreeNodeHeader(props: DirectoryTreeN
             <h4 className={styles.directoryName}>{title}</h4>
             {selectionCountBadge}
             {loading && <Spinner size={SpinnerSize.small} />}
-            {!loading && error && (
-                <Tippy content={error.message}>
+            {!loading && error && collapsed && (
+                <Tooltip content={error.message}>
                     <SvgIcon
                         className={styles.errorIcon}
                         height={ICON_SIZE}
@@ -121,7 +120,7 @@ export default React.memo(function DirectoryTreeNodeHeader(props: DirectoryTreeN
                         viewBox="0 0 24 24"
                         width={ICON_SIZE}
                     />
-                </Tippy>
+                </Tooltip>
             )}
         </span>
     );

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -6,6 +6,13 @@
     height: calc(100% - var(--margin));
 }
 
+.error-message {
+    color: var(--error-text-color);
+    margin: var(--margin);
+    line-height: 1.25;
+    font-size: var(--s-paragraph-size);
+}
+
 .list {
     height: calc(100% - 3px);
     position: relative;

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -7,10 +7,11 @@
 }
 
 .error-message {
-    color: var(--error-text-color);
-    margin: var(--margin);
+    color: var(--primary-text-color);
+    margin-bottom: 10px;
     line-height: 1.25;
     font-size: var(--s-paragraph-size);
+    font-style: italic;
 }
 
 .list {

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -169,7 +169,6 @@ export default function FileList(props: FileListProps) {
         return (
             <div className={classNames(styles.container, className)}>
                 <div className={styles.errorMessage}>
-                    {" "}
                     Sorry, some files could not load. Error: {localError.message}
                 </div>
             </div>

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -169,7 +169,7 @@ export default function FileList(props: FileListProps) {
         return (
             <div className={classNames(styles.container, className)}>
                 <div className={styles.errorMessage}>
-                    Sorry, some files could not load. Error: {localError.message}
+                    Some files could not be loaded. Error: {localError.message}
                 </div>
             </div>
         );

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -167,7 +167,12 @@ export default function FileList(props: FileListProps) {
     let content: React.ReactNode;
     if (!!localError) {
         return (
-            <div className={styles.errorMessage}> Something went wrong: {localError.message}</div>
+            <div className={classNames(styles.container, className)}>
+                <div className={styles.errorMessage}>
+                    {" "}
+                    Sorry, some files could not load. Error: {localError.message}
+                </div>
+            </div>
         );
     }
     if (totalCount === null || totalCount > 0) {


### PR DESCRIPTION
## Context
Extremely similar to #490, but that PR only addressed root level errors, not ones where groups were applied and individual file lists errored out. I originally missed this since that's a case that's much harder to replicate, but can be achieved with localhost --> staging FES at [this link](http://localhost:9001/app?c=file_name%3A0.4%2Cfile_size%3A0.15%2Cfile_id%3A0.22499999999999998%2Cfile_path%3A0.22499999999999998&group=Gene&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-03-27T07%3A00%3A00.000Z%2C2025-03-28T06%3A59%3A59.485Z%29%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22TJP1%22%5D&openFolder=%5B%22EOMES%22%5D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D) -- spotted while working on "no value" groups

## Changes
- Adds a local error state to the same place where I added root error checking in #490
- Updates error icon & tooltip to match current styling
- Fixes a small bug where the folder would "open" but not show the correct downward caret on errors
- [x] To do: get UX feedback before I fully open the PR

## Testing
Tested on [this link](http://localhost:9001/app?c=file_name%3A0.4%2Cfile_size%3A0.15%2Cfile_id%3A0.22499999999999998%2Cfile_path%3A0.22499999999999998&group=Gene&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-03-27T07%3A00%3A00.000Z%2C2025-03-28T06%3A59%3A59.485Z%29%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22TJP1%22%5D&openFolder=%5B%22EOMES%22%5D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D) and other similar ones

## Screenshots (if relevant) 
After (open vs closed):
<img width="634" alt="Screenshot 2025-03-27 at 4 12 31 PM" src="https://github.com/user-attachments/assets/15c1ceeb-1254-4961-88bd-6d1d3bb80e4b" />
<img width="635" alt="image" src="https://github.com/user-attachments/assets/2a7d6237-dc52-4312-970b-7d25ca35a85b" />


Before: eternal loading state
https://github.com/user-attachments/assets/3acd25c7-9e7b-4343-aecd-fae73f1fe0f5
<img width="886" alt="image" src="https://github.com/user-attachments/assets/4dd276cf-0beb-4a0b-a417-6fa970c1d0ad" />