### PR TITLE
Feature/Handle server errors when loading data sources

### DIFF
--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -140,8 +140,8 @@ export default abstract class DatabaseService {
             }
         } catch (err) {
             let formattedError = (err as Error).message;
-            // DuckDB does not provide informative server errors, so
-            // send a separate check for what the error was
+            // DuckDB does not provide informative server errors, so send a
+            // separate 'get' call to retrieve error messages for URL data sources
             if (!(uri instanceof File)) {
                 await axios.get(uri).catch((error) => {
                     // Error responses can be formatted differently

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -146,16 +146,16 @@ export default abstract class DatabaseService {
                 await axios.get(uri).catch((error) => {
                     // Error responses can be formatted differently
                     // Get progressively less specific in where we look for the message
-                    if (error.response) {
+                    if (error?.response) {
                         formattedError = `Request failed with status ${error.response.status}: ${
                             error.response?.data?.error ||
                             error.response?.data?.message ||
                             error.response?.statusText ||
                             error.response.data
                         }`;
-                    } else {
+                    } else if (error?.message) {
                         formattedError = error.message;
-                    }
+                    } // else use default error message
                 });
             }
             await this.deleteDataSource(name);

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { isEmpty } from "lodash";
 
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
@@ -138,8 +139,27 @@ export default abstract class DatabaseService {
                 await this.addRequiredColumns(dataSource.name);
             }
         } catch (err) {
+            let formattedError = (err as Error).message;
+            // DuckDB does not provide informative server errors, so
+            // send a separate check for what the error was
+            if (!(uri instanceof File)) {
+                await axios.get(uri).catch((error) => {
+                    // Error responses can be formatted differently
+                    // Get progressively less specific in where we look for the message
+                    if (error.response) {
+                        formattedError = `Request failed with status ${error.response.status}: ${
+                            error.response?.data?.error ||
+                            error.response?.data?.message ||
+                            error.response?.statusText ||
+                            error.response.data
+                        }`;
+                    } else {
+                        formattedError = error.message;
+                    }
+                });
+            }
             await this.deleteDataSource(name);
-            throw new DataSourcePreparationError((err as Error).message, name);
+            throw new DataSourcePreparationError(formattedError, name);
         }
     }
 

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -804,12 +804,14 @@ const setDataSourceReloadErrorLogic = createLogic({
             const {
                 payload: { dataSourceName, error },
             } = deps.action as AddDataSourceReloadError;
+            // Trim error message to only the first few lines
+            const truncatedError = error.length > 200 ? error.substring(0, 200) + "..." : error;
             const datasourceErrorDefaultMessage = `
                 The following error occurred while loading the data source
                 &quot;${dataSourceName}&quot;:
                 </br>
                 </br>
-                ${error}
+                ${truncatedError}
                 </br>
                 </br>
                 Please re-select the data source or a replacement.

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -1,4 +1,4 @@
-import { castArray, find, sortBy, uniqWith } from "lodash";
+import { castArray, find, sortBy, truncate, uniqWith } from "lodash";
 import { AnyAction } from "redux";
 import { createLogic } from "redux-logic";
 import { batch } from "react-redux";
@@ -805,7 +805,7 @@ const setDataSourceReloadErrorLogic = createLogic({
                 payload: { dataSourceName, error },
             } = deps.action as AddDataSourceReloadError;
             // Trim error message to only the first few lines
-            const truncatedError = error.length > 200 ? error.substring(0, 200) + "..." : error;
+            const truncatedError = truncate(error, { length: 200 });
             const datasourceErrorDefaultMessage = `
                 The following error occurred while loading the data source
                 &quot;${dataSourceName}&quot;:

--- a/packages/core/state/selection/test/logics.test.ts
+++ b/packages/core/state/selection/test/logics.test.ts
@@ -4,28 +4,32 @@ import {
     mergeState,
     ResponseStub,
 } from "@aics/redux-utils";
+import axios from "axios";
 import { expect } from "chai";
 import { get as _get, shuffle } from "lodash";
 import sinon from "sinon";
 
 import {
     addFileFilter,
-    selectFile,
+    addQuery,
+    changeDataSources,
+    changeSourceMetadata,
+    decodeSearchParams,
+    expandAllFileFolders,
     reorderAnnotationHierarchy,
     removeFileFilter,
     removeFromAnnotationHierarchy,
+    setAnnotationHierarchy,
+    selectFile,
+    selectNearbyFile,
+    ADD_DATASOURCE_RELOAD_ERROR,
     SET_ANNOTATION_HIERARCHY,
     SET_AVAILABLE_ANNOTATIONS,
     SET_FILE_FILTERS,
     SET_FILE_SELECTION,
     SET_OPEN_FILE_FOLDERS,
-    decodeSearchParams,
-    setAnnotationHierarchy,
-    selectNearbyFile,
     SET_SORT_COLUMN,
-    changeDataSources,
-    changeSourceMetadata,
-    expandAllFileFolders,
+    Query,
 } from "../actions";
 import { initialState, interaction } from "../../";
 import { FESBaseUrl } from "../../../constants";
@@ -40,7 +44,7 @@ import FileFolder from "../../../entity/FileFolder";
 import FileSet from "../../../entity/FileSet";
 import FileSelection from "../../../entity/FileSelection";
 import FileSort, { SortOrder } from "../../../entity/FileSort";
-import { DatasetService } from "../../../services";
+import { DatabaseService, DatasetService } from "../../../services";
 import HttpAnnotationService from "../../../services/AnnotationService/HttpAnnotationService";
 import { DataSource } from "../../../services/DataSourceService";
 import HttpFileService from "../../../services/FileService/HttpFileService";
@@ -675,6 +679,180 @@ describe("Selection logics", () => {
             expect(
                 actions.includesMatch({
                     type: interaction.actions.REFRESH,
+                })
+            ).to.be.true;
+        });
+    });
+
+    describe("addQueryLogic", () => {
+        // Custom mock to stub `addDataSource` and keep `prepareDataSources`
+        class MockDatabaseService extends DatabaseService {
+            protected addDataSource(): Promise<void> {
+                return Promise.reject("MockDatabaseService:addDataSource");
+            }
+
+            public execute(): Promise<void> {
+                return Promise.resolve();
+            }
+
+            public saveQuery(): Promise<Uint8Array> {
+                return Promise.reject("MockDatabaseService:saveQuery");
+            }
+
+            public query(): Promise<{ [key: string]: string }[]> {
+                return Promise.reject("MockDatabaseService:query");
+            }
+        }
+        const state = mergeState(initialState, {
+            interaction: {
+                platformDependentServices: {
+                    databaseService: new MockDatabaseService(),
+                },
+            },
+        });
+        const mockQuery = (dataSourceName: string, uri: string | File): Query => {
+            return {
+                name: dataSourceName,
+                parts: {
+                    hierarchy: [],
+                    filters: [],
+                    openFolders: [],
+                    sources: [{ name: dataSourceName, type: "csv", uri }],
+                },
+            };
+        };
+
+        afterEach(() => {
+            sinon.resetHistory();
+            sinon.restore();
+        });
+
+        it("dispatches data source error for 404 status response", async () => {
+            // Arrange
+            const dataSourceName = "Mock Dataset 404";
+            const response = { status: 404, data: "Not Found" };
+            sinon.stub(axios, "get").returns(Promise.reject({ response }));
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: selectionLogics,
+            });
+
+            // Act
+            store.dispatch(addQuery(mockQuery(dataSourceName, "http://fake-uri.test/404")));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: ADD_DATASOURCE_RELOAD_ERROR,
+                    payload: {
+                        dataSourceName,
+                        error: "Request failed with status 404: Not Found",
+                    },
+                })
+            ).to.be.true;
+        });
+
+        it("dispatches data source error for 500 status response object", async () => {
+            // Arrange
+            const dataSourceName = "Mock Dataset 500";
+            const errorMessage = "A differently formatted error message";
+            // Intentionally using a different error message format for testing
+            const response = { status: 500, data: { message: errorMessage } };
+            sinon.stub(axios, "get").returns(Promise.reject({ response }));
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: selectionLogics,
+            });
+
+            // Act
+            store.dispatch(addQuery(mockQuery(dataSourceName, "http://fake-uri.test/500")));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: ADD_DATASOURCE_RELOAD_ERROR,
+                    payload: {
+                        dataSourceName,
+                        error: `Request failed with status 500: ${errorMessage}`,
+                    },
+                })
+            ).to.be.true;
+        });
+
+        it("dispatches data source error when no response object is provided", async () => {
+            // Arrange
+            const dataSourceName = "Mock Dataset with error";
+            const errorMessage = "Something went wrong";
+            sinon.stub(axios, "get").returns(Promise.reject({ message: errorMessage }));
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: selectionLogics,
+            });
+
+            // Act
+            store.dispatch(addQuery(mockQuery(dataSourceName, "http://fake-uri.test/some/error")));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: ADD_DATASOURCE_RELOAD_ERROR,
+                    payload: {
+                        dataSourceName,
+                        error: `${errorMessage}`,
+                    },
+                })
+            ).to.be.true;
+        });
+
+        it("dispatches the default data source error message if axios does not return info", async () => {
+            // Arrange
+            const dataSourceName = "Mock Dataset";
+            sinon.stub(axios, "get").returns(Promise.reject());
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: selectionLogics,
+            });
+
+            // Act
+            // addQuery will fail since addDataSource is set to reject in MockDatabaseService
+            store.dispatch(addQuery(mockQuery(dataSourceName, "http://fake-uri.test/error")));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: ADD_DATASOURCE_RELOAD_ERROR,
+                    payload: {
+                        dataSourceName,
+                        error: "Unknown error while adding query",
+                    },
+                })
+            ).to.be.true;
+        });
+
+        it("dispatches the default data source error message for File type sources", async () => {
+            const dataSourceName = "Mock Data Source";
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: selectionLogics,
+            });
+
+            // Act
+            // addQuery will fail since addDataSource is set to reject in MockDatabaseService
+            store.dispatch(addQuery(mockQuery(dataSourceName, new File([], "Mock Data Source"))));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: ADD_DATASOURCE_RELOAD_ERROR,
+                    payload: {
+                        dataSourceName,
+                        error: "Unknown error while adding query",
+                    },
                 })
             ).to.be.true;
         });


### PR DESCRIPTION
@will-moore 
## Context
<!-- Describe the issues or requests addressed by this PR. Link to any relevant issues. -->
Resolves #563 . When DuckDB attempts to create a table from a data source, if the server fails to return data, DuckDB does not pass along the error status or provide informative messages. This means users can't see what went wrong -- it just triggers the "Missing File Path column" error.

## Changes
<!-- Describe the changes proposed in this PR. -->
Unfortunately, there's not a clear way to make DuckDB more descriptive. Instead, when the step to create a table fails, if the source is a url (i.e., not a `File` object), we can run our own `axios` check to retrieve error info from the server directly.

For this PR I'm just clipping the error message to a maximum of 200 characters (approx. 3 lines), but we may consider making the message expandable or allowing users to open the message in a separate dialog/tab
<img width="746" height="229" alt="image" src="https://github.com/user-attachments/assets/d6720fdb-60bc-42cc-bd6d-3f03cb6aada7" />

## Testing
<!-- Describe testing steps used to validate these changes, including automated and/or manual testing. -->
Added unit tests to make sure errors are dispatched for different stubbed error responses. 

Also manually tested by using a tiny fake server that sends different error formats for different endpoints.


<!-- ## Screenshots (if relevant) -->
