### PR TITLE
(Small) Feature/improve styling of collapsed queries

### DIFF
--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -24,6 +24,7 @@
 
 .display-row {
     margin: 8px 0;
+    line-height: 1.5;
 }
 
 .display-row, .collapse-button i {
@@ -32,6 +33,10 @@
 
 .display-row > strong {
     font-weight: 600;
+}
+
+.divider {
+    margin-block-start: 5px;
 }
 
 .container {
@@ -54,6 +59,10 @@
 .container:hover:not(.selected) .expand-button {
     color: var(--highlight-text-color);
     background: none;
+}
+
+.container:hover:not(.selected) .divider {
+    background: var(--highlight-text-color);
 }
 
 .header {

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -11,6 +11,7 @@ import QueryGroup from "../QueryPart/QueryGroup";
 import QuerySort from "../QueryPart/QuerySort";
 import Tooltip from "../Tooltip";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
+import { FilterType } from "../../entity/FileFilter";
 import { interaction, metadata, selection } from "../../state";
 import { Query as QueryType } from "../../state/selection/actions";
 
@@ -110,6 +111,7 @@ export default function Query(props: QueryProps) {
                         data-testid="expand-button"
                     />
                 </div>
+                {!isExpanded && <hr className={styles.divider}></hr>}
                 <p className={styles.displayRow}>
                     <strong>Data source:</strong>{" "}
                     {queryComponents.sources.map((source) => source.name).join(", ")}
@@ -128,9 +130,36 @@ export default function Query(props: QueryProps) {
                 )}
                 {!!queryComponents.filters.length && (
                     <p className={styles.displayRow}>
-                        <strong>Filter:</strong>{" "}
-                        {queryComponents.filters
-                            .map((filter) => `${filter.name}: ${filter.value}`)
+                        <strong>Filter{queryComponents.filters.length > 1 ? "s" : ""}:</strong>{" "}
+                        {/* Show a condensed version of the filters list with counts instead of values */}
+                        {Object.entries(
+                            queryComponents.filters.reduce((accum, filter) => {
+                                let value = "";
+                                // Don't show a count for ranges (e.g., date range)
+                                if (!filter.value.toString().includes("RANGE")) {
+                                    switch (filter.type) {
+                                        case FilterType.ANY:
+                                            value = "Any value";
+                                            break;
+                                        case FilterType.EXCLUDE:
+                                            value = "No value";
+                                            break;
+                                        default:
+                                            value = (
+                                                (Number(accum[filter.name]) || 0) + 1
+                                            ).toString();
+                                    }
+                                }
+                                return {
+                                    ...accum,
+                                    [filter.name]: value,
+                                };
+                            }, {} as { [index: string]: string })
+                        )
+                            .map(([name, value]) => {
+                                if (value === "") return name;
+                                return `${name} (${value})`;
+                            })
                             .join(", ")}
                     </p>
                 )}


### PR DESCRIPTION
## Context
Updating appearance of collapsed queries in the sidebar per #197 

## Changes
Followed the designs in Figma and added some processing on the filters so that different information appears depending on the filter type (e.g., regular filters should show a count of the values, any/none filters should show "Any value" or "No value" respectively, and range filters shouldn't show anything).

## Testing
Added a couple unit tests

## Screenshots 
Before vs after with multiple applied filters
<img width="250" alt="Screenshot 2025-06-04 at 12 32 35 PM" src="https://github.com/user-attachments/assets/a9c11645-9198-4fe7-8275-5f079752aef7" />
<img width="250" alt="Screenshot 2025-06-04 at 12 32 40 PM" src="https://github.com/user-attachments/assets/bd389d5c-4a38-4fba-8373-0de1b631b5d9" />

Hover state
<img width="356" alt="Screenshot 2025-06-04 at 12 32 49 PM" src="https://github.com/user-attachments/assets/425db718-104f-40b8-8235-cd5a123b863a" />


#### Before vs after for a filter that has an extremely long value
<img width="250" alt="Screenshot 2025-06-04 at 1 22 55 PM" src="https://github.com/user-attachments/assets/08d17199-cc01-4ec5-a904-a335c3b32280" />
<img width="259" alt="Screenshot 2025-06-04 at 1 23 08 PM" src="https://github.com/user-attachments/assets/77cb644d-3494-4df5-af11-dd340d8d1858" />


