### PR TITLE
Ensure no conflicts occur in auto-generated UIDs

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -204,6 +204,7 @@ function getSupportedApps(fileDetails?: FileDetail): IContextualMenuItem[] {
         case "dvi":
         case "n5":
             return [apps.neuroglancer];
+        case "tif":
         case "tiff":
             return [apps.agave];
         case "zarr":


### PR DESCRIPTION
Hotfix to get adding multiple data sources to work again. It seems currently when trying to add more than one data source the hidden UIDs aren't generated properly for the view into the combination. This resets the hidden UID generation for the view specifically on creation so conflicts shouldn't ever happen.