### PR TITLE
Server error handling for data sources

### DIFF
--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { isEmpty } from "lodash";
 
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
@@ -138,8 +139,27 @@ export default abstract class DatabaseService {
                 await this.addRequiredColumns(dataSource.name);
             }
         } catch (err) {
+            let formattedError = (err as Error).message;
+            // DuckDB does not provide informative server errors, so
+            // send a separate check for what the error was
+            if (!(uri instanceof File)) {
+                await axios.get(uri).catch((error) => {
+                    // Error responses can be formatted differently
+                    // Get progressively less specific in where we look for the message
+                    if (error.response) {
+                        formattedError = `Request failed with status ${error.response.status}: ${
+                            error.response?.data?.error ||
+                            error.response?.data?.message ||
+                            error.response?.statusText ||
+                            error.response.data
+                        }`;
+                    } else {
+                        formattedError = error.message;
+                    }
+                });
+            }
             await this.deleteDataSource(name);
-            throw new DataSourcePreparationError((err as Error).message, name);
+            throw new DataSourcePreparationError(formattedError, name);
         }
     }
 


### PR DESCRIPTION
## Context
<!-- Describe the issues or requests addressed by this PR. Link to any relevant issues. -->
Addresses #563 . When DuckDB attempts to create a table from a data source, if it fails to read the source it does not provide informative errors. This means users can't see what went wrong (it just triggers the "No File Path" error).

## Changes
<!-- Describe the changes proposed in this PR. -->
Unfortunately there's not a way to make DuckDB more descriptive, so instead when the step to create a table fails, we can run our own axios check to retrieve error info.

## Testing
<!-- Describe testing steps used to validate these changes, including automated and/or manual testing. -->
Created a tiny fake server that sends back different error types for different endpoints. Tried to make sure the status info & message was retrieved for different error formats. 
Will add unit tests

<!-- ## Screenshots (if relevant) -->
