### PR TITLE
(Tiny) Fix opening tiffs in Vol-E

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -360,7 +360,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             // if the user has more than one file selected, try to filter out what Vol-E can't open
             const filteredDetails = details.filter((detail) => {
                 const fileExt = getFileExtension(detail);
-                return ["", "zarr", "tiff", "tif"].indexOf(fileExt) !== 0;
+                return ["", "zarr", "tiff", "tif"].includes(fileExt);
             });
             if (filteredDetails.length !== 0) {
                 details = filteredDetails;


### PR DESCRIPTION
In #621, I introduced a step to the process of opening files in Vol-E that looked at file extensions and filtered out files that didn't look openable in Vol-E... and I didn't include the extensions for .tiff files! This PR fixes that, and makes that filtering step a bit more lenient generally.
