### PR TITLE
Bugfix/Unable to close Electron child windows

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { app, BrowserWindow, Menu } from "electron";
+import { app, BrowserWindow, dialog, Menu } from "electron";
 
 import getMenuTemplate from "./menu";
 import ExecutionEnvServicElectron from "../services/ExecutionEnvServiceElectron";
@@ -80,6 +80,29 @@ const createMainWindow = () => {
     mainWindow.on("closed", () => {
         // Dereference the window
         mainWindow = undefined;
+    });
+
+    // Customize window.open or target="_blank" calls that create new Electron windows
+    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+        // Creating a new BrowserWindow allows us to set event handlers on child windows
+        const childWindow = new BrowserWindow({ parent: mainWindow });
+        childWindow.loadURL(url);
+        // Catch 'beforeunload' events from web page since Electron handles these differently from browser
+        childWindow.webContents.on("will-prevent-unload", (ev: Event) => {
+            const options = {
+                type: "question",
+                buttons: ["Cancel", "Leave"],
+                message: "Leave site?",
+                detail: "Changes you made may not be saved.",
+            };
+            const shouldLeave = dialog.showMessageBoxSync(childWindow, options) === 1;
+            if (shouldLeave) {
+                ev.preventDefault();
+                childWindow.destroy();
+            }
+        });
+        // Prevent default behavior, avoid duplicate windows
+        return { action: "deny" };
     });
 
     if (isDevelopment) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -91,11 +91,11 @@ const createMainWindow = () => {
         childWindow.webContents.on("will-prevent-unload", (ev: Event) => {
             const options = {
                 type: "question",
-                buttons: ["Cancel", "Leave"],
+                buttons: ["Leave", "Cancel"],
                 message: "Leave site?",
                 detail: "Changes you made may not be saved.",
             };
-            const shouldLeave = dialog.showMessageBoxSync(childWindow, options) === 1;
+            const shouldLeave = dialog.showMessageBoxSync(childWindow, options) === 0;
             if (shouldLeave) {
                 ev.preventDefault();
                 childWindow.destroy();

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -82,7 +82,9 @@ const createMainWindow = () => {
         mainWindow = undefined;
     });
 
-    // Customize window.open or target="_blank" calls that create new Electron windows
+    // Customize window.open or target="_blank" calls that create new Electron windows.
+    // Used for all external links, but specifically necessary for opening the Labkey Plate UI
+    // and any other web page with an "unsaved changes" alert
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
         // Creating a new BrowserWindow allows us to set event handlers on child windows
         const childWindow = new BrowserWindow({ parent: mainWindow });


### PR DESCRIPTION
## Context
resolves #513 
When desktop users opened files in LabKey from BFF, if they interacted with LabKey at all they were unable to close the Electron window and had to quit/restart the entire app. 
This is because LabKey has a `beforeunload` event that warns users about unsaved changes when they try to exit, which is supposed to show up like this: 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/31ea0892-a4af-4db3-a00f-4e524960f897" />

However, Electron doesn't handle those events the same way, so was blocking the alert and any way of closing the window.

## Changes
Adds a custom handler for opening new windows in Electron ([docs here,](https://www.electronjs.org/docs/latest/api/window-open/) gets used any time we use `window.open` or `target=_blank` in desktop). This allows us to watch for `beforeunload` via `will-prevent-unload` events.
Now users will see this alert:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/affaa83b-e771-438b-b47d-f9cf1110c372" />

## Testing
Only manual testing:
- Tested by opening files in LabKey from BFF, interacting with interface and then closing (tested both leave and cancel)
- Made sure other apps (Agave, Neuroglancer, Vol-E) still work in desktop
- Checked the alert also works for other sites like GitHub (edit file and exit without saving)
