### PR TITLE
Admin/Upgrade node to v20

### DIFF
--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci
@@ -42,7 +42,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci
@@ -60,7 +60,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci
@@ -78,7 +78,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci
@@ -100,7 +100,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build Electron app
         uses: AllenCellSoftware/action-electron-builder@fms-file-explorer

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build/release Electron app
         uses: AllenCellSoftware/action-electron-builder@fms-file-explorer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build/release Electron app
         uses: AllenCellSoftware/action-electron-builder@fms-file-explorer

--- a/dev-docs/02-setup-and-workflow.md
+++ b/dev-docs/02-setup-and-workflow.md
@@ -12,7 +12,7 @@ To help with the management of three interconnected packages, this project makes
 
 
 ### System requirements
-1. NodeJS version 18.x (use `nvm` or similar)
+1. NodeJS version 20.x (use `nvm` or similar)
 2. NPM version 10.x
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "6.5.1",
+  "version": "8.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "6.5.1",
+      "version": "8.5.1",
       "license": "2-clause BSD license plus a third clause that prohibits redistribution and use for commercial purposes without further permission.",
       "workspaces": [
         "packages/desktop",
@@ -91,7 +91,7 @@
         "typescript": "4.9.x"
       },
       "engines": {
-        "node": "18.x",
+        "node": "20.x",
         "npm": "10.x"
       }
     },
@@ -21187,7 +21187,7 @@
     },
     "packages/desktop": {
       "name": "fms-file-explorer-desktop",
-      "version": "8.5.0",
+      "version": "8.5.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "root",
-  "version": "6.5.1",
+  "version": "8.5.1",
   "license": "2-clause BSD license plus a third clause that prohibits redistribution and use for commercial purposes without further permission.",
   "engines": {
-    "node": "18.x",
+    "node": "20.x",
     "npm": "10.x"
   },
   "workspaces": [


### PR DESCRIPTION
## Context
Would like to upgrade Node to [v20](https://nodejs.org/en/blog/release/v20.0.0/). It allows use of the native File class (previously unavailable for Node) which isn't a HUGE deal but does make unit tests easier -- we've had to work around this in the past (I can't find the issue to tag right now)

## Changes
Upgrades Node to 20.x in the package.json and in our workflows. None of our dependencies conflict with v20 so nothing else needed to be updated. 

## Testing
Local tests still pass, and web runs successfully. The `manual-build` workflow also passes, and the build works for Mac. The workflow succeeds for Windows, and I was able to open the version of BFF that it creates, but I'm not able to test it more thoroughly.
