### PR TITLE
use path.includes('.zarr') check for zarr thumbnail

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -194,7 +194,7 @@ export default class FileDetail {
 
         // If no thumbnail present try to render the file itself as the thumbnail
         if (!this.thumbnail) {
-            if (this.path.endsWith(".zarr")) {
+            if (this.path.includes(".zarr")) {
                 return renderZarrThumbnailURL(this.path);
             }
 


### PR DESCRIPTION
## Context
This re-applies the change I originally made in #435 but got lost in #467, which allows Zarr Thumbnails to be shown if the path *includes* `.zarr`.
