### PR TITLE
Extend styling across entire row

### DIFF
--- a/packages/core/components/FileList/Header.module.css
+++ b/packages/core/components/FileList/Header.module.css
@@ -23,13 +23,10 @@
   background-color: var(--primary-background-color);
   border-radius: var(--small-border-radius);
   box-shadow: var(--box-shadow);
-  color: var(--primary-text-color);
-  padding: var(--inner-header-padding) 0;
 }
 
 .header:hover {
   background-color: var(--accent-dark);
-  color: var(--primary-text-color);
 }
 
 .header > div {
@@ -44,9 +41,20 @@
 
 .header-cell {
   cursor: pointer;
+  background-color: inherit;
+  box-shadow: var(--box-shadow);
+  color: var(--primary-text-color);
+  padding: var(--inner-header-padding) 0;
 }
 
-.header-cell:hover {
+/* The first cell should have rounded corners on the left side */
+.header-cell:first-of-type {
+  border-top-left-radius: var(--small-border-radius);
+  border-bottom-left-radius: var(--small-border-radius);
+}
+
+/* Only highlight text when hovering the title itself */
+.header-title:hover {
   color: var(--highlight-text-color);
 }
 

--- a/packages/core/components/FileList/Header.tsx
+++ b/packages/core/components/FileList/Header.tsx
@@ -37,13 +37,11 @@ function Header(
         dispatch(selection.actions.resizeColumn({ name, width: width || 0.25 }));
     };
     const headerCells: CellConfig[] = map(columns, (column) => ({
+        className: styles.headerCell, // pass style elements to cell component
         // needs to match the value used to produce `column`s passed to the `useResizableColumns` hook
         columnKey: column.name,
         displayValue: (
-            <span
-                className={styles.headerCell}
-                onClick={() => dispatch(selection.actions.sortColumn(column.name))}
-            >
+            <span onClick={() => dispatch(selection.actions.sortColumn(column.name))}>
                 <Tooltip content={annotationNameToAnnotationMap[column.name]?.description}>
                     <span className={styles.headerTitle}>
                         {annotationNameToAnnotationMap[column.name]?.displayName}

--- a/packages/core/components/FileRow/Cell.module.css
+++ b/packages/core/components/FileRow/Cell.module.css
@@ -11,6 +11,7 @@
     font-size: initial;
     height: 100%;
     line-height: normal;
+    background-color: inherit;
 }
 
 .cell:first-of-type {
@@ -30,16 +31,17 @@
 }
 
 .resize-target {
-    background-color: var(--highlight-background-color);
-    height: 18px;
+    color: var(--highlight-background-color);
+    font-size: 18px;
+    font-weight: bolder;
     position: absolute;
     right: calc(1em / 2);
     text-align: center;
-    top: 0;
+    top: 3px;
     touch-action: none;
-    width: 2px;
+    width: 5px;
 }
 
 .resize-target:hover {
-    background-color: var(--highlight-hover-background-color);
+    color: var(--highlight-hover-background-color);
 }

--- a/packages/core/components/FileRow/Cell.tsx
+++ b/packages/core/components/FileRow/Cell.tsx
@@ -112,7 +112,9 @@ export default class Cell extends React.Component<React.PropsWithChildren<CellPr
                 <span
                     className={classNames(styles.resizeTarget, resizeTargetClassName)}
                     ref={this.resizeTarget}
-                />
+                >
+                    |
+                </span>
             </div>
         );
     }

--- a/packages/core/components/FileRow/index.tsx
+++ b/packages/core/components/FileRow/index.tsx
@@ -10,6 +10,7 @@ import { selection } from "../../state";
 import styles from "./FileRow.module.css";
 
 export interface CellConfig {
+    className?: string;
     columnKey: string;
     displayValue: string | React.ReactNode;
     title?: string;
@@ -51,7 +52,9 @@ export default function FileRow(props: FileRowProps) {
         <div className={classNames(styles.row, className)} onClick={onClick}>
             {map(cells, (cell) => (
                 <Cell
-                    className={classNames({ [styles.smallFont]: shouldDisplaySmallFont })}
+                    className={classNames(cell.className, {
+                        [styles.smallFont]: shouldDisplaySmallFont,
+                    })}
                     key={cell.columnKey}
                     columnKey={cell.columnKey}
                     onContextMenu={onContextMenu}


### PR DESCRIPTION
## Context
Resolves #647 
Row styling was only being applied to initially rendered columns and not to overflow columns

Unrelated: In the column headers, we currently use a very thin filled rectangle as a divider. However, because it's thin, the click target is hard to interact with

## Changes
Row styling issue:
- Moved some styling from the row wrapper to its child components; added ability to pass classes directly to the `Cell` itself instead of only styling its contents

Row divider issue:
- Changed the element for resizing columns (switched to using "|" rather than the filled rectangle and made the div wider) to make the click target easier to hover over

## Testing
Tested manually
- Added new columns and scrolled to the right to make sure styling was still applied
- Tested with and without groups/folders
- Made sure header hover & click behavior is still the same

## Screenshots
#### Before
<img width="946" height="464" alt="image" src="https://github.com/user-attachments/assets/69fc179b-b341-478a-b035-c57aa7be81a1" />

#### After
<img width="949" height="470" alt="image" src="https://github.com/user-attachments/assets/ac9a072c-eabe-4fb3-bda9-03f5ea393f62" />

