### PR TITLE
Feature/Download zarr from virtualized S3 urls

### DIFF
--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -146,7 +146,7 @@ export default function FileDetails(props: Props) {
         if (!isDownloadDisabled) return;
         if (isZarr && isOnWeb) {
             if (calculatedSize === null) {
-                return "Unable to determine zarr size";
+                return "Unable to determine size of .zarr file. Upload files to an AWS S3 bucket to enable .zarr downloads.";
             } else if (calculatedSize > MAX_DOWNLOAD_SIZE_WEB) {
                 const downloadSizeString = annotationFormatterFactory(
                     AnnotationType.NUMBER

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -141,20 +141,23 @@ export default function FileDetails(props: Props) {
               // meaning that if the size cannot be determined, the download is also not possible.
               (calculatedSize === null || calculatedSize > MAX_DOWNLOAD_SIZE_WEB))
         : true;
-
+    // Display a tooltip if download is disabled
     const downloadDisabledMessage = React.useMemo(() => {
         if (!isDownloadDisabled) return;
+        if (!fileDetails) return "File details not available";
         if (isZarr && isOnWeb) {
             if (calculatedSize === null) {
-                return "Unable to determine size of .zarr file. Upload files to an AWS S3 bucket to enable .zarr downloads.";
+                return "Unable to determine size of .zarr file";
             } else if (calculatedSize > MAX_DOWNLOAD_SIZE_WEB) {
                 const downloadSizeString = annotationFormatterFactory(
                     AnnotationType.NUMBER
                 ).displayValue(MAX_DOWNLOAD_SIZE_WEB, "bytes");
                 return "File exceeds maximum download size of " + downloadSizeString;
             }
+            return "Unable to download file. Upload files to an AWS S3 bucket to enable .zarr downloads";
         }
-        return "Unable to download file";
+        // Otherwise, fileId is in processStatuses and details are visible to user there
+        return "Download disabled";
     }, [isDownloadDisabled, isZarr, isOnWeb, calculatedSize]);
 
     // Prevent triggering multiple downloads accidentally -- throttle with a 1s wait

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -115,11 +115,8 @@ export default function FileDetails(props: Props) {
                         .canUseDirectoryArguments(fileDetails.path)
                         .then((canUse) => {
                             if (!canUse) return;
-                            const {
-                                hostname,
-                                bucket,
-                                key,
-                            } = fileDownloadService.parseVirtualizedUrl(fileDetails.path);
+                            const { hostname, bucket, key } =
+                                fileDownloadService.parseVirtualizedUrl(fileDetails.path);
                             fileDownloadService
                                 .calculateS3DirectorySize(hostname, key, bucket)
                                 .then(setCalculatedSize);
@@ -158,7 +155,7 @@ export default function FileDetails(props: Props) {
         }
         // Otherwise, fileId is in processStatuses and details are visible to user there
         return "Download disabled";
-    }, [isDownloadDisabled, isZarr, isOnWeb, calculatedSize]);
+    }, [calculatedSize, fileDetails, isDownloadDisabled, isZarr, isOnWeb]);
 
     // Prevent triggering multiple downloads accidentally -- throttle with a 1s wait
     const onDownload = React.useMemo(() => {

--- a/packages/core/components/FileDetails/test/FileDetails.test.tsx
+++ b/packages/core/components/FileDetails/test/FileDetails.test.tsx
@@ -1,0 +1,127 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+import { createSandbox } from "sinon";
+
+import * as useFileDetails from "../useFileDetails";
+import { Environment } from "../../../constants";
+import FileDetail from "../../../entity/FileDetail";
+import { MAX_DOWNLOAD_SIZE_WEB } from "../../../services/FileDownloadService";
+import { initialState } from "../../../state";
+
+import FileDetails from "..";
+describe("<FileDetails />", () => {
+    const sandbox = createSandbox();
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it("should disable downloads on web when file size exceeds max", async () => {
+        // Arrange
+        const { store, logicMiddleware } = configureMockStore({
+            state: mergeState(initialState, {
+                interaction: {
+                    isOnWeb: true,
+                },
+            }),
+        });
+        const fileDetails = new FileDetail(
+            {
+                file_path: "path/to/testFile.zarr",
+                file_id: "abc123",
+                file_name: "testFile.zarr",
+                file_size: MAX_DOWNLOAD_SIZE_WEB + 1,
+                uploaded: "01/01/01",
+                annotations: [],
+            },
+            Environment.TEST
+        );
+        sandbox.stub(useFileDetails, "default").returns([fileDetails, false]);
+
+        // Act
+        const { getByText, findByText, queryByText } = render(
+            <Provider store={store}>
+                <FileDetails />
+            </Provider>
+        );
+
+        await logicMiddleware.whenComplete();
+
+        // Assert
+        const tooltip = await findByText(/File exceeds maximum download size/);
+        expect(tooltip).to.exist;
+        expect(getByText(/DOWNLOAD/).closest("button")?.disabled).to.be.true;
+        expect(queryByText(/Download file to local system/)).to.not.exist;
+    });
+
+    it("should allow zarr downloads when file size is less than max", async () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: mergeState(initialState, {
+                interaction: {
+                    isOnWeb: true,
+                },
+            }),
+        });
+
+        const fileDetails = new FileDetail(
+            {
+                file_path: "path/to/testFile.zarr",
+                file_id: "abc123",
+                file_name: "testFile.zarr",
+                file_size: MAX_DOWNLOAD_SIZE_WEB / 2,
+                uploaded: "01/01/01",
+                annotations: [],
+            },
+            Environment.TEST
+        );
+        sandbox.stub(useFileDetails, "default").returns([fileDetails, false]);
+        // Act
+        const { findByText, getByText, queryByText } = render(
+            <Provider store={store}>
+                <FileDetails />
+            </Provider>
+        );
+        // Assert
+        const tooltip = await findByText(/Download file to local system/);
+        expect(tooltip).to.exist;
+        expect(getByText(/DOWNLOAD/).closest("button")?.disabled).to.be.false;
+        expect(queryByText(/File exceeds maximum download size/)).to.not.exist;
+    });
+
+    it("should allow downloads on desktop regardless of file size", () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: mergeState(initialState, {
+                interaction: {
+                    isOnWeb: false,
+                },
+            }),
+        });
+        const fileDetails = new FileDetail(
+            {
+                file_path: "path/to/testFile.zarr",
+                file_id: "abc123",
+                file_name: "testFile.zarr",
+                file_size: MAX_DOWNLOAD_SIZE_WEB + 1,
+                uploaded: "01/01/01",
+                annotations: [],
+            },
+            Environment.TEST
+        );
+        sandbox.stub(useFileDetails, "default").returns([fileDetails, false]);
+        // Act
+        const { getByText, queryByText } = render(
+            <Provider store={store}>
+                <FileDetails />
+            </Provider>
+        );
+        // Assert
+        expect(getByText(/DOWNLOAD/).closest("button")?.disabled).to.be.false;
+        expect(queryByText(/File exceeds maximum download size/)).to.not.exist;
+        expect(getByText(/Download file to local system/)).to.exist;
+    });
+});

