### PR TITLE
Refactor icon buttons to use new component

### DIFF
--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -65,19 +65,12 @@
 }
 
 .icon-button {
-    background-color: transparent;
-    color: var(--primary-text-color);
     top: -6px;
 }
 
 .icon-button i {
     font-size: 18px;
     height: 18px;
-}
-
-.icon-button:hover {
-    background-color: transparent;
-    color: var(--highlight-text-color);
 }
 
 .load-button-container {

--- a/packages/core/components/DataSourcePrompt/FilePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.module.css
@@ -75,13 +75,7 @@
 }
 
 .selected-file-button {
-    color: var(--primary-text-color);
     margin-left: 10px;
-}
-
-.selected-file-button:hover {
-    background-color: unset;
-    color: var(--highlight-text-color);
 }
 
 .selected-files {

--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -1,10 +1,10 @@
-import { Icon, IconButton, TextField } from "@fluentui/react";
+import { Icon, TextField } from "@fluentui/react";
 import classNames from "classnames";
 import { throttle } from "lodash";
 import * as React from "react";
 import { useDropzone } from "react-dropzone";
 
-import { SecondaryButton, TertiaryButton } from "../Buttons";
+import { SecondaryButton, TertiaryButton, TransparentIconButton } from "../Buttons";
 import Tooltip from "../Tooltip";
 import { Source, getNameAndTypeFromSourceUrl } from "../../entity/SearchParams";
 
@@ -97,9 +97,10 @@ export default function FilePrompt(props: Props) {
                             {props.selectedFile.name}.{props.selectedFile.type}
                         </p>
                     </Tooltip>
-                    <IconButton
+                    <TransparentIconButton
                         className={styles.selectedFileButton}
-                        iconProps={{ iconName: "Cancel" }}
+                        iconName="Cancel"
+                        title="Remove file"
                         onClick={() => props.onSelectFile(undefined)}
                     />
                 </div>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -1,10 +1,10 @@
-import { DefaultButton, Icon, IconButton } from "@fluentui/react";
+import { DefaultButton, Icon } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import FilePrompt from "./FilePrompt";
-import { LinkLikeButton, PrimaryButton } from "../Buttons";
+import { LinkLikeButton, PrimaryButton, TransparentIconButton } from "../Buttons";
 import { Source } from "../../entity/SearchParams";
 import { interaction, selection } from "../../state";
 import { DataSourcePromptInfo } from "../../state/interaction/actions";
@@ -77,9 +77,9 @@ export default function DataSourcePrompt(props: Props) {
             {!metadataSource && (
                 <div className={styles.advancedOptionsHeader}>
                     <h4 className={styles.fullWidth}>Add metadata descriptor file (optional)</h4>
-                    <IconButton
+                    <TransparentIconButton
                         className={styles.iconButton}
-                        iconProps={{ iconName: "Cancel" }}
+                        iconName="Cancel"
                         onClick={() => {
                             setMetadataSource(undefined);
                             setShowAdvancedOptions(false);

--- a/packages/core/components/EditMetadata/EditMetadata.module.css
+++ b/packages/core/components/EditMetadata/EditMetadata.module.css
@@ -138,13 +138,7 @@
 }
 
 .selected-option-button {
-  color: var(--primary-text-color);
   margin-left: 10px;
-}
-
-.selected-option-button:hover {
-  background-color: unset;
-  color: var(--highlight-text-color);
 }
 
 .text-field {

--- a/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
+++ b/packages/core/components/EditMetadata/NewAnnotationPathway.tsx
@@ -1,11 +1,11 @@
-import { IconButton, Stack, StackItem, TextField } from "@fluentui/react";
+import { Stack, StackItem, TextField } from "@fluentui/react";
 import classNames from "classnames";
 import Fuse from "fuse.js";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import MetadataDetails, { ValueCountItem } from "./MetadataDetails";
-import { PrimaryButton, SecondaryButton } from "../Buttons";
+import { PrimaryButton, SecondaryButton, TransparentIconButton } from "../Buttons";
 import ComboBox from "../ComboBox";
 import LoadingIcon from "../Icons/LoadingIcon";
 import Tooltip from "../Tooltip";
@@ -295,9 +295,10 @@ export default function NewAnnotationPathway(props: NewAnnotationProps) {
                                         <Tooltip content={option}>
                                             <p className={styles.selectedOption}>{option}</p>
                                         </Tooltip>
-                                        <IconButton
+                                        <TransparentIconButton
                                             className={styles.selectedOptionButton}
-                                            iconProps={{ iconName: "Cancel" }}
+                                            iconName="Cancel"
+                                            title={`Remove ${option}`}
                                             onClick={() => removeDropdownChip(option)}
                                         />
                                     </div>

--- a/packages/core/components/QueryPart/QueryPartRow.module.css
+++ b/packages/core/components/QueryPart/QueryPartRow.module.css
@@ -1,15 +1,8 @@
 .icon-button, .icon-button:hover {
-    background-color: unset;
-    color: unset;
     font-weight: 600;
     height: 37px;
     max-width: 22px;
     width: 100%;
-}
-
-.icon-button:hover {
-    background-color: unset;
-    color: var(--highlight-text-color);
 }
 
 .icon-button i {

--- a/packages/core/components/QueryPart/QueryPartRow.tsx
+++ b/packages/core/components/QueryPart/QueryPartRow.tsx
@@ -1,8 +1,8 @@
-import { DirectionalHint, Icon, IconButton } from "@fluentui/react";
+import { DirectionalHint, Icon } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
-import { useButtonMenu } from "../Buttons";
+import { TransparentIconButton, useButtonMenu } from "../Buttons";
 import { DnDItem, DnDItemRendererParams } from "../DnDList/DnDList";
 import Tooltip from "../Tooltip";
 
@@ -58,25 +58,20 @@ export default function QueryGroupRow(props: Props) {
                 </Tooltip>
             </div>
             {!!props.item.onRenderEditMenuList && (
-                <Tooltip content="Edit">
-                    <IconButton
-                        ariaLabel="Edit"
-                        className={classNames(styles.iconButton, styles.hiddenInnerIcon)}
-                        iconProps={{ iconName: "Edit" }}
-                        menuProps={editMenu}
-                    />
-                </Tooltip>
+                <TransparentIconButton
+                    className={classNames(styles.iconButton, styles.hiddenInnerIcon)}
+                    iconName="Edit"
+                    menuProps={editMenu}
+                    title="Edit"
+                />
             )}
             {props.item.onDelete && (
-                <Tooltip content="Delete">
-                    <IconButton
-                        ariaDescription="Delete"
-                        ariaLabel="Delete"
-                        className={styles.iconButton}
-                        iconProps={{ iconName: "Cancel" }}
-                        onClick={() => props.item.onDelete?.(props.item.id)}
-                    />
-                </Tooltip>
+                <TransparentIconButton
+                    className={styles.iconButton}
+                    iconName="Cancel"
+                    onClick={() => props.item.onDelete?.(props.item.id)}
+                    title="Delete"
+                />
             )}
         </div>
     );

--- a/packages/core/components/QuerySidebar/Query.module.css
+++ b/packages/core/components/QuerySidebar/Query.module.css
@@ -3,21 +3,6 @@
     background-color: var(--primary-sidebar-color);
 }
 
-.collapse-button:hover {
-    color: var(--highlight-text-color);
-    background-color: var(--highlight-background-color);
-}
-
-.expand-button {
-    color: var(--primary-sidebar-text-color);
-    background: none;
-}
-
-.expand-button:hover {
-    color: var(--highlight-text-color);
-    background: none;
-}
-
 .collapse-button i, .expand-button i {
     font-weight: 600;
 }

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -1,9 +1,10 @@
-import { IContextualMenuItem, IconButton, SpinnerSize, TextField } from "@fluentui/react";
+import { IContextualMenuItem, SpinnerSize, TextField } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import QueryFooter from "./QueryFooter";
+import { TertiaryButton, TransparentIconButton } from "../Buttons";
 import LoadingIcon from "../Icons/LoadingIcon";
 import QueryDataSource from "../QueryPart/QueryDataSource";
 import QueryFilter from "../QueryPart/QueryFilter";
@@ -119,12 +120,10 @@ export default function Query(props: QueryProps) {
                             <i>Building new query...</i>
                         </h4>
                     </Tooltip>
-                    <IconButton
-                        ariaDescription="Expand view details"
-                        ariaLabel="Expand"
+                    <TransparentIconButton
                         className={styles.expandButton}
                         disabled
-                        iconProps={{ iconName: "ChevronDownMed" }}
+                        iconName="ChevronDownMed"
                     />
                 </div>
                 <hr className={styles.divider}></hr>
@@ -154,13 +153,11 @@ export default function Query(props: QueryProps) {
                     <Tooltip content={props.query.name}>
                         <h4>{props.query.name}</h4>
                     </Tooltip>
-                    <IconButton
-                        ariaDescription="Expand view details"
-                        ariaLabel="Expand"
+                    <TransparentIconButton
                         className={styles.expandButton}
                         onClick={() => setIsExpanded(!isExpanded)}
-                        iconProps={{ iconName: "ChevronDownMed" }}
-                        data-testid="expand-button"
+                        iconName="ChevronDownMed"
+                        id="expand-button"
                     />
                 </div>
                 {!isExpanded && <hr className={styles.divider}></hr>}
@@ -214,13 +211,12 @@ export default function Query(props: QueryProps) {
                         }
                     />
                 </div>
-                <IconButton
-                    ariaDescription="Collapse view details"
-                    ariaLabel="Collapse"
+                <TertiaryButton
                     className={styles.collapseButton}
                     onClick={() => setIsExpanded(!isExpanded)}
-                    iconProps={{ iconName: "ChevronUpMed" }}
+                    iconName="ChevronUpMed"
                     data-testid="collapse-button"
+                    title="Collapse query details"
                 />
             </div>
             <QueryDataSource


### PR DESCRIPTION
## Context
We added a new icon button component in #616. This and other button components allow us to have more consistent styling across the app.

## Changes
This refactors existing code to use that new component, and removes duplicate or unnecessary styling. 
The visual appearance and functionality should be exactly the same. 

## Testing
Visually verified that the affected components appear the same as before. 
