### PR TITLE
enable localpath downloads for non-zarr on desktop

### DIFF
--- a/packages/desktop/src/services/FileDownloadServiceElectron.ts
+++ b/packages/desktop/src/services/FileDownloadServiceElectron.ts
@@ -92,12 +92,13 @@ export default class FileDownloadServiceElectron extends FileDownloadService {
             );
         }
 
-        if (fileInfo.data instanceof Uint8Array) {
-            downloadUrl = URL.createObjectURL(new Blob([fileInfo.data]));
-        } else if (fileInfo.data instanceof Blob) {
-            downloadUrl = URL.createObjectURL(fileInfo.data);
-        } else if (typeof fileInfo.data === "string") {
-            const dataAsBlob = new Blob([fileInfo.data], { type: "application/json" });
+        const path = fileInfo.data || fileInfo.path;
+        if (path instanceof Uint8Array) {
+            downloadUrl = URL.createObjectURL(new Blob([path]));
+        } else if (path instanceof Blob) {
+            downloadUrl = URL.createObjectURL(path);
+        } else if (typeof path === "string" && !destination) {
+            const dataAsBlob = new Blob([path], { type: "application/json" });
             downloadUrl = URL.createObjectURL(dataAsBlob);
         } else {
             return this.downloadHttpFile(fileInfo, downloadRequestId, onProgress, destination);


### PR DESCRIPTION
## Context
Desktop was only checking `fileInfo.data`, but we now also use `fileInfo.path` to download files that have a local path. Because of this, the conditional was reading the path as undefined and skipping to the `else` condition. Then it would attempt to use the http file download method and fail to parse the file path as a url

## Changes
Adds `path` and checks for a `destination` (which indicates whether we're downloading a buffer and should use the http file method).

## Testing
Manually testing on desktop:
- Downloaded the files where the error was reported in #487 and #496 
- Tested downloading other files that have a local path and are not zarrs
- Made sure can still download files with only a cloud path