### PR TITLE
Remove call to fetch total count from query footer

### DIFF
--- a/packages/core/components/QuerySidebar/QueryFooter.tsx
+++ b/packages/core/components/QuerySidebar/QueryFooter.tsx
@@ -5,18 +5,14 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { TertiaryButton } from "../Buttons";
 import { ModalType } from "../Modal";
-import Tooltip from "../Tooltip";
 import Tutorial from "../../entity/Tutorial";
 import IncludeFilter from "../../entity/FileFilter/IncludeFilter";
-import FileSet from "../../entity/FileSet";
 import { SearchParamsComponents } from "../../entity/SearchParams";
 import useSaveMetadataOptions from "../../hooks/useSaveMetadataOptions";
 import { interaction, selection } from "../../state";
 import { Query } from "../../state/selection/actions";
 
 import styles from "./QueryFooter.module.css";
-
-const MAX_MANIFEST_FILE_COUNT = 250000;
 
 interface Props {
     isDeletable?: boolean;
@@ -32,37 +28,12 @@ export default function QueryFooter(props: Props) {
     const dispatch = useDispatch();
 
     const url = useSelector(selection.selectors.getEncodedSearchParams);
-    const fileService = useSelector(interaction.selectors.getFileService);
-    const [totalFileCount, setTotalFileCount] = React.useState(0);
     const combinedFilters = React.useMemo(() => {
         const groupByFilters = props.queryComponents.hierarchy.map(
             (annotationName) => new IncludeFilter(annotationName)
         );
         return [...props.queryComponents.filters, ...groupByFilters];
     }, [props.queryComponents.filters, props.queryComponents.hierarchy]);
-    const totalFileSet = React.useMemo(() => {
-        return new FileSet({
-            fileService,
-            filters: combinedFilters,
-        });
-    }, [fileService, combinedFilters]);
-
-    // Get a count of all files
-    React.useEffect(() => {
-        totalFileSet
-            .fetchTotalCount()
-            .then((count) => {
-                setTotalFileCount(count);
-            })
-            .catch((err) => {
-                // Data source may not be prepared if the data source is taking longer to load
-                // than the component does to render. In this case, we can ignore the error.
-                // The component will re-render when the data source is prepared.
-                if (!err?.message.includes("Data source is not prepared")) {
-                    throw err;
-                }
-            });
-    }, [totalFileSet, setTotalFileCount]);
 
     const isEmptyQuery = !props.query.parts.sources.length;
 
@@ -153,21 +124,13 @@ export default function QueryFooter(props: Props) {
                 onClick={onDuplicateQuery}
                 title="Duplicate query"
             />
-            <Tooltip
-                content={
-                    totalFileCount > MAX_MANIFEST_FILE_COUNT
-                        ? "Unable to save full result for >250,000 files"
-                        : undefined
-                }
-            >
-                <TertiaryButton
-                    invertColor
-                    disabled={isEmptyQuery || totalFileCount > MAX_MANIFEST_FILE_COUNT}
-                    iconName="Save"
-                    menuItems={saveQueryAsOptions}
-                    title="Save query result as..."
-                />
-            </Tooltip>
+            <TertiaryButton
+                invertColor
+                disabled={isEmptyQuery}
+                iconName="Save"
+                menuItems={saveQueryAsOptions}
+                title="Save query result as..."
+            />
             <TertiaryButton
                 invertColor
                 disabled={isEmptyQuery}


### PR DESCRIPTION
## Context
Resolves #636: Every time the user updates filters on a data source, an extra `SELECT COUNT(*)` query runs in the background, which can be slow and expensive.

The query panel footer includes a button that allows users to save the entire query result as a csv/json/parquet file. 
When we initially implemented this, there were some concerns about whether we should allow folks to download results for a huge number of files (e.g., hundreds of thousands +). To address this, we placed a somewhat arbitrary limit on the total file count (250,000) and disabled the button when the file count exceeded this number.

The problem is that this total file count has to happen separately from the query that populates the file count at the bottom of file lists. When there are groups applied, we don't actually know the file count for each group until we open a group "folder." 

It seems like the best solution in this case is to fully remove the check/restriction from the query footer: 
1. We don't actually have evidence yet of issues with users needing to save CSVs for huge numbers of files (aside from the note below re FES)
2. Even if we did, the restriction doesn't have to (and probably shouldn't) happen that early on in the UI. We could move it to the manifest download modal instead, so that the count only occurs when the user actually intends to download the manifest instead of on every query update.

## Changes
For now, fully removes `fetchTotalCount` from the query footer, and enables manifest downloads for any number of files. 
If we want to restrict this in the future, we can consider implementing (2) above

## Testing
Tested manually:
 - Not seeing the extra `SELECT COUNT(*)` query anymore
 - Can still download manifests (for <12,000 files... see below)


## Note
Found an incidental bug in FES where the manifest query cuts off the results for >12,000 files. There's nothing for us to do about this on the BFF side right now, but depending on the source of the issue, we may need to consider restricting manifest download sizes anyway
