### PR TITLE
Add featured section to datasets page

### DIFF
--- a/packages/core/styles/global.css
+++ b/packages/core/styles/global.css
@@ -58,6 +58,7 @@ body {
     --light-grey: #BFBFBF;
     --white: #ffffff;
     --red: #c23030;
+    --yellow: #EBB326;
 
     /* DEFAULT THEME (dark theme) */
     --primary-background-color: var(--primary-dark);

--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.module.css
@@ -22,15 +22,14 @@
 .button-wrapper {
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
+  padding-right: calc(2*var(--margin));
+  max-width: 1100px;
+  width: 90vw;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-}
-
-.button-wrapper:hover {
-  width: 100%;
 }
 
 .button-wrapper-hidden {

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.module.css
@@ -3,6 +3,14 @@
   position: relative;
 }
 
+/* Adjust left to allow for "favorite" icon */
+.table-root {
+  left: -15px;
+}
+.table-header {
+  margin-left: 15px;
+}
+
 .table-header > div {
   background-color: var(--secondary-dark);
   background: var(--secondary-dark);
@@ -52,6 +60,21 @@
 .link:hover {
   text-decoration: underline;
   color: var(--bright-aqua);
+}
+
+.row-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.favorite-icon {
+  color: var(--yellow);
+  font-size: var(--s-paragraph-size);
+  margin-bottom: 5px;
+}
+/* Keep present to maintain spacing, but hidden */
+.favorite-icon-hidden {
+  color: transparent;
 }
 
 /* Toggle overlay depending on screen size */

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
@@ -1,6 +1,7 @@
 import {
     createTheme,
     IColumn,
+    Icon,
     IDetailsRowProps,
     IRenderFunction,
     PartialTheme,
@@ -24,6 +25,7 @@ import styles from "./DatasetTable.module.css";
 
 interface DatasetTableProps {
     onLoadDataset: (dataset: PublicDataset) => void;
+    featured?: boolean; // Flag to filter down to only the featured datasets
 }
 
 export default function DatasetTable(props: DatasetTableProps) {
@@ -44,7 +46,7 @@ export default function DatasetTable(props: DatasetTableProps) {
             };
         }
     );
-    const [items, isLoading, error] = useDatasetDetails(sortColumn);
+    const [items, isLoading, error] = useDatasetDetails(sortColumn, props?.featured);
 
     const renderRow = (
         rowProps: IDetailsRowProps | undefined,
@@ -52,11 +54,19 @@ export default function DatasetTable(props: DatasetTableProps) {
     ): JSX.Element => {
         if (rowProps && defaultRender) {
             return (
-                <DatasetRow
-                    rowProps={rowProps}
-                    defaultRender={defaultRender}
-                    onLoadDataset={props.onLoadDataset}
-                />
+                <div className={styles.rowWrapper}>
+                    <Icon
+                        className={classNames(styles.favoriteIcon, {
+                            [styles.favoriteIconHidden]: !props.featured,
+                        })}
+                        iconName="FavoriteStarFill"
+                    />
+                    <DatasetRow
+                        rowProps={rowProps}
+                        defaultRender={defaultRender}
+                        onLoadDataset={props.onLoadDataset}
+                    />
+                </div>
             );
         }
         return <></>;
@@ -118,6 +128,7 @@ export default function DatasetTable(props: DatasetTableProps) {
                     ariaLabelForShimmer="Content is being fetched"
                     ariaLabelForGrid="Item details"
                     detailsListStyles={{
+                        root: styles.tableRoot,
                         headerWrapper: styles.tableHeader,
                     }}
                     onRenderRow={(props, defaultRender) => renderRow(props, defaultRender)}

--- a/packages/web/src/components/OpenSourceDatasets/OpenSourceDatasets.module.css
+++ b/packages/web/src/components/OpenSourceDatasets/OpenSourceDatasets.module.css
@@ -53,8 +53,5 @@
 }
 
 .table-title {
-  font-weight: 300;
-  font-size: 24px;
-  line-height: 1.25;
   margin-top: calc(2*var(--margin));
 }

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -73,17 +73,21 @@ export default function OpenSourceDatasets() {
                         <div className={styles.bannerContentText}>
                             <div className={styles.bannerHeader}> Open-source datasets</div>
                             <div className={styles.bannerBody}>
-                                The tables below contain examples of datasets that are available for
-                                exploration.
-                            </div>
-                            <div className={styles.bannerBody}>
-                                Select a dataset to view more information, or click LOAD to open it
-                                in the BioFile Finder app.
+                                The datasets below are available for exploration and open use. Click
+                                LOAD to open a dataset in BioFile Finder, view images in your web
+                                browser, download files, or share selected subdatasets as links.
                             </div>
                         </div>
                     </div>
                 </div>
                 <div className={styles.content}>
+                    <h2 className={styles.tableTitle}>Datasets optimized for BioFile Finder</h2>
+                    <p>
+                        These datasets utilize features that highlight BFF&apos;s capabilities, such
+                        as as thumbnail rendering and interoperability with viewers.
+                    </p>
+                    <DatasetTable onLoadDataset={loadDataset} featured />
+                    <h2 className={styles.tableTitle}>All datasets</h2>
                     <DatasetTable onLoadDataset={loadDataset} />
                     <p>
                         Want to include your dataset? Send us a request at

--- a/packages/web/src/components/OpenSourceDatasets/useDatasetDetails.ts
+++ b/packages/web/src/components/OpenSourceDatasets/useDatasetDetails.ts
@@ -12,7 +12,8 @@ import PublicDataset, { PublicDatasetProps } from "../../entity/PublicDataset";
  * of the return array will be true.
  */
 export default function useDatasetDetails(
-    fileSort?: FileSort | undefined
+    fileSort?: FileSort | undefined,
+    featured?: boolean
 ): [PublicDatasetProps[] | null, boolean, string | undefined] {
     const [isLoading, setIsLoading] = React.useState(false);
     const [error, setError] = React.useState<string>();
@@ -39,13 +40,16 @@ export default function useDatasetDetails(
                 })
                 .then((itemList) => {
                     setItems(
-                        itemList.map(
-                            (dataset) =>
-                                new PublicDataset(
-                                    { dataset_name: dataset.name },
-                                    dataset.annotations
-                                ).details
-                        )
+                        itemList
+                            .map(
+                                (dataset) =>
+                                    new PublicDataset(
+                                        { dataset_name: dataset.name },
+                                        dataset.annotations
+                                    )
+                            )
+                            .filter((dataset) => dataset?.featured === !!featured)
+                            .map((dataset) => dataset.details)
                     );
                     setIsLoading(false);
                 })
@@ -57,6 +61,6 @@ export default function useDatasetDetails(
         return () => {
             setIsLoading(false);
         };
-    }, [fileSet, publicDatasetListService]);
+    }, [featured, fileSet, publicDatasetListService]);
     return [items, isLoading, error];
 }

--- a/packages/web/src/entity/PublicDataset/index.ts
+++ b/packages/web/src/entity/PublicDataset/index.ts
@@ -13,6 +13,7 @@ export interface PublicDatasetProps {
     dataset_size?: string;
     description?: string;
     doi?: string;
+    featured?: "TRUE" | "FALSE"; // string containing boolean indicating if this is one of BFF's featured datasets
     file_count?: string;
     index?: string;
     created?: string;
@@ -51,11 +52,12 @@ export const DatasetAnnotations = {
     DATASET_ID: new DatasetAnnotation("Dataset ID", "dataset_id"),
     DATASET_NAME: new DatasetAnnotation("Dataset name", "dataset_name", 50),
     DATASET_PATH: new DatasetAnnotation("File Path", "dataset_path"),
-    INDEX: new DatasetAnnotation("Index", "index", 1),
     DATASET_SIZE: new DatasetAnnotation("Size", "dataset_size", 78),
     DATASET_DESCRIPTION: new DatasetAnnotation("Short description", "description", 200),
     DOI: new DatasetAnnotation("DOI", "doi"),
+    FEATURED: new DatasetAnnotation("Featured", "featured"),
     FILE_COUNT: new DatasetAnnotation("File count", "file_count", 89),
+    INDEX: new DatasetAnnotation("Index", "index", 1),
     ORGANIZATION: new DatasetAnnotation("Organization", "organization", 114),
     PUBLICATION_DATE: new DatasetAnnotation("Publication date", "published", 128),
     RELATED_PUBLICATON: new DatasetAnnotation("Related publication", "related_publication", 178),
@@ -112,7 +114,9 @@ export default class PublicDataset {
                     this.setMetadata(
                         mappedAnnotationsToProps,
                         value.name as keyof PublicDatasetProps,
-                        equivalentAnnotation.values[0] as string // Temporary measure to avoid type errors
+                        // We currently split on commas, which breaks the description field into multiple values
+                        // This is hopefully just a temporary solution, since doesn't work for numbers (e.g., 30,000 becomes 30, 000)
+                        equivalentAnnotation.values.join(", ") as string // String casting as temporary measure to avoid type errors
                     );
                 }
             });
@@ -164,6 +168,10 @@ export default class PublicDataset {
         } else {
             return SearchParams.decode(this.datasetDetails.specific_query);
         }
+    }
+
+    public get featured(): boolean {
+        return this.datasetDetails.featured === "TRUE";
     }
 
     public getFirstAnnotationValue(annotationName: string): string | number | boolean | undefined {


### PR DESCRIPTION
## Context
Partially addresses #604. We'd like to emphasize datasets that are optimized to show off BFF's capabilities so that users know where to start. This creates a new section that features those datasets (currently, the Variance dataset). 

Not addressed: Does not include the guidance links since those don't exist yet.

## Changes

- Adds a new section to the dataset page based on @lynwilhelm 's [Figma design](https://www.figma.com/design/oNQvOAK11YINcbPvNmkgwO/BFF---File-Explorer?node-id=4253-12708&t=Qi6dmbKlQ5qgqCDZ-0) 

Also fixes a couple older dataset page bugs
- Descriptions were accidentally getting truncated wherever there were commas (we split by default)
- The hover actions were getting cut off because the overlay width was not responsive

## Testing
Tested manually

## Screenshots
<img width="1728" height="971" alt="Screenshot 2025-12-05 at 4 26 50 PM" src="https://github.com/user-attachments/assets/ccc5c330-e115-49d8-bc01-7b2e955e2489" />

Description truncation bug, before and after
<img width="512" height="637" alt="Screenshot 2025-12-05 at 4 29 50 PM" src="https://github.com/user-attachments/assets/79548eea-7d5d-4ec7-b251-cc963d75cf81" />
<img width="512" height="707" alt="Screenshot 2025-12-05 at 4 29 55 PM" src="https://github.com/user-attachments/assets/68c69505-ab96-45d4-beeb-1def666a7fd4" />

Action buttons getting cut off, before and after
<img width="989" height="309" alt="Screenshot 2025-12-05 at 4 31 05 PM" src="https://github.com/user-attachments/assets/03218650-6b42-4b9e-bfc3-445fec842b57" />
<img width="988" height="362" alt="Screenshot 2025-12-05 at 4 31 13 PM" src="https://github.com/user-attachments/assets/d625f695-f9e3-47ec-adbd-d1372fbbab61" />