--- a/packages/core/services/FileDownloadService/test/FileDownloadService.test.ts
+++ b/packages/core/services/FileDownloadService/test/FileDownloadService.test.ts
@@ -63,4 +63,16 @@ describe("FileDownloadService", () => {
             });
         });
     });
+
+    describe("parseVirtualizedUrl", () => {
+        const fileDownloadService = new FileDownloadServiceNoop();
+        it("parses url correctly", () => {
+            const { hostname, key, bucket } = fileDownloadService.parseVirtualizedUrl(
+                "https://example.com/directory-name/path/to/file.zarr"
+            );
+            expect(hostname).to.equal("example.com");
+            expect(key).to.equal("directory-name/path/to/file.zarr");
+            expect(bucket).to.equal("");
+        });
+    });
 });

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -261,10 +261,10 @@ const downloadFilesLogic = createLogic({
                 if (file.path.endsWith(".zarr")) {
                     if (!isStandardS3Url) {
                         // Only check for virtualized URLs if not already an S3 URL
-                        const isVirtualized = await fileDownloadService.canUseDirectoryArguments(
+                        const canUseDirectoryArgs = await fileDownloadService.canUseDirectoryArguments(
                             file.path
                         );
-                        if (!isVirtualized) return; // Can't calculate size
+                        if (!canUseDirectoryArgs) return; // Can't calculate size
                     }
                     const parsingFunc = isStandardS3Url
                         ? fileDownloadService.parseS3Url


### PR DESCRIPTION
## Context
Resolves #558.
The drug perturbation dataset is virtualized using CloudFront, so we were unable to identify the file urls as S3 & therefore had their downloads disabled. The infrastructure team also recently [updated CloudFront settings](https://github.com/AllenCellSoftware/InfraEngRequests/issues/436) for that bucket to allow us to pass query arguments through to S3

## Changes
- Adds a method to check whether we can use `list-type` query arguments on the file path url, which was the main reason we've previously restricted zarr downloads to be S3 only. 
- Adds a tooltip when the Download button is disabled so users will have a better idea of why they can't click it

## Testing
Manually tested on the [Drug Perturbation dataset ](https://staging.bff.allencell.org/app?c=File+Name%3A0.25%2CTreatment+Group%3A0.25%2CGene%3A0.25%2CCell+Line%3A0.25&group=Structure&group=Drug+Label&group=Drug+Concentration&group=Timepoint&openFolder=%5B%22Microtubules%22%5D&openFolder=%5B%22Microtubules%22%2C%22Paclitaxel%22%5D&openFolder=%5B%22Microtubules%22%2C%22Paclitaxel%22%2C%225%22%5D&openFolder=%5B%22Microtubules%22%2C%22Paclitaxel%22%2C%225%22%2C%222%22%5D&source=%7B%22name%22%3A%22Drug%2BPerturbation%2BDataset.csv+%289%2F11%2F2025+2%3A10%3A06+PM%29%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22https%3A%2F%2Fbiofile-finder-datasets.s3.us-west-2.amazonaws.com%2FDrug%2BPerturbation%2BDataset.csv%22%7D&sort=%7B%22annotationName%22%3A%22File+Name%22%2C%22order%22%3A%22DESC%22%7D) (changes are currently deployed to staging).
- Made sure download is still disabled if we can't use the directory query arguments, and that error messages are still correctly thrown

Added a couple unit tests to make sure downloads are enabled/disabled for the major cases
