### PR TITLE
Remove expanded dependency

### DIFF
--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -44,9 +44,9 @@ export default function Query(props: QueryProps) {
 
     const [isExpanded, setIsExpanded] = React.useState(false);
     React.useEffect(() => {
-        if (isLoadingNewQuery && isExpanded) setIsExpanded(false);
+        if (isLoadingNewQuery) setIsExpanded(false);
         else setIsExpanded(props.isSelected);
-    }, [isExpanded, isLoadingNewQuery, props.isSelected]);
+    }, [isLoadingNewQuery, props.isSelected]);
 
     const queryComponents = React.useMemo(
         () =>
@@ -58,28 +58,25 @@ export default function Query(props: QueryProps) {
 
     const condensedFilterString = React.useMemo(() => {
         return Object.entries(
-            queryComponents.filters.reduce(
-                (accum, filter) => {
-                    let value = "";
-                    switch (filter.type) {
-                        case FilterType.ANY:
-                            value = "any value";
-                            break;
-                        case FilterType.EXCLUDE:
-                            value = "no value";
-                            break;
-                        default:
-                            value = ((Number(accum[filter.name]) || 0) + 1).toString();
-                    }
-                    // Special case for ranges since we don't know the exact count
-                    if (filter.value.toString().match(/^RANGE\((.*)\)$/)) value = "range";
-                    return {
-                        ...accum,
-                        [filter.name]: value,
-                    };
-                },
-                {} as { [index: string]: string }
-            )
+            queryComponents.filters.reduce((accum, filter) => {
+                let value = "";
+                switch (filter.type) {
+                    case FilterType.ANY:
+                        value = "any value";
+                        break;
+                    case FilterType.EXCLUDE:
+                        value = "no value";
+                        break;
+                    default:
+                        value = ((Number(accum[filter.name]) || 0) + 1).toString();
+                }
+                // Special case for ranges since we don't know the exact count
+                if (filter.value.toString().match(/^RANGE\((.*)\)$/)) value = "range";
+                return {
+                    ...accum,
+                    [filter.name]: value,
+                };
+            }, {} as { [index: string]: string })
         )
             .map(([name, value]) => {
                 if (value === "") return name;


### PR DESCRIPTION
## Context
Patch for #589. The last commit I added to that PR was to add `isExpanded` as a dependency to a `useEffect`. I did not catch that this actually causes a weird re-render loop where old queries flicker open and closed when a new one is added.
Can reproduce by going to [staging](https://staging.bff.allencell.org/app?c=file_name%3A0.4%2CKind%3A0.2%2CType%3A0.25%2Cfile_size%3A0.15&filter=%7B%22name%22%3A%22uploaded%22%2C%22value%22%3A%22RANGE%282024-09-19T07%3A00%3A00.000Z%2C2025-09-20T06%3A59%3A59.310Z%29%22%2C%22type%22%3A%22default%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D), adding one data source, and then loading a new one after that.

## Changes
Removes the condition from the `if` statement that I added in the previous PR (it wasn't doing anything beneficial) so that the dependency can also be removed

It also looks like the linter re-re-formatted an unrelated method

## Testing
Verified that the query flickering loop no longer occurs, and that the desired behavior from #589 still works
