### PR TITLE
Bugfix/error on load datasource

### DIFF
--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -131,6 +131,8 @@ export default function FileList(props: FileListProps) {
 
     // Get a count of all files in the FileList, but don't wait on it
     React.useEffect(() => {
+        // Show loading state in UI instead of stale count (could be from unrelated query set)
+        setTotalCount(null);
         let cancel = false;
         fileSet
             .fetchTotalCount()

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -72,11 +72,16 @@
     justify-content: space-between;
 }
 
-.header > h4 {
+.header h4 {
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
     white-space: nowrap;
+    line-height: 1.5;
+}
+
+.header-collapsed > div {
+    width: calc(100% - 42px);
 }
 
 .loading-container {

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -127,7 +127,7 @@ export default function Query(props: QueryProps) {
                 }
                 onContextMenu={onContextMenu}
             >
-                <div className={styles.header}>
+                <div className={classNames(styles.header, styles.headerCollapsed)}>
                     <Tooltip content={props.query.name}>
                         <h4>{props.query.name}</h4>
                     </Tooltip>

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -78,12 +78,21 @@ const initializeApp = createLogic({
         // into the query to render (ex. when refreshing a page)
         if (isOnWeb && window.location.search) {
             try {
-                dispatch(
-                    selection.actions.addQuery({
-                        name: DEFAULT_QUERY_NAME,
-                        parts: SearchParams.decode(window.location.search),
-                    })
-                );
+                // If the query is already present, we shouldn't add it again, just refresh it
+                const equivalentExists = queries.some((query) => {
+                    return `?${SearchParams.encode(query?.parts)}` === window.location.search;
+                });
+                // Refresh existing query
+                if (queries.length && equivalentExists) {
+                    dispatch(refresh);
+                } else {
+                    dispatch(
+                        selection.actions.addQuery({
+                            name: DEFAULT_QUERY_NAME,
+                            parts: SearchParams.decode(window.location.search),
+                        })
+                    );
+                }
             } catch (err) {
                 // Parsing error from SearchParams.decode
                 dispatch(

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import DatasetTable from "./DatasetTable";
@@ -8,7 +8,7 @@ import PublicDataset from "../../entity/PublicDataset";
 import { metadata, selection } from "../../../../core/state";
 
 import styles from "./OpenSourceDatasets.module.css";
-import {
+import SearchParams, {
     SearchParamsComponents,
     getNameAndTypeFromSourceUrl,
     Source,
@@ -21,7 +21,6 @@ import {
 export default function OpenSourceDatasets() {
     const dispatch = useDispatch();
     const navigate = useNavigate();
-    const currentGlobalURL = useSelector(selection.selectors.getEncodedSearchParams);
 
     // Begin request action so dataset manifest is ready for table child component
     React.useEffect(() => {
@@ -39,9 +38,15 @@ export default function OpenSourceDatasets() {
                 parts: { ...url, sources: [source] },
             })
         );
+
+        // The initialization function automatically parses and adds queries from the
+        // url search params
         navigate({
             pathname: "/app",
-            search: `?${currentGlobalURL}`,
+            search: `?${SearchParams.encode({
+                ...url,
+                sources: [source],
+            })}`,
         });
     };
 


### PR DESCRIPTION
## Context
For our open-source datasets, the app sometimes flashes an error status before loading the dataset. Reproduce by going [here](https://bff.allencell.org/datasets) and loading a large dataset (e.g., "Structural organization and gene...").
This is because when we load a dataset, the app tries to add the query via dispatch ("Process A") and also by reading the query search params ("Process B"), which creates parallel processes that conflict with each other:
1. User selects a dataset to load
2. "Process A" starts loading the dataset, and creates a table in the database with the source name. Meanwhile, the page redirects to the app's current search params (usually empty). 
3. Process A updates the search params. The app registers that the params change, reads the query params, and starts also trying to load the dataset via "Process B"
5. Process B sees that the dataset is already present, has a little panic (`Table with name <name> already exists`), tries to clean itself up, and accidentally deletes the dataset loaded from Process A
6. Process A now can't find its data (because B deleted it), and has its own panic (`Table with name <name> does not exist`) --> this is the error the user sees briefly
7. This is somewhat of a guess since hard to track: The query args are still present in the url, so we try one more time to load the query, and this time it succeeds

These conflicting processes were also creating a secondary bug, where if you loaded a dataset, navigated backwards to the dataset page, and then added a new dataset, old queries would erroneously get added multiple times.

## Changes
When we initialize the app, instead of immediately adding a new query from the search params, first check if the query has already been added via redux. If it has, just reload the existing query instead of adding it again.

Semi-related changes: 
- When a new query was being loaded, the file count sometimes showed a stale count. Now it displays the loading state until a new count comes back
- Collapsed query titles were overflowing their bounds instead of using ellipses 
Before vs after:
<img width="200" height="214" alt="image" src="https://github.com/user-attachments/assets/c4373cdd-cfb8-48cb-9138-742dfa9743ed" />
<img width="200" height="232" alt="image" src="https://github.com/user-attachments/assets/59996ee0-489b-4f7a-b47f-718c929ce312" />



## Testing
<!-- Describe testing steps used to validate these changes, including automated and/or manual testing. -->

<!-- ## Screenshots (if relevant) -->
