### PR TITLE
Hide provenence addition button

### DIFF
--- a/packages/core/components/QueryPart/QueryDataSource.tsx
+++ b/packages/core/components/QueryPart/QueryDataSource.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import QueryPart from ".";
-import { DataSourceType } from "../DataSourcePrompt";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
 import { Source } from "../../entity/SearchParams";
 import { interaction, metadata, selection } from "../../state";
@@ -84,20 +83,21 @@ export default function QueryDataSource(props: Props) {
                         );
                     },
                 },
+                // TODO: Hide this for now until we have better docs for explaining this
                 // Temporary menu item for adding provenance data
-                {
-                    key: "New Provenance Data Source",
-                    text: "New provenance data source",
-                    onClick: () => {
-                        dispatch(
-                            interaction.actions.promptForDataSource({
-                                query: selectedQuery,
-                                source: selectedDataSources[0],
-                                sourceType: DataSourceType.provenance,
-                            })
-                        );
-                    },
-                },
+                // {
+                //     key: "New Provenance Data Source",
+                //     text: "New provenance data source",
+                //     onClick: () => {
+                //         dispatch(
+                //             interaction.actions.promptForDataSource({
+                //                 query: selectedQuery,
+                //                 source: selectedDataSources[0],
+                //                 sourceType: DataSourceType.provenance,
+                //             })
+                //         );
+                //     },
+                // },
             ]}
             rows={[
                 ...props.dataSources.map((dataSource) => ({


### PR DESCRIPTION
Until we have docs available to users lets hide this button. Provenance will still be available for testing via supplying in the UI