### PR TITLE
Feature/delete metadata via edit modal

### DIFF
--- a/packages/core/components/Buttons/BaseButton.tsx
+++ b/packages/core/components/Buttons/BaseButton.tsx
@@ -20,6 +20,8 @@ interface Props {
     // title is only required if tooltip would be different from button text
     // or if button does not have text (e.g., icon only)
     title?: string;
+    // default to all-caps except for link-like buttons
+    useSentenceCase?: boolean;
 }
 
 /**
@@ -40,7 +42,9 @@ export default function BaseButton(props: Props) {
                     iconName={props.iconName}
                 />
             )}
-            <span className={styles.buttonText}>{props.text?.toUpperCase()}</span>
+            <span className={styles.buttonText}>
+                {props?.useSentenceCase ? props.text : props.text?.toUpperCase()}
+            </span>
         </span>
     );
 

--- a/packages/core/components/Buttons/LinkLikeButton.module.css
+++ b/packages/core/components/Buttons/LinkLikeButton.module.css
@@ -2,7 +2,7 @@
   background: none;
   color: var(--highlight-background-color);
   border: none;
-  font-size: small;
+  font-size: var(--s-paragraph-size);
   padding: 0;
   justify-content: flex-start;
   width: fit-content;

--- a/packages/core/components/Buttons/LinkLikeButton.module.css
+++ b/packages/core/components/Buttons/LinkLikeButton.module.css
@@ -1,0 +1,19 @@
+.button {
+  background: none;
+  color: var(--highlight-background-color);
+  border: none;
+  font-size: small;
+  padding: 0;
+  justify-content: flex-start;
+  width: fit-content;
+}
+
+.button span {
+  font-weight: unset;
+  margin: 0;
+}
+
+.button:hover, .button:focus {
+  background-color: unset;
+  color: var(--highlight-hover-background-color);
+}

--- a/packages/core/components/Buttons/LinkLikeButton.tsx
+++ b/packages/core/components/Buttons/LinkLikeButton.tsx
@@ -1,0 +1,36 @@
+import classNames from "classnames";
+import * as React from "react";
+
+import BaseButton from "./BaseButton";
+
+import styles from "./LinkLikeButton.module.css";
+
+interface Props {
+    className?: string;
+    disabled?: boolean;
+    iconName?: string;
+    id?: string;
+    onClick?: () => void;
+    text?: string;
+    title?: string;
+}
+
+/**
+ * Component styled for buttons that look like links
+ */
+export default function LinkLikeButton(props: Props) {
+    return (
+        <BaseButton
+            className={classNames(props.className, styles.button, {
+                [styles.disabled]: props.disabled,
+            })}
+            disabled={props.disabled}
+            iconName={props.iconName}
+            id={props.id}
+            onClick={props.onClick}
+            text={props.text}
+            title={props.title}
+            useSentenceCase
+        />
+    );
+}

--- a/packages/core/components/Buttons/index.tsx
+++ b/packages/core/components/Buttons/index.tsx
@@ -1,6 +1,7 @@
+import LinkLikeButton from "./LinkLikeButton";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import TertiaryButton from "./TertiaryButton";
 import useButtonMenu from "./useButtonMenu";
 
-export { PrimaryButton, SecondaryButton, TertiaryButton, useButtonMenu };
+export { LinkLikeButton, PrimaryButton, SecondaryButton, TertiaryButton, useButtonMenu };

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import FilePrompt from "./FilePrompt";
-import { PrimaryButton, SecondaryButton } from "../Buttons";
+import { LinkLikeButton, PrimaryButton, SecondaryButton } from "../Buttons";
 import { Source } from "../../entity/SearchParams";
 import { interaction, selection } from "../../state";
 import { DataSourcePromptInfo } from "../../state/interaction/actions";
@@ -185,12 +185,10 @@ export default function DataSourcePrompt(props: Props) {
                     <FilePrompt onSelectFile={setMetadataSource} selectedFile={metadataSource} />
                 </>
             ) : (
-                <DefaultButton
-                    className={styles.linkLikeButton}
+                <LinkLikeButton
                     onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-                >
-                    (Optional) Add metadata source
-                </DefaultButton>
+                    text="(Optional) Add metadata source"
+                />
             )}
             <div className={styles.loadButtonContainer}>
                 {props.hideTitle && <SecondaryButton text="CANCEL" onClick={() => onDismiss()} />}

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -20,7 +20,7 @@
   padding: var(--margin);
 }
 
