### PR TITLE
Fix unit test failure

### DIFF
--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -15,6 +15,27 @@ import { AnnotationType } from "../../../entity/AnnotationFormatter";
 
 describe("<FileAnnotationList />", () => {
     describe("file path representation", () => {
+        const annotations = [
+            ...TOP_LEVEL_FILE_ANNOTATIONS,
+            new Annotation({
+                annotationDisplayName: "Cache Eviction Date",
+                annotationName: AnnotationName.CACHE_EVICTION_DATE,
+                description: "Indicates when the cache for this file should be evicted.",
+                type: AnnotationType.STRING,
+            }),
+            new Annotation({
+                annotationDisplayName: "File Path (Local VAST)",
+                annotationName: AnnotationName.LOCAL_FILE_PATH,
+                description: "Local path for the file on the host machine.",
+                type: AnnotationType.STRING,
+            }),
+            new Annotation({
+                annotationDisplayName: "Should Be in Local Cache",
+                annotationName: AnnotationName.SHOULD_BE_IN_LOCAL,
+                description: "Indicates if the file should be cached locally.",
+                type: AnnotationType.BOOLEAN,
+            }),
+        ];
         it("has both cloud file path and local file path adjusted to OS & allen mount point", async () => {
             // Arrange
             const hostMountPoint = "/some/path";
@@ -28,28 +49,7 @@ describe("<FileAnnotationList />", () => {
             const { store } = configureMockStore({
                 state: mergeState(initialState, {
                     metadata: {
-                        annotations: [
-                            ...TOP_LEVEL_FILE_ANNOTATIONS,
-                            new Annotation({
-                                annotationDisplayName: "Cache Eviction Date",
-                                annotationName: AnnotationName.CACHE_EVICTION_DATE,
-                                description:
-                                    "Indicates when the cache for this file should be evicted.",
-                                type: AnnotationType.STRING,
-                            }),
-                            new Annotation({
-                                annotationDisplayName: "File Path (Local VAST)",
-                                annotationName: AnnotationName.LOCAL_FILE_PATH,
-                                description: "Local path for the file on the host machine.",
-                                type: AnnotationType.STRING,
-                            }),
-                            new Annotation({
-                                annotationDisplayName: "Should Be in Local Cache",
-                                annotationName: AnnotationName.SHOULD_BE_IN_LOCAL,
-                                description: "Indicates if the file should be cached locally.",
-                                type: AnnotationType.BOOLEAN,
-                            }),
-                        ],
+                        annotations,
                     },
                     interaction: {
                         platformDependentServices: {
@@ -144,7 +144,7 @@ describe("<FileAnnotationList />", () => {
             );
         });
 
-        it("has loading message when file is downloading", () => {
+        it("has loading message when file is downloading", async () => {
             // Arrange
             class FakeExecutionEnvService extends ExecutionEnvServiceNoop {
                 public formatPathForHost(posixPath: string): Promise<string> {
@@ -154,7 +154,7 @@ describe("<FileAnnotationList />", () => {
             const { store } = configureMockStore({
                 state: mergeState(initialState, {
                     metadata: {
-                        annotations: TOP_LEVEL_FILE_ANNOTATIONS,
+                        annotations,
                     },
                     interaction: {
                         platformDependentServices: {
@@ -184,9 +184,8 @@ describe("<FileAnnotationList />", () => {
             );
 
             // Assert
-            ["File Path (Local VAST)", "Copying to VAST in progress…"].forEach(async (cellText) => {
-                expect(await findByText(cellText)).to.not.be.undefined;
-            });
+            expect(await findByText("File Path (Local VAST)")).to.not.be.undefined;
+            expect(await findByText("Copying to VAST in progress…")).to.not.be.undefined;
         });
     });
 });

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -215,7 +215,7 @@ export default function Query(props: QueryProps) {
                     className={styles.collapseButton}
                     onClick={() => setIsExpanded(!isExpanded)}
                     iconName="ChevronUpMed"
-                    data-testid="collapse-button"
+                    id="collapse-button"
                     title="Collapse query details"
                 />
             </div>

--- a/packages/core/components/QuerySidebar/test/Query.test.tsx
+++ b/packages/core/components/QuerySidebar/test/Query.test.tsx
@@ -13,7 +13,7 @@ import ExcludeFilter from "../../../entity/FileFilter/ExcludeFilter";
 import { initialState } from "../../../state";
 
 describe("<Query />", () => {
-    it.skip("expands and collapses when clicked", async () => {
+    it("expands and collapses when clicked", async () => {
         // Arrange
         const { store } = configureMockStore({
             state: initialState,
@@ -31,21 +31,22 @@ describe("<Query />", () => {
                             sources: [{ name: sourceName }],
                             openFolders: [],
                         },
+                        loading: false,
                     }}
                 />
             </Provider>
         );
 
         // (sanity-check) is collapsed
-        expect(getByTestId("expand-button")).to.exist;
-        expect(() => getByTestId("collapse-button")).to.throw();
+        expect(getByTestId(/expand-button/)).to.exist;
+        expect(() => getByTestId(/collapse-button/)).to.throw();
 
         // Act
-        fireEvent.click(getByTestId("expand-button"));
+        fireEvent.click(getByTestId(/expand-button/));
 
         // Assert
-        expect(getByTestId("collapse-button")).to.exist;
-        expect(() => getByTestId("expand-button")).to.throw();
+        expect(getByTestId(/collapse-button/)).to.exist;
+        expect(() => getByTestId(/expand-button/)).to.throw();
     });
 
     it("renders spinner and loading header when new query is in loading state", () => {


### PR DESCRIPTION
## Context
Resolves #602. A `Query` unit test started failing somewhat inconsistently after recent code changes. It was passing when run on its own, and passing in GitHub, but failing locally when run with the whole test suite. Our previous solution was to `skip` that test; this re-enables it.  

It turned out that an unrelated test (in `FileAnnotationList`) that should have been marked as asynchronous was interfering/overlapping with the `Query` tests. The `FileAnnotationList` test was quietly failing, and because of the async behavior it wasn't being properly caught. 

## Changes

Made the `FileAnnotationList` test asynchronous, which also allowed fixing the underlying issues with that test (wasn't mocking the full list of annotations)
Also needed to make some minor changes associated with #619 to the `Query` tests and component.

## Testing

- Made sure unit tests pass locally, both individually and when run as a whole suite
- Also passing in GitHub actions
