### PR TITLE
Feature/warn unsaved edits

### DIFF
--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -47,6 +47,7 @@ export default function App(props: AppProps) {
 
     const dispatch = useDispatch();
     const hasQuerySelected = useSelector(selection.selectors.hasQuerySelected);
+    const hasUnsavedChanges = useSelector(interaction.selectors.getHasUnsavedChanges);
     const requiresDataSourceReload = useSelector(selection.selectors.getRequiresDataSourceReload);
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const platformDependentServices = useSelector(
@@ -55,6 +56,23 @@ export default function App(props: AppProps) {
     const [measuredNodeRef, _measuredHeight, measuredWidth] = useLayoutMeasurements<
         HTMLDivElement
     >();
+
+    React.useEffect(() => {
+        const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+            // Modern browser alert: Does not allow custom messages
+            event.preventDefault();
+
+            // Legacy support (e.g. Chrome/Edge < 119): Allows custom messages
+            event.returnValue =
+                "Edits to external data sources will not be saved. Make sure to download the result in order to keep your changes";
+        };
+
+        if (hasUnsavedChanges) window.addEventListener("beforeunload", beforeUnloadHandler);
+        // remove the event listener
+        return () => {
+            window.removeEventListener("beforeunload", beforeUnloadHandler);
+        };
+    }, [hasUnsavedChanges]);
 
     // Check for updates to the application on startup
     React.useEffect(() => {

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -14,7 +14,7 @@ import GlobalActionButtonRow from "./components/GlobalActionButtonRow";
 import StatusMessage from "./components/StatusMessage";
 import TutorialTooltip from "./components/TutorialTooltip";
 import QuerySidebar from "./components/QuerySidebar";
-import { Environment } from "./constants";
+import { Environment, UNSAVED_DATA_WARNING } from "./constants";
 import { interaction, selection } from "./state";
 import useLayoutMeasurements from "./hooks/useLayoutMeasurements";
 
@@ -64,8 +64,7 @@ export default function App(props: AppProps) {
 
             // Legacy support (e.g. Chrome/Edge < 119): Allows custom messages
             // Deprecated, does not affect modern browsers
-            event.returnValue =
-                "Edits to external data sources will not be saved. Make sure to download the result in order to keep your changes";
+            event.returnValue = UNSAVED_DATA_WARNING;
         };
 
         if (hasUnsavedChanges) window.addEventListener("beforeunload", beforeUnloadHandler);

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -63,6 +63,7 @@ export default function App(props: AppProps) {
             event.preventDefault();
 
             // Legacy support (e.g. Chrome/Edge < 119): Allows custom messages
+            // Deprecated, does not affect modern browsers
             event.returnValue =
                 "Edits to external data sources will not be saved. Make sure to download the result in order to keep your changes";
         };

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -89,3 +89,6 @@ export enum DatasetBucketUrl {
     PRODUCTION = "https://biofile-finder-datasets.s3.us-west-2.amazonaws.com",
     TEST = "http://test-aics.corp.alleninstitute.org",
 }
+
+export const UNSAVED_DATA_WARNING =
+    "Edits to data source files are not preserved by this app. Download to save a copy with your changes.";

--- a/packages/core/hooks/useFileAccessContextMenu.ts
+++ b/packages/core/hooks/useFileAccessContextMenu.ts
@@ -104,27 +104,23 @@ export default (folderFilters?: FileFilter[], onDismiss?: () => void) => {
                     },
                     subMenuProps: { items: saveAsSubMenuItems },
                 },
-                ...(isQueryingAicsFms
-                    ? [
-                          {
-                              key: "edit",
-                              text: "Edit metadata",
-                              title: "Edit metadata for selected files",
-                              disabled: !folderFilters && fileSelection.count() === 0,
-                              iconProps: {
-                                  iconName: "Edit",
-                              },
-                              onClick() {
-                                  dispatch(
-                                      interaction.actions.setVisibleModal(
-                                          ModalType.EditMetadata,
-                                          folderFilters
-                                      )
-                                  );
-                              },
-                          },
-                      ]
-                    : []),
+                {
+                    key: "edit",
+                    text: "Edit metadata",
+                    title: "Edit metadata for selected files",
+                    disabled: !folderFilters && fileSelection.count() === 0,
+                    iconProps: {
+                        iconName: "Edit",
+                    },
+                    onClick() {
+                        dispatch(
+                            interaction.actions.setVisibleModal(
+                                ModalType.EditMetadata,
+                                folderFilters
+                            )
+                        );
+                    },
+                },
                 ...(isQueryingAicsFms && !isOnWeb
                     ? [
                           {

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -267,6 +267,21 @@ export const initializeApp = (payload: { environment: string }) => ({
 });
 
 /**
+ * Indicate that there are unsaved edits for non-AICS data sources
+ */
+export const SET_HAS_UNSAVED_CHANGES = makeConstant(STATE_BRANCH_NAME, "set-has-unsaved-changes");
+
+export interface SetHasUnsavedChanges {
+    type: string;
+}
+
+export function setHasUnsavedChanges(): SetHasUnsavedChanges {
+    return {
+        type: SET_HAS_UNSAVED_CHANGES,
+    };
+}
+
+/**
  * Edit the currently selected files with the given metadata
  */
 export const EDIT_FILES = makeConstant(STATE_BRANCH_NAME, "edit-files");
@@ -379,6 +394,36 @@ export function promptUserToUpdateApp(processId: string, msg: string): PromptUse
                 msg,
             },
             processId,
+        },
+    };
+}
+
+/**
+ * INFO MESSAGE
+ *
+ * Intention to provide user with general info about a (potentially long-running) process.
+ */
+export interface ProcessInfoAction {
+    type: string;
+    payload: StatusUpdate;
+}
+
+export function processInfo(
+    processId: string,
+    msg: string,
+    onCancel?: () => void,
+    fileId?: string[]
+): ProcessStartAction {
+    return {
+        type: SET_STATUS,
+        payload: {
+            data: {
+                fileId,
+                msg,
+                status: ProcessStatus.NOT_SET,
+            },
+            processId,
+            onCancel,
         },
     };
 }

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -420,7 +420,7 @@ export function processInfo(
             data: {
                 fileId,
                 msg,
-                status: ProcessStatus.NOT_SET,
+                status: ProcessStatus.NOT_SET, // default: info
             },
             processId,
             onCancel,

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -7,6 +7,7 @@ import {
     DOWNLOAD_MANIFEST,
     DownloadManifestAction,
     processError,
+    processInfo,
     processProgress,
     processStart,
     processSuccess,
@@ -26,6 +27,7 @@ import {
     PROMPT_FOR_NEW_EXECUTABLE,
     setUserSelectedApplication,
     INITIALIZE_APP,
+    setHasUnsavedChanges,
     setIsAicsEmployee,
     SET_IS_SMALL_SCREEN,
     SetIsSmallScreenAction,
@@ -551,6 +553,8 @@ const editFilesLogic = createLogic({
         const fileService = interactionSelectors.getFileService(deps.getState());
         const fileSelection = selection.selectors.getFileSelection(deps.getState());
         const sortColumn = selection.selectors.getSortColumn(deps.getState());
+        const hasUnsavedChanges = interaction.selectors.getHasUnsavedChanges(deps.getState());
+        const isQueryingAicsFms = selection.selectors.isQueryingAicsFms(deps.getState());
         const annotationNameToAnnotationMap = metadata.selectors.getAnnotationNameToAnnotationMap(
             deps.getState()
         );
@@ -622,6 +626,15 @@ const editFilesLogic = createLogic({
             }
             dispatch(refresh); // Sync state to pull updated files
             dispatch(processSuccess(editRequestId, "Successfully edited files."));
+            if (!hasUnsavedChanges && !isQueryingAicsFms) {
+                dispatch(setHasUnsavedChanges());
+                dispatch(
+                    processInfo(
+                        "edit-info-msg",
+                        "Edits made to external data sources are not permanent. Make sure to save/download data to keep your edited versions."
+                    )
+                );
+            }
         } catch (err) {
             // Dispatch an event to alert the user of the failure
             const errorMsg = `Failed to finish editing files, some may have been edited. Details:<br/>${

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -552,9 +552,9 @@ const editFilesLogic = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const fileService = interactionSelectors.getFileService(deps.getState());
         const fileSelection = selection.selectors.getFileSelection(deps.getState());
-        const sortColumn = selection.selectors.getSortColumn(deps.getState());
         const hasUnsavedChanges = interaction.selectors.getHasUnsavedChanges(deps.getState());
         const isQueryingAicsFms = selection.selectors.isQueryingAicsFms(deps.getState());
+        const sortColumn = selection.selectors.getSortColumn(deps.getState());
         const annotationNameToAnnotationMap = metadata.selectors.getAnnotationNameToAnnotationMap(
             deps.getState()
         );
@@ -630,7 +630,7 @@ const editFilesLogic = createLogic({
                 dispatch(setHasUnsavedChanges());
                 dispatch(
                     processInfo(
-                        "edit-info-msg",
+                        "edit-info-message",
                         "Edits made to external data sources are not permanent. Make sure to save/download data to keep your edited versions."
                     )
                 );

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -42,6 +42,7 @@ import {
     DeleteMetadataAction,
 } from "./actions";
 import * as interactionSelectors from "./selectors";
+import { UNSAVED_DATA_WARNING } from "../../constants";
 import { DownloadResolution, FileInfo } from "../../services/FileDownloadService";
 import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileSet from "../../entity/FileSet";
@@ -640,12 +641,7 @@ const editFilesLogic = createLogic({
             dispatch(processSuccess(editRequestId, "Successfully edited files."));
             if (!hasUnsavedChanges && !isQueryingAicsFms) {
                 dispatch(setHasUnsavedChanges());
-                dispatch(
-                    processInfo(
-                        "edit-info-message",
-                        "Edits made to external data sources are not permanent. Make sure to save/download data to keep your edited versions."
-                    )
-                );
+                dispatch(processInfo("edit-info-message", UNSAVED_DATA_WARNING));
             }
         } catch (err) {
             // Dispatch an event to alert the user of the failure

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -42,21 +42,21 @@ import {
     DeleteMetadataAction,
 } from "./actions";
 import * as interactionSelectors from "./selectors";
+import { ModalType } from "../../components/Modal";
 import { UNSAVED_DATA_WARNING } from "../../constants";
-import { DownloadResolution, FileInfo } from "../../services/FileDownloadService";
+import AnnotationName from "../../entity/Annotation/AnnotationName";
 import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
+import FileDetail from "../../entity/FileDetail";
 import FileSet from "../../entity/FileSet";
+import FileSelection from "../../entity/FileSelection";
+import NumericRange from "../../entity/NumericRange";
+import SearchParams, { DEFAULT_AICS_FMS_QUERY } from "../../entity/SearchParams";
 import {
     ExecutableEnvCancellationToken,
     SystemDefaultAppLocation,
 } from "../../services/ExecutionEnvService";
+import { DownloadResolution, FileInfo } from "../../services/FileDownloadService";
 import { UserSelectedApplication } from "../../services/PersistentConfigService";
-import FileDetail from "../../entity/FileDetail";
-import AnnotationName from "../../entity/Annotation/AnnotationName";
-import FileSelection from "../../entity/FileSelection";
-import NumericRange from "../../entity/NumericRange";
-import SearchParams, { DEFAULT_AICS_FMS_QUERY } from "../../entity/SearchParams";
-import { ModalType } from "../../components/Modal";
 
 export const DEFAULT_QUERY_NAME = "New Query";
 

--- a/packages/core/state/interaction/reducer.ts
+++ b/packages/core/state/interaction/reducer.ts
@@ -20,6 +20,7 @@ import {
     MARK_AS_USED_APPLICATION_BEFORE,
     MARK_AS_DISMISSED_SMALL_SCREEN_WARNING,
     ShowManifestDownloadDialogAction,
+    SET_HAS_UNSAVED_CHANGES,
     SET_IS_AICS_EMPLOYEE,
     PROMPT_FOR_DATA_SOURCE,
     DownloadManifestAction,
@@ -56,6 +57,7 @@ export interface InteractionStateBranch {
     fileFiltersForVisibleModal: FileFilter[];
     environment: "LOCALHOST" | "PRODUCTION" | "STAGING" | "TEST";
     hasDismissedSmallScreenWarning: boolean;
+    hasUnsavedChanges: boolean;
     hasUsedApplicationBefore: boolean;
     isAicsEmployee?: boolean;
     isOnWeb: boolean;
@@ -80,6 +82,7 @@ export const initialState: InteractionStateBranch = {
     fileFiltersForVisibleModal: [],
     fileTypeForVisibleModal: "csv",
     hasDismissedSmallScreenWarning: false,
+    hasUnsavedChanges: false,
     hasUsedApplicationBefore: false,
     isOnWeb: false,
     platformDependentServices: {
@@ -143,6 +146,10 @@ export default makeReducer<InteractionStateBranch>(
         [SET_USER_SELECTED_APPLICATIONS]: (state, action) => ({
             ...state,
             userSelectedApplications: action.payload,
+        }),
+        [SET_HAS_UNSAVED_CHANGES]: (state) => ({
+            ...state,
+            hasUnsavedChanges: true,
         }),
         [SET_IS_AICS_EMPLOYEE]: (state, action) => ({
             ...state,

--- a/packages/core/state/interaction/selectors.ts
+++ b/packages/core/state/interaction/selectors.ts
@@ -41,6 +41,7 @@ export const getFileTypeForVisibleModal = (state: State) =>
     state.interaction.fileTypeForVisibleModal;
 export const getHasDismissedSmallScreenWarning = (state: State) =>
     state.interaction.hasDismissedSmallScreenWarning;
+export const getHasUnsavedChanges = (state: State) => state.interaction.hasUnsavedChanges;
 export const hasUsedApplicationBefore = (state: State) =>
     state.interaction.hasUsedApplicationBefore;
 export const isOnWeb = (state: State) => state.interaction.isOnWeb;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -107,6 +107,24 @@ const createMainWindow = () => {
         return { action: "deny" };
     });
 
+    /***
+     * Catch 'beforeunload' events since Electron handles these differently from browser
+     * Similar to above, but for main window instead of child window
+     */
+    mainWindow.webContents.on("will-prevent-unload", (ev: Event) => {
+        const options = {
+            type: "question",
+            buttons: ["Leave", "Cancel"],
+            message: "Leave site?",
+            detail:
+                "Edits to external data sources may not be saved. Download query results to save edits.",
+        };
+        if (mainWindow) {
+            const shouldLeave = dialog.showMessageBoxSync(mainWindow, options) === 0;
+            if (shouldLeave) ev.preventDefault(); // Unblock & perform the blocked action (e.g., leave, reload)
+        }
+    });
+
     if (isDevelopment) {
         mainWindow
             .loadURL(`http://localhost:${process.env.WEBPACK_DEV_SERVER_PORT}`)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import FileDownloadServiceElectron from "../services/FileDownloadServiceElectron
 import NotificationServiceElectron from "../services/NotificationServiceElectron";
 import PersistentConfigServiceElectron from "../services/PersistentConfigServiceElectron";
 import { Environment } from "../util/constants";
+import { UNSAVED_DATA_WARNING } from "../../../core/constants";
 import { PersistedConfigKeys } from "../../../core/services";
 
 const isDevelopment = process.env.NODE_ENV === "development";
@@ -116,8 +117,7 @@ const createMainWindow = () => {
             type: "question",
             buttons: ["Leave", "Cancel"],
             message: "Leave site?",
-            detail:
-                "Edits to external data sources may not be saved. Download query results to save edits.",
+            detail: UNSAVED_DATA_WARNING,
         };
         if (mainWindow) {
             const shouldLeave = dialog.showMessageBoxSync(mainWindow, options) === 0;


### PR DESCRIPTION
## Context
When users perform edits on non-FMS data sources, the changes aren't permanent (e.g., they only exist in the temporary DuckDB version of the data). If the page is reloaded or exited, they will lose any edits they've made.
Therefore, we want to warn users before they leave/reload. 

resolves #392 

## Changes
- Re-enables editing for non-FMS data sources (was hidden)
- Adds a before unload event for both web and desktop that pops up the browser's alert message.
   - Modern web browsers don't let us customize the alert message, so per UX/design discussion also added in an info message ONLY after the first time a user makes an edit to a non-FMS file (see screenshot) 
   - Desktop needs an additional event handler (per #514, Electron doesn't show alerts from these events to the user). This DOES allow us to customize the message

## Testing
Manually tested by making edits to uploaded datasets and then trying to reload and/or close the window

## Screenshots
Info message after initial edit (non-FMS source)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/daedfd03-75ac-49b6-ba0f-9398cccb6048" />

Chrome v121 reload/exit alert (not customizable)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cd8c94b2-ff09-437b-9b0b-77530b04dded" />

Firefox v139 reload/exit alert (not customizable)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/68447e0b-da82-42fd-8001-258738fa2625" />

Desktop reload/exit alert (customized message)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ba728bee-26e6-49eb-9183-b204e23b6dfc" />

