### PR TITLE
Bugfix/Date range infinite re-renders

### DIFF
--- a/packages/core/components/DateRangePicker/test/DateRangePicker.test.tsx
+++ b/packages/core/components/DateRangePicker/test/DateRangePicker.test.tsx
@@ -40,7 +40,7 @@ describe("<DateRangePicker />", () => {
         // Arrange
         const currentRange = new FileFilter(
             "date",
-            `RANGE(2024-02-21T00:00:00.000Z,2024-03-21T00:00:00.000Z)`
+            `RANGE(2024-02-21T08:00:00.000Z,2024-03-21T08:00:00.000Z)`
         );
         const { getByText } = render(
             <DateRangePicker onSearch={noop} onReset={noop} currentRange={currentRange} />


### PR DESCRIPTION
## Context
resolves #528 

Using the date range selection component was causing the app to hang and then crash. It seems we weren't checking whether values had actually changed before triggering the search, so the page was entering a re-render loop that sent infinite network calls. (Reproduce by opening a new BFF window and then trying to edit the `Uploaded` dates)

Also, the UTC conversion code was causing the starting date/time to change every time the DateRangePicker component was rendered (kept bumping it forward by 7 hours), which may have also contributed to the issue. I don't remember this happening before, but I'm unsure if something changed in the way we handle dates since this code was originally added.

## Changes
- Adds a value comparison check before triggering `onSearch`
- Gets rid of the UTC to ISO conversion function. It seems to now be causing issues rather than solving them, but again, unsure if something has changed?

## Testing
- Made sure selecting date ranges (or triggering the component) no longer causes app crashes
- Tested applying date ranges and made sure the returned values were logically consistent (e.g., files uploaded at 12am on the 13th show up when the start date is the 13th)
- An old unit test failed and needed to be updated with this change because 00:00:00Z is technically the previous day in our time zone. I'm sure there's a more elegant way to handle this, so open to suggestions 

### Potential to do?
- This may mean we don't account for different time zones now? Our UTC vs ISO date format situation is confusing me
- Will look into adding more unit tests as needed