### PR TITLE
Bugfix/Error selecting query before DuckDB table has loaded

### DIFF
--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -59,6 +59,7 @@ export default function DataSourcePrompt(props: Props) {
                 selection.actions.addQuery({
                     name: `New ${dataSource.name} Query`,
                     parts: { sources: [dataSource], sourceMetadata: metadataSource },
+                    loading: true,
                 })
             );
         }

--- a/packages/core/components/DirectoryTree/RootLoadingIndicator.tsx
+++ b/packages/core/components/DirectoryTree/RootLoadingIndicator.tsx
@@ -10,7 +10,10 @@ interface LoadingIndicatorProps {
 
 export default function RootLoadingIndicator({ visible }: LoadingIndicatorProps) {
     return (
-        <div className={classNames(styles.loadingIndicator, { [styles.hidden]: !visible })}>
+        <div
+            className={classNames(styles.loadingIndicator, { [styles.hidden]: !visible })}
+            data-testid={"root-loading-indicator"}
+        >
             <ProgressIndicator
                 className={styles.indeterminateProgressBar}
                 progressHidden={!visible}

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -41,8 +41,8 @@ export default function DirectoryTree(props: FileListProps) {
     const globalFilters = useSelector(selection.selectors.getFileFilters);
     const sortColumn = useSelector(selection.selectors.getSortColumn);
     const visibleModal = useSelector(interaction.selectors.getVisibleModal);
-    // If user is loading a new query, show root loading state in file list
-    // since it may take some time for the view to update with new query results
+    // If user is loading a new data source, show root loading state in file list
+    // since it may take time for the view to update with new query results
     const isLoadingNewQuery = useSelector(selection.selectors.getLoadingNewQuery);
     const fileSet = React.useMemo(() => {
         return new FileSet({

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -41,6 +41,9 @@ export default function DirectoryTree(props: FileListProps) {
     const globalFilters = useSelector(selection.selectors.getFileFilters);
     const sortColumn = useSelector(selection.selectors.getSortColumn);
     const visibleModal = useSelector(interaction.selectors.getVisibleModal);
+    // If user is loading a new query, show root loading state in file list
+    // since it may take some time for the view to update with new query results
+    const isLoadingNewQuery = useSelector(selection.selectors.getLoadingNewQuery);
     const fileSet = React.useMemo(() => {
         return new FileSet({
             fileService: fileService,
@@ -77,7 +80,7 @@ export default function DirectoryTree(props: FileListProps) {
 
     return (
         <div className={classNames(props.className, styles.container)}>
-            <RootLoadingIndicator visible={isLoading} />
+            <RootLoadingIndicator visible={isLoading || isLoadingNewQuery} />
             <div className={styles.verticalGradient} />
             <ul
                 className={styles.scrollContainer}

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -490,4 +490,34 @@ describe("<DirectoryTree />", () => {
         header = await findByTestId(directoryTreeNodes[0], "treeitemheader"); // refresh node
         expect(header.classList.contains(styles.focused)).to.be.true;
     });
+
+    it("displays root loading indicator when new query is in loading state", async () => {
+        // Arrange
+        const state = mergeState(initialState, {
+            selection: {
+                queries: [
+                    {
+                        name: "Test Query",
+                        parts: {
+                            hierarchy: [],
+                            filters: [],
+                            sources: [],
+                            openFolders: [],
+                        },
+                        loading: true,
+                    },
+                ],
+            },
+        });
+        const { store } = configureMockStore({ state });
+
+        const { getByTestId } = render(
+            <Provider store={store}>
+                <DirectoryTree />
+            </Provider>
+        );
+
+        // Assert
+        expect(getByTestId("root-loading-indicator")).to.exist;
+    });
 });

--- a/packages/core/components/Icons/LoadingIcon.module.css
+++ b/packages/core/components/Icons/LoadingIcon.module.css
@@ -3,5 +3,5 @@
 }
 
 .invert-color > div {
-    border-color: var(--secondary-text-color) var(--secondary-background-color) var(--secondary-background-color);
+    border-color: var(--secondary-text-color) var(--secondary-text-color) var(--secondary-background-color);
 }

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -50,7 +50,7 @@
     width: calc(100% - 5px);
 }
 
-.container:hover:not(.selected) {
+.container:hover:not(.selected):not(.disabled) {
     background-color: var(--highlight-background-color);
     color: var(--highlight-text-color);
     cursor: pointer;
@@ -61,7 +61,7 @@
     background: none;
 }
 
-.container:hover:not(.selected) .divider {
+.container:hover:not(.selected):not(.disabled) .divider {
     background: var(--highlight-text-color);
 }
 

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -80,6 +80,10 @@
     line-height: 1.5;
 }
 
+.header h4 i {
+    font-weight: 400;
+}
+
 .header-collapsed > div {
     width: calc(100% - 42px);
 }
@@ -87,9 +91,9 @@
 .loading-container {
     align-items: center;
     display: flex;
-    justify-content: center;
-    height: 250px;
+    justify-content: flex-start;
     width: 100%;
+    padding: 4px 0 6px;
 }
 
 .title-container {

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -44,13 +44,9 @@ export default function Query(props: QueryProps) {
 
     const [isExpanded, setIsExpanded] = React.useState(false);
     React.useEffect(() => {
-        setIsExpanded(props.isSelected);
-    }, [props.isSelected]);
-
-    // Collapse open queries while a new query is actively loading
-    React.useEffect(() => {
-        if (isLoadingNewQuery) setIsExpanded(false);
-    }, [isLoadingNewQuery]);
+        if (isLoadingNewQuery && isExpanded) setIsExpanded(false);
+        else setIsExpanded(props.isSelected);
+    }, [props.isSelected, isLoadingNewQuery]);
 
     const queryComponents = React.useMemo(
         () =>

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -46,7 +46,7 @@ export default function Query(props: QueryProps) {
     React.useEffect(() => {
         if (isLoadingNewQuery && isExpanded) setIsExpanded(false);
         else setIsExpanded(props.isSelected);
-    }, [props.isSelected, isLoadingNewQuery]);
+    }, [isExpanded, isLoadingNewQuery, props.isSelected]);
 
     const queryComponents = React.useMemo(
         () =>

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -119,7 +119,7 @@ export default function Query(props: QueryProps) {
 
     if (isLoading) {
         return (
-            <div className={styles.container}>
+            <div className={classNames(styles.container, styles.disabled)}>
                 <div className={classNames(styles.header, styles.headerCollapsed)}>
                     <Tooltip content="Uploading file and creating table...">
                         <h4>

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -40,11 +40,17 @@ export default function Query(props: QueryProps) {
         (shouldHaveDataSource && !hasDataSource && !hasReloadError) ||
         props.query.name === AICS_FMS_DATA_SOURCE_NAME ||
         props?.loading;
+    const isLoadingNewQuery = useSelector(selection.selectors.getLoadingNewQuery);
 
     const [isExpanded, setIsExpanded] = React.useState(false);
     React.useEffect(() => {
         setIsExpanded(props.isSelected);
     }, [props.isSelected]);
+
+    // Collapse open queries while a new query is actively loading
+    React.useEffect(() => {
+        if (isLoadingNewQuery) setIsExpanded(false);
+    }, [isLoadingNewQuery]);
 
     const queryComponents = React.useMemo(
         () =>

--- a/packages/core/components/QuerySidebar/index.tsx
+++ b/packages/core/components/QuerySidebar/index.tsx
@@ -137,6 +137,7 @@ export default function QuerySidebar(props: QuerySidebarProps) {
                             key={query.name}
                             isSelected={query.name === selectedQuery || queries.length === 1}
                             query={query}
+                            loading={query?.loading}
                         />
                     ))
                 ) : (

--- a/packages/core/components/QuerySidebar/test/Query.test.tsx
+++ b/packages/core/components/QuerySidebar/test/Query.test.tsx
@@ -48,6 +48,36 @@ describe("<Query />", () => {
         expect(() => getByTestId("expand-button")).to.throw();
     });
 
+    it("renders spinner and loading header when new query is in loading state", () => {
+        // Arrange
+        const { store } = configureMockStore({
+            state: initialState,
+        });
+
+        // Act
+        const { getByTestId, getByText } = render(
+            <Provider store={store}>
+                <Query
+                    isSelected
+                    query={{
+                        name: "Test Data Source",
+                        parts: {
+                            filters: [],
+                            hierarchy: [],
+                            sources: [],
+                            openFolders: [],
+                        },
+                        loading: true,
+                    }}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(getByText(/Building new query/)).to.exist;
+        expect(getByTestId("query-spinner")).to.exist;
+    });
+
     it("renders spinner when loading an FMS source", () => {
         // Arrange
         const { store } = configureMockStore({

--- a/packages/core/components/QuerySidebar/test/Query.test.tsx
+++ b/packages/core/components/QuerySidebar/test/Query.test.tsx
@@ -67,8 +67,8 @@ describe("<Query />", () => {
                             sources: [],
                             openFolders: [],
                         },
-                        loading: true,
                     }}
+                    loading={true}
                 />
             </Provider>
         );

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -283,11 +283,13 @@ export const ADD_QUERY = makeConstant(STATE_BRANCH_NAME, "add-query");
 export interface Query {
     name: string;
     parts: SearchParamsComponents;
+    loading?: boolean;
 }
 
 interface PartialQuery {
     name: string;
     parts: Partial<SearchParamsComponents>;
+    loading?: boolean;
 }
 
 export interface AddQuery {

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -681,10 +681,13 @@ const addQueryLogic = createLogic({
         const { payload: newQuery } = deps.action as AddQuery;
         // Map the query names to their occurrences so that queries with the same name
         // have their occurences appended to their name to make them unique
-        const queryNameToOccurrence = queries.reduce((acc, query) => {
-            const nameWithoutOccurence = query.name.replace(/ \(\d+\)$/, "");
-            return { ...acc, [nameWithoutOccurence]: (acc[nameWithoutOccurence] || 0) + 1 };
-        }, {} as Record<string, number>);
+        const queryNameToOccurrence = queries.reduce(
+            (acc, query) => {
+                const nameWithoutOccurence = query.name.replace(/ \(\d+\)$/, "");
+                return { ...acc, [nameWithoutOccurence]: (acc[nameWithoutOccurence] || 0) + 1 };
+            },
+            {} as Record<string, number>
+        );
 
         const newQueryName = newQuery.name.replace(/ \(\d+\)$/, "");
         next({
@@ -715,6 +718,7 @@ const changeQueryLogic = createLogic({
                 query.name === deps.ctx.previouslySelectedQueryName
                     ? currentQueryParts
                     : query.parts,
+            loading: false,
         }));
 
         if (newlySelectedQuery) {

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -115,6 +115,10 @@ export const getEncodedSearchParams = createSelector([getCurrentQueryParts], (qu
     SearchParams.encode(queryParts)
 );
 
+export const getLoadingNewQuery = createSelector([getQueries], (queries): boolean =>
+    queries.some((q) => q.loading)
+);
+
 export const getPythonConversion = createSelector(
     [
         getPlatformDependentServices,


### PR DESCRIPTION
## Context
Closes #571. Replaces #579. When users add large data source files that take a long time to load, if they try to click on the newly created query before DuckDB has finished making a new table for that data source, an error temporarily appears because the database doesn't recognize the table yet.

## Changes
Per UX recommendation, adds a loading state to the query component that prevents user interactions with that query just while DuckDB creates the table. Then we allow user interactions and display the usual loading UI in the file list while the query retrieves results from that table.

The linter also made unrelated changes to the files I edited.

## Testing
Manually tested 
- loading large/slow data sources
- loading small/fast data sources

Also added a couple basic unit tests for the loading state

## Screen recording 
Before: With bug where error appears on user interaction

[before-video](https://github.com/user-attachments/assets/ac263e3a-4947-47a3-acad-33bc07cb4876)

After: Query has loading styling that prevents interaction until table is created, and file list also enters loading state while new query is loading (my computer is extra slow today so the clip is much longer than it should be)

[after-video](https://github.com/user-attachments/assets/fa95c794-b970-43f7-a73d-7dbe0e903854)

