### PR TITLE
(Tiny) Add mock httpClient to unit test

### DIFF
--- a/packages/core/services/S3StorageService/test/S3StorageService.test.ts
+++ b/packages/core/services/S3StorageService/test/S3StorageService.test.ts
@@ -1,13 +1,15 @@
-import { expect } from "chai";
 import { createMockHttpClient } from "@aics/redux-utils";
+import { expect } from "chai";
+import { get as _get } from "lodash";
 
 import S3StorageService from "..";
 
 describe("S3StorageService", () => {
     // This uses an external package, so is mostly just a consistency check
     describe("formatAsHttpResource", () => {
+        const virtualizedS3Url = "https://example.com/directory-name";
         const httpClient = createMockHttpClient({
-            when: `https://example.com/directory-name/path/to/file.zarr`,
+            when: (config) => _get(config, "url", "").includes(virtualizedS3Url),
             respondWith: {},
         });
         const s3StorageService = new S3StorageService({ httpClient });
@@ -48,13 +50,11 @@ describe("S3StorageService", () => {
         it("parses virtualized s3 url", async () => {
             // Act
             const reformattedUrl = await s3StorageService.formatAsHttpResource(
-                "https://example.com/directory-name/path/to/file.zarr"
+                `${virtualizedS3Url}/path/to/file.zarr`
             );
 
             // Assert
-            expect(reformattedUrl).to.equal(
-                "https://example.com/directory-name%2Fpath%2Fto%2Ffile.zarr"
-            );
+            expect(reformattedUrl).to.equal(`${virtualizedS3Url}%2Fpath%2Fto%2Ffile.zarr`);
         });
     });
 });


### PR DESCRIPTION
## Context
The S3StorageService unit test was passing locally but failing in Github actions. Seems to be because the httpClient was failing the axios check on the virtualized URL but passing it locally. 

This is mainly to separate unrelated changes from the big DBService PR I'm opening

## Changes
Adds a mock httpClient that simulates a successful check on the virtualized url.

## Testing
Still passes locally. Unit test also now passes in CI, but checks are currently failing on the Windows certificate
