### PR TITLE
Support subpaths into zarr/n5 containers

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -182,9 +182,12 @@ function getSupportedApps(fileDetails?: FileDetail): IContextualMenuItem[] {
 
     const isLikelyLocalFile =
         !fileDetails.path.startsWith("http") && !fileDetails.path.startsWith("s3");
-
+    
     const fileExt = fileDetails.path.slice(fileDetails.path.lastIndexOf(".") + 1).toLowerCase();
     const apps = APPS(fileDetails);
+
+    // Check for common file extensions first
+
     switch (fileExt) {
         case "bmp":
         case "html":
@@ -202,8 +205,6 @@ function getSupportedApps(fileDetails?: FileDetail): IContextualMenuItem[] {
         case "dcm":
             return [apps.volview];
         case "dvi":
-        case "n5":
-            return [apps.neuroglancer];
         case "tif":
         case "tiff":
             return [apps.agave];
@@ -212,9 +213,22 @@ function getSupportedApps(fileDetails?: FileDetail): IContextualMenuItem[] {
             return isLikelyLocalFile
                 ? [apps.agave, apps.neuroglancer, apps.vole]
                 : [apps.vole, apps.neuroglancer, apps.agave, apps.validator];
-        default:
-            return [];
+        
     }
+        
+    // Now check for special cases where the path may include a subpath into the container
+
+    if (fileDetails.path.includes(".n5")) {
+        return [apps.neuroglancer];
+    }
+
+    if (fileDetails.path.includes(".zarr")) {
+        return isLikelyLocalFile
+            ? [apps.agave, apps.neuroglancer, apps.vole]
+            : [apps.vole, apps.neuroglancer, apps.agave, apps.validator];
+    }
+
+    return [];
 }
 
 export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMenuItem[] => {


### PR DESCRIPTION
## Context
This addresses issue #503 to support OME-Zarrs with subpaths. After the usual check for extension (everything after the last dot) we now check to see if the path includes ".n5" or ".zarr" anywhere (similar to how #493 implemented the same feature in another part of the code).  

## Changes
Add additional checks to see if the path `includes` ".zarr" or ".n5", which can occur in the middle of a path.

I removed the "n5" check from the `switch` statement since it's no longer necessary, but I left the extra "zarr" in the `switch` for now, because it's not clear to me if all zarr viewers support subpaths within a container. Neuroglancer and OME-NGFF validator definitely do. Vol-E and Agave don't seem to, in which case maybe they should be removed from return statement after the `includes` check, but I'm not the one to make that call.

## Testing
Loaded [my test data CSV](https://docs.google.com/spreadsheets/d/e/2PACX-1vTTpnSiPRxOuJgq3dQ7aLYGtMPd2KYTKK6lYqz0geHmnygqMLYDC1XkRTHjPXJ9u_oC3t0Nu0FBIS_r/pub?gid=200533885&single=true&output=csv) and clicked through several examples to ensure that Neuroglancer appears under "Support file type" in "Open File".

