### PR TITLE
Add Vol-E as .tiff viewer by default

### DIFF
--- a/packages/core/services/FileDownloadService/index.ts
+++ b/packages/core/services/FileDownloadService/index.ts
@@ -182,15 +182,16 @@ export default abstract class FileDownloadService extends HttpServiceBase {
     }
 
     /**
-     * Retrieve file metadata (specifically, file size) from an S3 object using a HEAD request.
+     * Attempt to retrieve file size from an http object using a HEAD request.
+     *
+     * Returns bytes (octet)
      */
-    public async headS3Object(url: string): Promise<{ size: number }> {
+    public async getHttpObjectSize(url: string): Promise<number> {
         try {
             const response = await axios.head(url);
-            const fileSize = parseInt(response.headers["content-length"] || "0", 10);
-            return { size: fileSize };
+            return parseInt(response.headers["content-length"] || "0", 10);
         } catch (err) {
-            console.error(`Failed to get file metadata: ${err}`);
+            console.error(`Failed to get file size (content-length): ${err}`);
             throw err;
         }
     }

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -284,8 +284,7 @@ const downloadFilesLogic = createLogic({
                 } else if (file.size === 0 && isStandardS3Url) {
                     // Handle individual S3 files
                     try {
-                        const s3HeadResponse = await fileDownloadService.headS3Object(file.path);
-                        file.size = s3HeadResponse.size;
+                        file.size = await fileDownloadService.getHttpObjectSize(file.path);
                     } catch (err) {
                         console.error(`Failed to fetch file size for ${file.name}: ${err}`);
                     }


### PR DESCRIPTION
Vol-E can load "small enough" tiff files. This adds Vol-E as a viewer for .tiff files. In the future, it would be great to determine the max size and remove it as an option when too big.
