### PR TITLE
Render thumbnails if possible

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -96,6 +96,10 @@ export default class FileDetail {
         return `${AICS_FMS_S3_URL_PREFIX}${path}`;
     }
 
+    private static isLikelyLocalFile(path: string): boolean {
+        return !path.startsWith("http") && !path.startsWith("s3");
+    }
+
     constructor(fileDetail: FmsFile, env: Environment, uniqueId?: string) {
         this.fileDetail = fileDetail;
         this.env = env;
@@ -150,7 +154,7 @@ export default class FileDetail {
     }
 
     public get isLikelyLocalFile(): boolean {
-        return !this.path.startsWith("http") && !this.path.startsWith("s3");
+        return FileDetail.isLikelyLocalFile(this.path);
     }
 
     public get downloadInProgress(): boolean {
@@ -200,21 +204,23 @@ export default class FileDetail {
         }
 
         // If no thumbnail present try to render the file itself as the thumbnail
-        if (!this.thumbnail) {
-            // Cannot currently read locally stored zarrs on web
-            if (this.path.includes(".zarr") && !this.isLikelyLocalFile) {
-                return renderZarrThumbnailURL(this.path, targetSize);
-            }
+        const pathToRender = this.thumbnail || this.path;
 
-            const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
-                this.path.toLowerCase().endsWith(format)
-            );
-            if (isFileRenderableImage) {
-                return this.path;
-            }
+        // Cannot currently read locally stored zarrs on web
+        if (pathToRender.includes(".zarr") && !FileDetail.isLikelyLocalFile(pathToRender)) {
+            return renderZarrThumbnailURL(pathToRender, targetSize);
         }
 
-        return this.thumbnail;
+        // If file can be easily rendered in the browser automatically (like a .png)
+        // then just go ahead and return it
+        const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
+            pathToRender.toLowerCase().endsWith(format)
+        );
+        if (!isFileRenderableImage) {
+            return undefined;
+        }
+
+        return pathToRender;
     }
 
     public getLinkToPlateUI(labkeyHost: string): string | undefined {

--- a/packages/core/entity/FileDetail/test/FileDetail.test.ts
+++ b/packages/core/entity/FileDetail/test/FileDetail.test.ts
@@ -1,0 +1,102 @@
+import { expect } from "chai";
+import { uniqueId } from "lodash";
+
+import { Environment } from "../../../constants";
+
+import FileDetail from "..";
+
+describe("FileDetail", () => {
+    describe("getPathToThumbnail", () => {
+        const metadata = {
+            annotations: [],
+            file_path: uniqueId() + ".png",
+            file_id: uniqueId(),
+            file_name: "MyFile.png",
+            file_size: 7,
+            uploaded: "01/01/01",
+        };
+
+        it("returns thumbnail when .png", async () => {
+            // Arrange
+            const thumbnail = "thumbnail.png";
+            const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.equal(thumbnail);
+        });
+
+        // Need .zarr in test files to test since file gets touched
+        it.skip("returns thumbnail when .zarr", async () => {
+            // Arrange
+            const thumbnail = "thumbnail.zarr";
+            const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.equal(thumbnail);
+        });
+
+        it("returns path when missing thumbnail and is .png", async () => {
+            // Arrange
+            const filePath = "file.png";
+            const detail = new FileDetail(
+                { ...metadata, file_path: filePath, thumbnail: undefined },
+                Environment.TEST
+            );
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.equal(filePath);
+        });
+
+        // Need .zarr in test files to test since file gets touched
+        it.skip("returns path when missing thumbnail and is .zarr", async () => {
+            // Arrange
+            const filePath = "file.zarr";
+            const detail = new FileDetail(
+                { ...metadata, file_path: filePath, thumbnail: undefined },
+                Environment.TEST
+            );
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.equal(filePath);
+        });
+
+        it("returns undefined when thumbnail is invalid type", async () => {
+            // Arrange
+            const thumbnail = "thumbnail.blah";
+            const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.undefined;
+        });
+
+        it("returns undefined when path is invalid type and thumbnail missing", async () => {
+            // Arrange
+            const filePath = "file.blah";
+            const detail = new FileDetail(
+                { ...metadata, file_path: filePath, thumbnail: undefined },
+                Environment.TEST
+            );
+
+            // Act
+            const path = await detail.getPathToThumbnail();
+
+            // Assert
+            expect(path).to.be.undefined;
+        });
+    });
+});


### PR DESCRIPTION
## What this does

This has BFF try to render thumbnails even if it points to a .zarr by just using the same logic that we use to render a thumbnail from a .zarr when it is provided as the main file path.

## Context

Saurabh brought up an interesting question, can the user supply a .zarr as a thumbnail? BFF already can handle rendering a thumbnail from a .zarr but the usual use case for a thumbnail is to provide a simpler format than the file path so usually people provide a .png. However, in this case the file path was to a .simularium file so .zarr is the simpler format. Resolves #676 

## Testing

Seems to work just fine with .zarr as a thumbnail in my local tests - unit tests seem positive as well, though I can't add one for testing the actual .zarr portion due to not having test files in the suite at the moment