-.delete-warning-message {
+.delete-warning {
   font-size: var(--l-paragraph-size);
 }
 .delete-warning-section {
@@ -29,7 +29,6 @@
   color: var(--error-status-text-color);
   padding: 10px;
   border-radius: 4px;
-  font-size: var(--l-paragraph-size);
 }
 
 .delete-warning-section > i {

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -20,9 +20,34 @@
   padding: var(--margin);
 }
 
+.delete-warning {
+  font-size: var(--l-paragraph-size);
+}
+
 .error-message {
   color: var(--error-status-text-color);
   line-height: 1.5;
+}
+
+.error-message-section {
+  background-color: var(--error-status-background-color);
+  border: var(--error-background-color) 1px solid;
+  color: var(--error-status-text-color);
+  padding: 10px;
+  border-radius: 4px;
+  font-size: var(--l-paragraph-size);
+}
+
+.error-message-icon {
+  padding: 0 8px;
+  font-weight: 600;
+  top: 3px;
+  position: relative;
+  font-size: 18px;
+}
+
+.hidden {
+  display: none;
 }
 
 .flex-wrapper {

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -15,9 +15,18 @@
   padding-left: 5px;
 }
 
+.delete-button {
+  align-self: flex-end;
+  padding: var(--margin);
+}
+
 .error-message {
   color: var(--error-status-text-color);
   line-height: 1.5;
+}
+
+.flex-wrapper {
+  display: flex;
 }
 
 .warning-message {

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -20,16 +20,10 @@
   padding: var(--margin);
 }
 
-.delete-warning {
+.delete-warning-message {
   font-size: var(--l-paragraph-size);
 }
-
-.error-message {
-  color: var(--error-status-text-color);
-  line-height: 1.5;
-}
-
-.error-message-section {
+.delete-warning-section {
   background-color: var(--error-status-background-color);
   border: var(--error-background-color) 1px solid;
   color: var(--error-status-text-color);
@@ -38,7 +32,7 @@
   font-size: var(--l-paragraph-size);
 }
 
-.error-message-icon {
+.delete-warning-section > i {
   padding: 0 8px;
   font-weight: 600;
   top: 3px;
@@ -46,12 +40,17 @@
   font-size: 18px;
 }
 
-.hidden {
-  display: none;
+.error-message {
+  color: var(--error-status-text-color);
+  line-height: 1.5;
 }
 
 .flex-wrapper {
   display: flex;
+}
+
+.hidden {
+  display: none;
 }
 
 .warning-message {

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
 import useAnnotationValueByNameMap from "./useAnnotationValueByNameMap";
-import { PrimaryButton, SecondaryButton } from "../Buttons";
+import { LinkLikeButton, PrimaryButton, SecondaryButton } from "../Buttons";
 import ComboBox from "../ComboBox";
 import Annotation from "../../entity/Annotation";
 import { AnnotationType } from "../../entity/AnnotationFormatter";
@@ -16,6 +16,7 @@ import styles from "./EditMetadata.module.css";
 
 interface ExistingAnnotationProps {
     onDismiss: () => void;
+    onDelete: (annotationToDelete: string) => void;
     selectedFileCount: number;
     user?: string;
 }
@@ -105,6 +106,13 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
         }
     };
 
+    function onClickDelete(selectedAnnotation: string) {
+        if (selectedAnnotation) {
+            console.info("attempting to delete", selectedAnnotation, "from files");
+            props.onDelete(selectedAnnotation);
+        }
+    }
+
     function onSubmit() {
         const trimmedValues = newValues?.trim();
         const newValuesAsArray = newValues?.split(",").map((value) => value.trim());
@@ -137,15 +145,26 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
 
     return (
         <>
-            <ComboBox
-                className={styles.comboBox}
-                label="Select a metadata field"
-                placeholder="Select a field..."
-                selectedKey={selectedAnnotation}
-                options={annotationOptions}
-                onChange={onSelectMetadataField}
-                disabled={!annotationOptions.length}
-            />
+            <div className={styles.flexWrapper}>
+                <ComboBox
+                    className={styles.comboBox}
+                    label="Select a metadata field"
+                    placeholder="Select a field..."
+                    selectedKey={selectedAnnotation}
+                    options={annotationOptions}
+                    onChange={onSelectMetadataField}
+                    disabled={!annotationOptions.length}
+                />
+                {!!selectedAnnotation && (
+                    <div className={styles.deleteButton}>
+                        <LinkLikeButton
+                            onClick={() => onClickDelete(selectedAnnotation)}
+                            text="Delete"
+                            title="Delete metadata field and values"
+                        />
+                    </div>
+                )}
+            </div>
             {!!selectedAnnotation && (
                 <MetadataDetails
                     dropdownOptions={dropdownOptions}

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -151,12 +151,12 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
 
     const deleteMetadataWarning = (
         <>
-            <p className={styles.deleteWarning}>
+            <p className={styles.deleteWarningMessage}>
                 <b>{selectedAnnotation}</b> and all associated values will be deleted from selected
                 files.
             </p>
-            <p className={styles.errorMessageSection}>
-                <Icon className={styles.errorMessageIcon} iconName="Warning" />
+            <p className={styles.deleteWarningSection}>
+                <Icon iconName="Warning" />
                 This action is destructive and permanent.
             </p>
             <div className={classNames(styles.footer, styles.footerAlignRight)}>

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -150,8 +150,8 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
     };
 
     const deleteMetadataWarning = (
-        <>
-            <p className={styles.deleteWarningMessage}>
+        <div className={styles.deleteWarning}>
+            <p>
                 <b>{selectedAnnotation}</b> and all associated values will be deleted from selected
                 files.
             </p>
@@ -163,7 +163,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
                 <SecondaryButton title="" text="Back" onClick={() => onClickDelete(false)} />
                 <PrimaryButton title="" text="Delete" onClick={onDeleteMetadata} />
             </div>
-        </>
+        </div>
     );
 
     return isDeleting ? (

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -108,7 +108,6 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
 
     function onClickDelete(selectedAnnotation: string) {
         if (selectedAnnotation) {
-            console.info("attempting to delete", selectedAnnotation, "from files");
             props.onDelete(selectedAnnotation);
         }
     }

--- a/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/ExistingAnnotationPathway.tsx
@@ -1,4 +1,4 @@
-import { IComboBoxOption } from "@fluentui/react";
+import { IComboBoxOption, Icon } from "@fluentui/react";
 import classNames from "classnames";
 import { uniqueId } from "lodash";
 import * as React from "react";
@@ -16,7 +16,7 @@ import styles from "./EditMetadata.module.css";
 
 interface ExistingAnnotationProps {
     onDismiss: () => void;
-    onDelete: (annotationToDelete: string) => void;
+    onSelectDelete: (isDeleting: boolean) => void;
     selectedFileCount: number;
     user?: string;
 }
@@ -32,6 +32,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
     const [selectedAnnotation, setSelectedAnnotation] = React.useState<string>();
     const [annotationType, setAnnotationType] = React.useState<AnnotationType>();
     const [dropdownOptions, setDropdownOptions] = React.useState<string[]>();
+    const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
 
     const annotationValueByNameMap = useAnnotationValueByNameMap();
     const filters = useSelector(interaction.selectors.getFileFiltersForVisibleModal);
@@ -106,10 +107,9 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
         }
     };
 
-    function onClickDelete(selectedAnnotation: string) {
-        if (selectedAnnotation) {
-            props.onDelete(selectedAnnotation);
-        }
+    function onClickDelete(isDeleting: boolean) {
+        setIsDeleting(isDeleting);
+        props.onSelectDelete(isDeleting);
     }
 
     function onSubmit() {
@@ -142,7 +142,33 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
         }
     }
 
-    return (
+    const onDeleteMetadata = () => {
+        if (selectedAnnotation) {
+            dispatch(interaction.actions.deleteMetadata(selectedAnnotation, props.user));
+            props.onDismiss();
+        }
+    };
+
+    const deleteMetadataWarning = (
+        <>
+            <p className={styles.deleteWarning}>
+                <b>{selectedAnnotation}</b> and all associated values will be deleted from selected
+                files.
+            </p>
+            <p className={styles.errorMessageSection}>
+                <Icon className={styles.errorMessageIcon} iconName="Warning" />
+                This action is destructive and permanent.
+            </p>
+            <div className={classNames(styles.footer, styles.footerAlignRight)}>
+                <SecondaryButton title="" text="Back" onClick={() => onClickDelete(false)} />
+                <PrimaryButton title="" text="Delete" onClick={onDeleteMetadata} />
+            </div>
+        </>
+    );
+
+    return isDeleting ? (
+        deleteMetadataWarning
+    ) : (
         <>
             <div className={styles.flexWrapper}>
                 <ComboBox
@@ -157,7 +183,7 @@ export default function ExistingAnnotationPathway(props: ExistingAnnotationProps
                 {!!selectedAnnotation && (
                     <div className={styles.deleteButton}>
                         <LinkLikeButton
-                            onClick={() => onClickDelete(selectedAnnotation)}
+                            onClick={() => onClickDelete(true)}
                             text="Delete"
                             title="Delete metadata field and values"
                         />

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -16,6 +16,7 @@ enum EditMetadataPathway {
 interface EditMetadataProps {
     className?: string;
     onDismiss: () => void;
+    onDelete: (annotationToDelete: string) => void;
     setHasUnsavedChanges: (hasUnsavedChanges: boolean) => void;
     user?: string;
 }
@@ -58,6 +59,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
                 {editPathway === EditMetadataPathway.EXISTING ? (
                     <ExistingAnnotationPathway
                         onDismiss={props.onDismiss}
+                        onDelete={props.onDelete}
                         selectedFileCount={fileCount}
                         user={props.user}
                     />

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -41,7 +41,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
         <div className={classNames(props.className, styles.root)}>
             <ChoiceGroup
                 className={classNames(styles.choiceGroup, {
-                    [styles.hidden]: isDeleting, // Don't show options while delete warning is active
+                    [styles.hidden]: isDeleting, // Hide radio while delete warning is active
                 })}
                 defaultSelectedKey={editPathway}
                 onChange={(_ev, option) =>

--- a/packages/core/components/EditMetadata/index.tsx
+++ b/packages/core/components/EditMetadata/index.tsx
@@ -16,7 +16,7 @@ enum EditMetadataPathway {
 interface EditMetadataProps {
     className?: string;
     onDismiss: () => void;
-    onDelete: (annotationToDelete: string) => void;
+    onSelectDelete: (isDeleting: boolean) => void;
     setHasUnsavedChanges: (hasUnsavedChanges: boolean) => void;
     user?: string;
 }
@@ -31,11 +31,18 @@ export default function EditMetadataForm(props: EditMetadataProps) {
     const [editPathway, setEditPathway] = React.useState<EditMetadataPathway>(
         EditMetadataPathway.EXISTING
     );
+    const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
+    const onSelectDelete = (isDeleting: boolean) => {
+        setIsDeleting(isDeleting);
+        props.onSelectDelete(isDeleting);
+    };
 
     return (
         <div className={classNames(props.className, styles.root)}>
             <ChoiceGroup
-                className={styles.choiceGroup}
+                className={classNames(styles.choiceGroup, {
+                    [styles.hidden]: isDeleting, // Don't show options while delete warning is active
+                })}
                 defaultSelectedKey={editPathway}
                 onChange={(_ev, option) =>
                     setEditPathway(
@@ -59,7 +66,7 @@ export default function EditMetadataForm(props: EditMetadataProps) {
                 {editPathway === EditMetadataPathway.EXISTING ? (
                     <ExistingAnnotationPathway
                         onDismiss={props.onDismiss}
-                        onDelete={props.onDelete}
+                        onSelectDelete={onSelectDelete}
                         selectedFileCount={fileCount}
                         user={props.user}
                     />

--- a/packages/core/components/Modal/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/Modal/EditMetadata/EditMetadata.module.css
@@ -1,3 +1,20 @@
+.error-message {
+  background-color: var(--error-status-background-color);
+  border: var(--error-background-color) 1px solid;
+  color: var(--error-status-text-color);
+  padding: 10px;
+  border-radius: 4px;
+  font-size: var(--l-paragraph-size);
+}
+
+.error-message-icon {
+  padding: 0 8px;
+  font-weight: 600;
+  top: 3px;
+  position: relative;
+  font-size: 18px;
+}
+
 .footer {
   margin-top: 20px;
   width: 100%;

--- a/packages/core/components/Modal/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/Modal/EditMetadata/EditMetadata.module.css
@@ -1,20 +1,3 @@
-.error-message {
-  background-color: var(--error-status-background-color);
-  border: var(--error-background-color) 1px solid;
-  color: var(--error-status-text-color);
-  padding: 10px;
-  border-radius: 4px;
-  font-size: var(--l-paragraph-size);
-}
-
-.error-message-icon {
-  padding: 0 8px;
-  font-weight: 600;
-  top: 3px;
-  position: relative;
-  font-size: 18px;
-}
-
 .footer {
   margin-top: 20px;
   width: 100%;

--- a/packages/core/components/Modal/EditMetadata/index.tsx
+++ b/packages/core/components/Modal/EditMetadata/index.tsx
@@ -80,22 +80,20 @@ export default function EditMetadata({ onDismiss }: ModalProps) {
                     setHasUnsavedChanges={setHasUnsavedChanges}
                     user={program && PROGRAM_TO_USER_MAP[program]}
                 />
-                {showUnsavedWarning && (
-                    <>
-                        <p className={styles.warning}>
-                            Some edits will not be completed and could cause inaccuracies. Are you
-                            sure you want to quit now?
-                        </p>
-                        <div className={classNames(styles.footer, styles.footerAlignRight)}>
-                            <SecondaryButton
-                                title=""
-                                text="Back"
-                                onClick={() => setShowUnsavedWarning(false)}
-                            />
-                            <PrimaryButton title="" text="Yes, Quit" onClick={onDismiss} />
-                        </div>
-                    </>
-                )}
+                <div className={classNames({ [styles.hidden]: !showUnsavedWarning })}>
+                    <p className={styles.warning}>
+                        Some edits will not be completed and could cause inaccuracies. Are you sure
+                        you want to quit now?
+                    </p>
+                    <div className={classNames(styles.footer, styles.footerAlignRight)}>
+                        <SecondaryButton
+                            title=""
+                            text="Back"
+                            onClick={() => setShowUnsavedWarning(false)}
+                        />
+                        <PrimaryButton title="" text="Yes, Quit" onClick={onDismiss} />
+                    </div>
+                </div>
             </>
         ) : (
             <PasswordForm

--- a/packages/core/components/Modal/EditMetadata/test/EditMetadata.test.tsx
+++ b/packages/core/components/Modal/EditMetadata/test/EditMetadata.test.tsx
@@ -1,0 +1,108 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+import { createSandbox } from "sinon";
+
+import Modal, { ModalType } from "../..";
+import { initialState } from "../../../../state";
+import { AICS_FMS_DATA_SOURCE_NAME } from "../../../../constants";
+import * as useFilteredSelection from "../../../../hooks/useFilteredSelection";
+import FileSelection from "../../../../entity/FileSelection";
+import FileSet from "../../../../entity/FileSet";
+import NumericRange from "../../../../entity/NumericRange";
+
+describe("<EditMetadata />", () => {
+    const visibleDialogState = mergeState(initialState, {
+        interaction: {
+            visibleModal: ModalType.EditMetadata,
+        },
+        metadata: {
+            passwordToProgramMap: {
+                mockPassword: "Fake Program",
+            },
+        },
+    });
+    const sandbox = createSandbox();
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("shows password prompt when querying AICS", async () => {
+        // Arrange
+        const state = mergeState(visibleDialogState, {
+            selection: {
+                dataSources: [{ name: AICS_FMS_DATA_SOURCE_NAME }],
+            },
+        });
+        const { store, logicMiddleware } = configureMockStore({ state });
+        const { getByText } = render(
+            <Provider store={store}>
+                <Modal />
+            </Provider>
+        );
+        // Act: wait for passwords to load
+        await logicMiddleware.whenComplete();
+
+        // Assert
+        expect(getByText("Password")).to.exist;
+        expect(getByText(/A password is required/)).to.exist;
+    });
+
+    it("skips password step for non AICS data source", async () => {
+        // Arrange
+        const state = mergeState(visibleDialogState, {
+            selection: {
+                dataSources: [{ name: "Mock Data Source" }],
+            },
+        });
+        const { store, logicMiddleware } = configureMockStore({ state });
+        const { getByText } = render(
+            <Provider store={store}>
+                <Modal />
+            </Provider>
+        );
+        // Act: Don't need to wait for passwords,
+        // but keeping for consistency with previous test
+        await logicMiddleware.whenComplete();
+
+        // Assert
+        // Make sure loading is complete
+        expect(getByText("Existing field")).to.exist;
+        expect(() => getByText("Password")).to.throw;
+    });
+
+    it("shows a count of selected files", () => {
+        const totalFileCount = 123;
+        const mockFileSelection = new FileSelection().select({
+            fileSet: new FileSet(),
+            index: new NumericRange(0, totalFileCount - 1),
+            sortOrder: 0,
+        });
+        sandbox.stub(useFilteredSelection, "default").returns(mockFileSelection);
+        const { store } = configureMockStore({ state: visibleDialogState });
+        const { getByText } = render(
+            <Provider store={store}>
+                <Modal />
+            </Provider>
+        );
+        expect(getByText(`Edit metadata (${totalFileCount} files)`)).to.exist;
+    });
+
+    it("hides deletion functionality when not in use", async () => {
+        const state = mergeState(visibleDialogState, {
+            selection: {
+                dataSources: [{ name: "Mock Data Source" }],
+            },
+        });
+        const { store, logicMiddleware } = configureMockStore({ state });
+        const { getByText } = render(
+            <Provider store={store}>
+                <Modal />
+            </Provider>
+        );
+        await logicMiddleware.whenComplete();
+        expect(() => getByText(/You are deleting metadata/)).to.throw;
+    });
+});

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -296,6 +296,29 @@ export function editFiles(
 }
 
 /**
+ * Delete metadata from a set of files by transforming into an edit
+ */
+export const DELETE_METADATA = makeConstant(STATE_BRANCH_NAME, "delete-metadata");
+
+export interface DeleteMetadataAction {
+    type: string;
+    payload: {
+        annotationName: string;
+        user?: string;
+    };
+}
+
+export function deleteMetadata(annotationName: string, user?: string): DeleteMetadataAction {
+    return {
+        type: DELETE_METADATA,
+        payload: {
+            annotationName,
+            user,
+        },
+    };
+}
+
+/**
  * PROCESS AND STATUS RELATED ENUMS, INTERFACES, ETC.
  */
 

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -296,7 +296,7 @@ export function editFiles(
 }
 
 /**
- * Delete metadata from a set of files by transforming into an edit
+ * Delete metadata from a set of files by transforming action into an edit action
  */
 export const DELETE_METADATA = makeConstant(STATE_BRANCH_NAME, "delete-metadata");
 

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -35,6 +35,9 @@ import {
     COPY_FILES,
     EDIT_FILES,
     EditFilesAction,
+    editFiles,
+    DeleteMetadataAction,
+    DELETE_METADATA,
 } from "./actions";
 import * as interactionSelectors from "./selectors";
 import { DownloadResolution, FileInfo } from "../../services/FileDownloadService";
@@ -525,6 +528,21 @@ const openWithLogic = createLogic({
 });
 
 /**
+ * Interceptor responsible for translating a DELETE_METADATA action
+ * into an EDIT_FILES action
+ */
+const deleteMetadataLogic = createLogic({
+    async process(deps: ReduxLogicDeps, dispatch) {
+        const filters = interactionSelectors.getFileFiltersForVisibleModal(deps.getState());
+        const {
+            payload: { annotationName, user },
+        } = deps.action as DeleteMetadataAction;
+        dispatch(editFiles({ [annotationName]: [] }, filters, user));
+    },
+    type: DELETE_METADATA,
+});
+
+/**
  * Interceptor responsible for translating an EDIT_FILES action into a progress tracked
  * series of edits on the files currently selected.
  */
@@ -807,6 +825,7 @@ const copyFilesLogic = createLogic({
 export default [
     initializeApp,
     downloadManifest,
+    deleteMetadataLogic,
     editFilesLogic,
     cancelFileDownloadLogic,
     promptForNewExecutable,


### PR DESCRIPTION
## Context
For metadata editing, we currently only allow users to add or modify file metadata. This allows users to fully remove/delete metadata from files (e.g., replace values for fields with null/empty).
Resolves #465 

## Changes
- Adds deletion UI with a warning to the `ExistingAnnotationPathway` per designs in [Figma](https://www.figma.com/design/oNQvOAK11YINcbPvNmkgwO/Public-File-Explorer?node-id=3184-6543&t=XhM1quWtnLJEdOou-0)
   - Created a "link-like" button to our suite of buttons. We technically already used one in the data source modal, this just formalizes it into its own styled component
- Adds redux logic for deleting. This is a thin wrapper for our pre-existing edit logic
- The parent components also need to keep track of whether the warning about deletion is active, since there are some things (modal title, whether or not the radio shows) that are defined further up the chain

## Testing
- Manually tested deleting metadata from test files while pointing at staging FES
- Added a test for redux logic (delete becomes edit)
- Added some unit tests to the modal. Some of these are unrelated unit tests for older functionality

## Screenshots (if relevant)
<img width="400" alt="Screenshot 2025-06-17 at 1 43 30 PM" src="https://github.com/user-attachments/assets/bd79a267-d4b7-4209-8c27-1e4b721718cf" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b521a958-6e94-4442-b93a-96caafbb0193" />
