### PR TITLE
Feature/deletion for external sources

### DIFF
--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -240,9 +240,11 @@ export default class DatabaseFileService implements FileService {
 
     public editFile(fileId: string, annotations: AnnotationNameToValuesMap): Promise<void> {
         const tableName = this.dataSourceNames.sort().join(", ");
-        const columnAssignments = Object.entries(annotations).map(
-            ([name, values]) => `"${name}" = '${values.join(DatabaseService.LIST_DELIMITER)}'`
-        );
+        const columnAssignments = Object.entries(annotations).map(([name, values]) => {
+            let valueString = `'${values.join(DatabaseService.LIST_DELIMITER)}'`;
+            if (values.length === 0) valueString = "NULL";
+            return `"${name}" = ${valueString}`;
+        });
         const sql = `\
             UPDATE '${tableName}' \
             SET ${columnAssignments.join(", ")} \

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -242,7 +242,7 @@ export default class DatabaseFileService implements FileService {
         const tableName = this.dataSourceNames.sort().join(", ");
         const columnAssignments = Object.entries(annotations).map(([name, values]) => {
             let valueString = `'${values.join(DatabaseService.LIST_DELIMITER)}'`;
-            if (values.length === 0) valueString = "NULL";
+            if (values.length === 0) valueString = "NULL"; // Empty value array means deletion
             return `"${name}" = ${valueString}`;
         });
         const sql = `\

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { createSandbox, match } from "sinon";
 
 import DatabaseService from "../../../DatabaseService";
 import FileSelection from "../../../../entity/FileSelection";
@@ -193,6 +194,113 @@ describe("DatabaseFileService", () => {
             // Uses AND between different filter types
             expect(modifiedSQLWithAND).to.include("AND");
             expect(modifiedSQLWithAND).not.to.include("OR");
+        });
+    });
+
+    describe("editFiles", () => {
+        const uidField = DatabaseService.HIDDEN_UID_ANNOTATION;
+        const sandbox = createSandbox();
+        afterEach(() => {
+            sandbox.restore();
+        });
+        class MockDatabaseEditService extends DatabaseService {
+            public execute(_sql: string): Promise<void> {
+                return Promise.resolve();
+            }
+
+            public saveQuery(): Promise<Uint8Array> {
+                return Promise.reject("MockDatabaseEditService:saveQuery");
+            }
+
+            public query(): Promise<{ [key: string]: string }[]> {
+                return Promise.reject("MockDatabaseEditService:query");
+            }
+
+            protected addDataSource(): Promise<void> {
+                return Promise.reject("MockDatabaseEditService:addDataSource");
+            }
+        }
+        const databaseEditService = new MockDatabaseEditService();
+
+        it("issues request to edit files matching given parameters", async () => {
+            // Arrange
+            const fileService = new DatabaseFileService({
+                dataSourceNames: ["Mock Source"],
+                databaseService: databaseEditService,
+                downloadService: new FileDownloadServiceNoop(),
+            });
+            const sqlSpy = sandbox.spy(databaseEditService, "execute");
+            const annotationName = "Test Annotation";
+            const annotationValue = "Some value";
+            // Act
+            await fileService.editFile("123", { [annotationName]: [annotationValue] });
+
+            // Assert
+            expect(sqlSpy.called).to.be.true;
+            const regex = new RegExp(String.raw`WHERE ${uidField} \= \'123\'`);
+            expect(sqlSpy.calledWith(match(regex))).to.be.true;
+        });
+
+        it("issues request to edit single value for files", async () => {
+            // Arrange
+            const fileService = new DatabaseFileService({
+                dataSourceNames: ["Mock Source"],
+                databaseService: databaseEditService,
+                downloadService: new FileDownloadServiceNoop(),
+            });
+            const sqlSpy = sandbox.spy(databaseEditService, "execute");
+            const annotationName = "Test Annotation";
+            const annotationValue = "Some value";
+            // Act
+            await fileService.editFile("123", { [annotationName]: [annotationValue] });
+
+            // Assert
+            expect(sqlSpy.called).to.be.true;
+            const regex = new RegExp(
+                String.raw`SET \"${annotationName}\" \= \'${annotationValue}\'`
+            );
+            expect(sqlSpy.calledWith(match(regex))).to.be.true;
+        });
+
+        it("issues request to edit multiple annotations for files", async () => {
+            // Arrange
+            const fileService = new DatabaseFileService({
+                dataSourceNames: ["Mock Source"],
+                databaseService: databaseEditService,
+                downloadService: new FileDownloadServiceNoop(),
+            });
+            const sqlSpy = sandbox.spy(databaseEditService, "execute");
+            const annotationName1 = "Test Annotation 1";
+            const annotationName2 = "Test Annotation 2";
+
+            const annotationValue = "Some value";
+            // Act
+            await fileService.editFile("123", {
+                [annotationName1]: [annotationValue],
+                [annotationName2]: [annotationValue],
+            });
+
+            // Assert
+            expect(sqlSpy.called).to.be.true;
+            const regex = new RegExp(
+                String.raw`SET \"${annotationName1}\" \= \'${annotationValue}\', \"${annotationName2}\" \=`
+            );
+            expect(sqlSpy.calledWith(match(regex))).to.be.true;
+        });
+
+        it("issues request to delete metadata from files", async () => {
+            const fileService = new DatabaseFileService({
+                dataSourceNames: ["Mock Source"],
+                databaseService: databaseEditService,
+                downloadService: new FileDownloadServiceNoop(),
+            });
+            const sqlSpy = sandbox.spy(databaseEditService, "execute");
+            const annotationName = "Test Annotation";
+            await fileService.editFile("123", { [annotationName]: [] });
+
+            expect(sqlSpy.called).to.be.true;
+            const regex = new RegExp(String.raw`SET \"${annotationName}\" \= NULL`);
+            expect(sqlSpy.calledWith(match(regex))).to.be.true;
         });
     });
 });

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -199,10 +199,12 @@ describe("DatabaseFileService", () => {
 
     describe("editFiles", () => {
         const uidField = DatabaseService.HIDDEN_UID_ANNOTATION;
+        const fileUid = "a1b2c3d4";
         const sandbox = createSandbox();
         afterEach(() => {
             sandbox.restore();
         });
+        // Custom mock to allow spying on `execute` args
         class MockDatabaseEditService extends DatabaseService {
             public execute(_sql: string): Promise<void> {
                 return Promise.resolve();
@@ -233,11 +235,11 @@ describe("DatabaseFileService", () => {
             const annotationName = "Test Annotation";
             const annotationValue = "Some value";
             // Act
-            await fileService.editFile("123", { [annotationName]: [annotationValue] });
+            await fileService.editFile(fileUid, { [annotationName]: [annotationValue] });
 
             // Assert
             expect(sqlSpy.called).to.be.true;
-            const regex = new RegExp(String.raw`WHERE ${uidField} \= \'123\'`);
+            const regex = new RegExp(String.raw`WHERE ${uidField} \= \'${fileUid}\'`);
             expect(sqlSpy.calledWith(match(regex))).to.be.true;
         });
 
@@ -252,7 +254,7 @@ describe("DatabaseFileService", () => {
             const annotationName = "Test Annotation";
             const annotationValue = "Some value";
             // Act
-            await fileService.editFile("123", { [annotationName]: [annotationValue] });
+            await fileService.editFile(fileUid, { [annotationName]: [annotationValue] });
 
             // Assert
             expect(sqlSpy.called).to.be.true;
@@ -275,7 +277,7 @@ describe("DatabaseFileService", () => {
 
             const annotationValue = "Some value";
             // Act
-            await fileService.editFile("123", {
+            await fileService.editFile(fileUid, {
                 [annotationName1]: [annotationValue],
                 [annotationName2]: [annotationValue],
             });
@@ -296,7 +298,7 @@ describe("DatabaseFileService", () => {
             });
             const sqlSpy = sandbox.spy(databaseEditService, "execute");
             const annotationName = "Test Annotation";
-            await fileService.editFile("123", { [annotationName]: [] });
+            await fileService.editFile(fileUid, { [annotationName]: [] });
 
             expect(sqlSpy.called).to.be.true;
             const regex = new RegExp(String.raw`SET \"${annotationName}\" \= NULL`);

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -542,7 +542,7 @@ const deleteMetadataLogic = createLogic({
             dispatch(editFiles({ [annotationName]: [] }, filters, user));
         } catch (err) {
             // Dispatch an event to alert the user of the failure
-            // We shouldn't reach this unless fails before `editFilesLogic` reaches its own error handling
+            // We shouldn't reach this unless logic fails before `editFilesLogic` reaches its own error handling
             const errorMsg = `Failed to delete metadata from files, some may have been edited. Details:<br/>${
                 err instanceof Error ? err.message : err
             }`;

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -532,12 +532,24 @@ const openWithLogic = createLogic({
  * into an EDIT_FILES action
  */
 const deleteMetadataLogic = createLogic({
-    async process(deps: ReduxLogicDeps, dispatch) {
+    async process(deps: ReduxLogicDeps, dispatch, done) {
         const filters = interactionSelectors.getFileFiltersForVisibleModal(deps.getState());
+        const deleteRequestId = uniqueId();
         const {
             payload: { annotationName, user },
         } = deps.action as DeleteMetadataAction;
-        dispatch(editFiles({ [annotationName]: [] }, filters, user));
+        try {
+            dispatch(editFiles({ [annotationName]: [] }, filters, user));
+        } catch (err) {
+            // Dispatch an event to alert the user of the failure
+            // We shouldn't reach this unless fails before `editFilesLogic` reaches its own error handling
+            const errorMsg = `Failed to delete metadata from files, some may have been edited. Details:<br/>${
+                err instanceof Error ? err.message : err
+            }`;
+            dispatch(processError(deleteRequestId, errorMsg));
+        } finally {
+            done();
+        }
     },
     type: DELETE_METADATA,
 });


### PR DESCRIPTION
## Context
Adds the logic for "deleting" (setting to `NULL`) metadata for external data sources (DuckDB).
Doesn't actually enable editing for external data sources for users; the option is still hidden in the menu until #392 is done.
resolves #544 

## Changes
When users click "delete" in the edit modal, Redux logic (already) sends an edit request where the values are set to `[]`. 
When our `DatabaseFileService` receives this request, it now converts that into the SQL `SET "<field>" = NULL`. Otherwise, it would execute `SET "<field>" = ''` which would make the field blank but not actually fully make it empty.

Unrelated: the `delete` logic was sending a console warning since I previously had forgotten to include `done()`. 

## Testing
Manual: Tested on the Variance data set
Also added unit tests, both for this and for editing in general
