### PR TITLE
Autogenerate missing file names

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -121,7 +121,13 @@ export default class FileDetail {
     public get name(): string {
         const name = this.fileDetail.file_name || this.getFirstAnnotationValue("File Name");
         if (name === undefined) {
-            throw new Error("File Name is not defined");
+            try {
+                // Same pattern as DatabaseService uses to auto-generate names
+                return this.path.replace(/^.*\/([^\/]*?)(\\.[^\/.]+)?$/, "$1");
+            } catch {
+                // File Path is also undefined
+                throw new Error("File Name is not defined");
+            }
         }
         return name as string;
     }


### PR DESCRIPTION
## Context
One potential option for resolving #531.
The EMT csv that Antoine was uploading had an empty File Name column, which meant that our database creation step skipped the conditional that would have caused it to autogenerate file names from the file paths.
Full context and potential options in issue description. This is option 3 from that list (quickest fix and lowest effort but feels slightly hacky)
Just opening as a draft right now because we likely want to explore other options

## Changes
If there isn't a file name, before throwing an error, first try generating one on the spot based on the file path

## Testing
If we think we might go with this, I'll spend more time on unit testing

Tested manually with
- the dataset Antoine provided where there's a "File Name" column but no values in it
- another simpler one I made where some but not all of the files have values for "File Name"
