### PR TITLE
Feature/collapse large annotations

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -94,7 +94,7 @@
 
 .hidden {
     /* arbitrarily large to move input off-screen */
-    left: -100;
-    top: -100;
+    left: -100%;
+    top: -100%;
     position: absolute;
 }

--- a/packages/core/components/DirectoryTree/DirectoryTreeNode.module.css
+++ b/packages/core/components/DirectoryTree/DirectoryTreeNode.module.css
@@ -13,7 +13,7 @@
 
     /* flex parent */
     display: flex;
-    align-items: center;
+    align-items: top;
 }
 
 .directory-header:hover :is(h4, svg) {
@@ -31,6 +31,7 @@
 }
 
 .icon, .folder-icon {
+    margin-top: 2px;
     fill: var(--secondary-text-color);
 }
 
@@ -47,6 +48,7 @@
     padding-top: 2px;
     display: inline-block;
     font-weight: normal;
+    line-height: 1.15;
 }
 
 .selection-count-badge {

--- a/packages/core/components/DirectoryTree/DirectoryTreeNodeHeader.tsx
+++ b/packages/core/components/DirectoryTree/DirectoryTreeNodeHeader.tsx
@@ -47,7 +47,10 @@ export default React.memo(function DirectoryTreeNodeHeader(props: DirectoryTreeN
     const { collapsed, error, fileSet, isLeaf, isFocused, loading, onClick, title } = props;
 
     const [isContextMenuActive, setContextMenuActive] = React.useState(false);
-
+    // Shorten folder title length to approximately one line
+    // Some overflow is acceptable as long as the folder doesn't wrap to more than two lines
+    const isLongHeader = title.length > 110;
+    const titleShortened = title.slice(0, 50) + "..." + title.slice(-50);
     const fileSelections = useSelector(selection.selectors.getFileSelection);
     const countSelectionsUnderneathFolder = React.useMemo(() => {
         return fileSelections.count(fileSet.filters);
@@ -108,7 +111,7 @@ export default React.memo(function DirectoryTreeNodeHeader(props: DirectoryTreeN
                 viewBox="0 0 24 24"
                 width={ICON_SIZE}
             />
-            <h4 className={styles.directoryName}>{title}</h4>
+            <h4 className={styles.directoryName}>{isLongHeader ? titleShortened : title}</h4>
             {selectionCountBadge}
             {loading && <Spinner size={SpinnerSize.small} />}
             {!loading && error && collapsed && (

--- a/packages/core/components/FileDetails/FileAnnotationRow.module.css
+++ b/packages/core/components/FileDetails/FileAnnotationRow.module.css
@@ -26,11 +26,16 @@
     padding-left: 0;
 }
 
+.cell > span, .cell div {
+    user-select: text;
+}
+
 .key {
     /* flex child */
     flex: 1 1 40%;
 
     font-weight: 500;
+    padding-right: var(--margin);
 }
 
 .link {
@@ -55,4 +60,35 @@
 
 .fms-state-indicator {
     font-style: italic;
+}
+
+.value-truncated {
+    min-height: 30px;
+    max-height: 90px;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 4 !important; /* number of lines to show */
+            line-clamp: 4; 
+    -webkit-box-orient: vertical !important;
+    word-wrap: break-word !important;
+}
+
+.expand-button {
+    font-size: 14px;
+    font-weight: 800;
+    color: var(--aqua);
+    padding: 0 5px;
+}
+
+.expand-button:hover {
+    color: var(--bright-aqua);
+    cursor: pointer;
+}
+
+.expand-button-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    padding-right: var(--margin);
 }

--- a/packages/core/components/FileDetails/FileAnnotationRow.module.css
+++ b/packages/core/components/FileDetails/FileAnnotationRow.module.css
@@ -76,10 +76,9 @@
 }
 
 .expand-button {
-    font-size: 14px;
-    font-weight: 800;
+    font-size: 12px;
+    font-weight: 700;
     color: var(--aqua);
-    padding: 0 5px;
 }
 
 .expand-button:hover {

--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -134,6 +134,9 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                                         iconName={
                                             showLongValue ? "ChevronUpSmall" : "ChevronDownSmall"
                                         }
+                                        data-testid={
+                                            showLongValue ? "collapse-metadata" : "expand-metadata"
+                                        }
                                         onClick={() => setShowLongValue(!showLongValue)}
                                     />
                                 </Tooltip>

--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -1,7 +1,9 @@
+import { Icon } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import Tooltip from "../Tooltip";
 import Cell from "../../components/FileRow/Cell";
 import { interaction, metadata, selection } from "../../state";
 
@@ -20,12 +22,16 @@ interface FileAnnotationRowProps {
  */
 export default function FileAnnotationRow(props: FileAnnotationRowProps) {
     const dispatch = useDispatch();
+    const trimmedValue = props.value.trim();
+    const [showLongValue, setShowLongValue] = React.useState(false);
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const annotationNameToAnnotationMap = useSelector(
         metadata.selectors.getAnnotationNameToAnnotationMap
     );
 
     const isOpenFileLink = annotationNameToAnnotationMap[props.name]?.isOpenFileLink;
+    // Character length approximately exceeds 4 lines of text
+    const isLongValue: boolean = trimmedValue.trim().length > 160;
 
     const onContextMenuHandlerFactory = (clipboardText: string) => {
         return (evt: React.MouseEvent) => {
@@ -42,6 +48,35 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                         navigator.clipboard.writeText(clipboardText);
                     },
                 },
+                ...(isLongValue
+                    ? showLongValue
+                        ? [
+                              {
+                                  key: "collapse",
+                                  text: "Collapse",
+                                  title: "Collapse metadata field",
+                                  iconProps: {
+                                      iconName: "CollapseContent",
+                                  },
+                                  onClick: () => {
+                                      setShowLongValue(false);
+                                  },
+                              },
+                          ]
+                        : [
+                              {
+                                  key: "expand",
+                                  text: "Expand",
+                                  title: "Expand metadata field",
+                                  iconProps: {
+                                      iconName: "ExploreContent",
+                                  },
+                                  onClick: () => {
+                                      setShowLongValue(true);
+                                  },
+                              },
+                          ]
+                    : []),
             ];
             dispatch(interaction.actions.showContextMenu(items, evt.nativeEvent));
         };
@@ -75,19 +110,35 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                 {isOpenFileLink ? (
                     <a
                         className={styles.link}
-                        onContextMenu={onContextMenuHandlerFactory(props.value.trim())}
-                        href={props.value.trim()}
+                        onContextMenu={onContextMenuHandlerFactory(trimmedValue)}
+                        href={trimmedValue}
                         rel="noreferrer"
                         target="_blank"
                     >
-                        {props.value.trim()}
+                        {trimmedValue}
                     </a>
                 ) : (
-                    <span
-                        style={{ userSelect: "text" }}
-                        onContextMenu={onContextMenuHandlerFactory(props.value.trim())}
-                    >
-                        {props.value.trim()}
+                    <span onContextMenu={onContextMenuHandlerFactory(trimmedValue)}>
+                        <div
+                            className={classNames({
+                                [styles.valueTruncated]: !showLongValue && isLongValue,
+                            })}
+                        >
+                            {trimmedValue}
+                        </div>
+                        {isLongValue && (
+                            <div className={styles.expandButtonWrapper}>
+                                <Tooltip content={showLongValue ? "Collapse text" : "Expand text"}>
+                                    <Icon
+                                        className={styles.expandButton}
+                                        iconName={
+                                            showLongValue ? "ChevronUpSmall" : "ChevronDownSmall"
+                                        }
+                                        onClick={() => setShowLongValue(!showLongValue)}
+                                    />
+                                </Tooltip>
+                            </div>
+                        )}
                     </span>
                 )}
             </Cell>

--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -48,6 +48,7 @@
 .overflow-container {
     overflow: auto;
     padding-bottom: 1.25em;
+    padding-right: var(--margin);
     width: 100%;
     height: calc(100% - var(--pagination-height));
 }

--- a/packages/core/components/FileList/Header.module.css
+++ b/packages/core/components/FileList/Header.module.css
@@ -3,7 +3,7 @@
   --inner-header-padding: 6px;
 
   position: sticky;
-  top: var(--inner-header-padding);
+  top: 0;
 
   /* NOTE! If this changes, you must also update a corresponding constant regarding the
   height of the header used to determine whether the currectly focused item is visible
@@ -59,6 +59,7 @@
 .list-parent {
   /* bizarrely necessary in order to not have the first list item initially render underneath the header */
   transform: translateY(0px);
+  margin-top: 5px; /* small space between header and first item of list */
 }
 
 .list-parent > div > div:nth-child(even) > div {

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -40,8 +40,8 @@ const DEFAULTS = {
 };
 
 const MAX_NON_ROOT_HEIGHT = 300;
-const SMALL_ROW_HEIGHT = 17;
-const TALL_ROW_HEIGHT = 19;
+const SMALL_ROW_HEIGHT = 20;
+const TALL_ROW_HEIGHT = 24;
 
 /**
  * Wrapper for react-window-infinite-loader and react-window that knows how to lazily fetch its own data. It will lay

--- a/packages/core/components/FileRow/Cell.module.css
+++ b/packages/core/components/FileRow/Cell.module.css
@@ -10,6 +10,7 @@
     vertical-align: middle;
     font-size: initial;
     height: 100%;
+    line-height: normal;
 }
 
 .cell:first-of-type {

--- a/packages/core/components/FileRow/FileRow.module.css
+++ b/packages/core/components/FileRow/FileRow.module.css
@@ -1,6 +1,5 @@
 .row {
     /* these are very important in order to properly overflow */
-    display: inline;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## Context
Addresses a few UI/UX issues, but mainly being able to collapse/expand super long metadata values
closes #168 , _hopefully_ closes #506 

Available for testing on [staging](https://staging.bff.allencell.org/app?c=file_name%3A0.4%2CKind%3A0.2%2CType%3A0.25%2Cfile_size%3A0.15&group=Acquisition+Time+by+Timepoint&group=Notes&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-05-09T07%3A00%3A00.000Z%2C2025-05-10T06%3A59%3A59.558Z%29%22%2C%22type%22%3A%22default%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D&showNulls=true)

## Changes
#### Main change:
Added expand/collapse logic for metadata values that wrap to more than 4 lines. 
After discussing with @lynwilhelm, departed slightly from the design in the issue description for logistic/style consistency reasons
<img width="400" alt="image" src="https://github.com/user-attachments/assets/90748c5d-45a6-4368-a30e-874eef1fbdd2" />
<img width="406" alt="image" src="https://github.com/user-attachments/assets/9a1bb4ba-80a5-4af1-a10b-5e3def1627a9" />

#### Other changes:
- Truncates super long folder names (from the center since end bit is often relevant/distinctive) when grouping and adjusted their alignment. I didn't end up making these expandable because I didn't want to add another clickable element on the folder, but I'm hoping it won't be super common to group on fields that are that long anyway
<img width="400" alt="image" src="https://github.com/user-attachments/assets/af90fec6-1c8d-454c-bb79-ac95e13462a8" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/51255cc1-bf9c-4900-9d34-40115cea79ff" />

- HOPEFULLY fixes the file row height issue
    - Made the row height slightly taller and set a line-height 
- Hides the pseudo element we use to capture focus  (white input in screenshot, shows up when you collapse the query panel-- was missing units on the css):
<img width="389" alt="image" src="https://github.com/user-attachments/assets/adb0a228-b076-46de-8321-3378dfafa503" />


## Testing
- Unit tests for expand/collapse metadata values

Manually tested:
- expand/collapse for various long metadata values, made sure is responsive to changes in the panel size
- line height: tried zooming in/out on different browsers, @thao-do verified on staging deployment


