### PR TITLE
Fixed data format prefix when opening n5 image in neuroglancer

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -97,7 +97,7 @@ const APPS = (fileDetails?: FileDetail): Apps => ({
         key: AppKeys.NEUROGLANCER,
         text: "Neuroglancer",
         title: `Open files with Neuroglancer`,
-        href: `https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22zarr://${fileDetails?.path}%22,%22name%22:%22${fileDetails?.name}%22}]}`,
+        href: `https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22${fileDetails?.path.includes(".n5") ? "n5" : "zarr"}://${fileDetails?.path}%22,%22name%22:%22${fileDetails?.name}%22}]}`,
         disabled: !fileDetails?.path,
         target: "_blank",
         onRenderContent(props, defaultRenders) {


### PR DESCRIPTION
## Context
I noticed that when trying to open N5's in Neuroglancer, it tries to load them as Zarrs and fails. This is because the data URL is hardcoded with a `zarr://` prefix.

## Changes
Changed code to return `zarr://` or `n5://` depending on the extension in the path.

## Testing
Loaded [my test data CSV](https://docs.google.com/spreadsheets/d/e/2PACX-1vTTpnSiPRxOuJgq3dQ7aLYGtMPd2KYTKK6lYqz0geHmnygqMLYDC1XkRTHjPXJ9u_oC3t0Nu0FBIS_r/pub?gid=200533885&single=true&output=csv) (requires #508 fix applied) and clicked through several examples to ensure that N5's open correctly in Neuroglancer.
