### PR TITLE
Attempt to render thumbnail even when of unknown type

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -194,33 +194,41 @@ export default class FileDetail {
     }
 
     public async getPathToThumbnail(targetSize?: number): Promise<string | undefined> {
+        // When no thumbnail is provided, try to render one from the file path if it's a
+        // zarr or a known renderable image format
+        if (!this.thumbnail) {
+            // If the actual file can be easily rendered in the browser automatically
+            // (like a .png) then just go ahead and return it instead
+            const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
+                this.path.toLowerCase().endsWith(format)
+            );
+            if (isFileRenderableImage) return this.path;
+
+            // Try to render a thumbnail from the zarr if the path is a zarr
+            // and isn't a local file (since we can't read local zarrs in the browser)
+            if (this.path.includes(".zarr") && !FileDetail.isLikelyLocalFile(this.path)) {
+                return renderZarrThumbnailURL(this.path, targetSize);
+            }
+
+            return undefined;
+        }
+
         // If the thumbnail is a relative path on the allen drive then preprend it to
         // the AICS FMS NGINX server path
-        if (this.thumbnail?.startsWith("/allen")) {
+        if (this.thumbnail.startsWith("/allen")) {
             const pathWithoutDrive = this.thumbnail.replace(NAS_HOST_PREFIXES[this.env], "");
             return FileDetail.convertAicsS3PathToHttpUrl(
                 `${AICS_FMS_S3_BUCKETS[this.env]}${pathWithoutDrive}`
             );
         }
 
-        // If no thumbnail present try to render the file itself as the thumbnail
-        const pathToRender = this.thumbnail || this.path;
-
-        // Cannot currently read locally stored zarrs on web
-        if (pathToRender.includes(".zarr") && !FileDetail.isLikelyLocalFile(pathToRender)) {
-            return renderZarrThumbnailURL(pathToRender, targetSize);
+        // Try to render a thumbnail from the zarr if the thumbnail is a zarr
+        // and isn't a local file (since we can't read local zarrs in the browser)
+        if (this.thumbnail.includes(".zarr") && !FileDetail.isLikelyLocalFile(this.thumbnail)) {
+            return renderZarrThumbnailURL(this.thumbnail, targetSize);
         }
 
-        // If file can be easily rendered in the browser automatically (like a .png)
-        // then just go ahead and return it
-        const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
-            pathToRender.toLowerCase().endsWith(format)
-        );
-        if (!isFileRenderableImage) {
-            return undefined;
-        }
-
-        return pathToRender;
+        return this.thumbnail;
     }
 
     public getLinkToPlateUI(labkeyHost: string): string | undefined {

--- a/packages/core/entity/FileDetail/test/FileDetail.test.ts
+++ b/packages/core/entity/FileDetail/test/FileDetail.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
 import { uniqueId } from "lodash";
+import sinon from "sinon";
 
+import * as zarrRenderer from "../RenderZarrThumbnailURL";
 import { Environment } from "../../../constants";
 
 import FileDetail from "..";
@@ -15,6 +17,21 @@ describe("FileDetail", () => {
             file_size: 7,
             uploaded: "01/01/01",
         };
+        const renderedOmeZarrThumbnailURL = "zarrThumbnail.png";
+
+        before(() => {
+            sinon
+                .stub(zarrRenderer, "renderZarrThumbnailURL")
+                .returns(Promise.resolve(renderedOmeZarrThumbnailURL));
+        });
+
+        afterEach(() => {
+            sinon.resetHistory();
+        });
+
+        after(() => {
+            sinon.restore();
+        });
 
         it("returns thumbnail when .png", async () => {
             // Arrange
@@ -28,20 +45,35 @@ describe("FileDetail", () => {
             expect(path).to.be.equal(thumbnail);
         });
 
-        // Need .zarr in test files to test since file gets touched
-        it.skip("returns thumbnail when .zarr", async () => {
-            // Arrange
-            const thumbnail = "thumbnail.zarr";
-            const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+        ["https://idr-example/webclient/render_thumbnail/1921257/", "file.blah"].forEach(
+            (thumbnail) => {
+                it(`returns thumbnail when unknown type: ${thumbnail}`, async () => {
+                    // Arrange
+                    const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
 
-            // Act
-            const path = await detail.getPathToThumbnail();
+                    // Act
+                    const path = await detail.getPathToThumbnail();
 
-            // Assert
-            expect(path).to.be.equal(thumbnail);
+                    // Assert
+                    expect(path).to.be.equal(thumbnail);
+                });
+            }
+        );
+
+        ["http://thumbnail.zarr", "s3://thumbnail.zarr/"].forEach((thumbnail) => {
+            it(`returns rendered zarr thumbnail when .zarr: ${thumbnail}`, async () => {
+                // Arrange
+                const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+
+                // Act
+                const path = await detail.getPathToThumbnail();
+
+                // Assert
+                expect(path).to.be.equal(renderedOmeZarrThumbnailURL);
+            });
         });
 
-        it("returns path when missing thumbnail and is .png", async () => {
+        it("returns path when missing thumbnail and path is .png", async () => {
             // Arrange
             const filePath = "file.png";
             const detail = new FileDetail(
@@ -56,47 +88,38 @@ describe("FileDetail", () => {
             expect(path).to.be.equal(filePath);
         });
 
-        // Need .zarr in test files to test since file gets touched
-        it.skip("returns path when missing thumbnail and is .zarr", async () => {
-            // Arrange
-            const filePath = "file.zarr";
-            const detail = new FileDetail(
-                { ...metadata, file_path: filePath, thumbnail: undefined },
-                Environment.TEST
-            );
+        ["http://thumbnail.zarr", "s3://thumbnail.zarr/"].forEach((filePath) => {
+            it(`returns rendered zarr thumbnail when missing thumbnail and path is .zarr: ${filePath}`, async () => {
+                // Arrange
+                const detail = new FileDetail(
+                    { ...metadata, file_path: filePath, thumbnail: undefined },
+                    Environment.TEST
+                );
 
-            // Act
-            const path = await detail.getPathToThumbnail();
+                // Act
+                const path = await detail.getPathToThumbnail();
 
-            // Assert
-            expect(path).to.be.equal(filePath);
+                // Assert
+                expect(path).to.be.equal(renderedOmeZarrThumbnailURL);
+            });
         });
 
-        it("returns undefined when thumbnail is invalid type", async () => {
-            // Arrange
-            const thumbnail = "thumbnail.blah";
-            const detail = new FileDetail({ ...metadata, thumbnail }, Environment.TEST);
+        ["https://idr-example/webclient/render_thumbnail/1921257/", "file.blah"].forEach(
+            (filePath) => {
+                it(`returns undefined when missing thumbnail and path is unknown type: ${filePath}`, async () => {
+                    // Arrange
+                    const detail = new FileDetail(
+                        { ...metadata, file_path: filePath, thumbnail: undefined },
+                        Environment.TEST
+                    );
 
-            // Act
-            const path = await detail.getPathToThumbnail();
+                    // Act
+                    const path = await detail.getPathToThumbnail();
 
-            // Assert
-            expect(path).to.be.undefined;
-        });
-
-        it("returns undefined when path is invalid type and thumbnail missing", async () => {
-            // Arrange
-            const filePath = "file.blah";
-            const detail = new FileDetail(
-                { ...metadata, file_path: filePath, thumbnail: undefined },
-                Environment.TEST
-            );
-
-            // Act
-            const path = await detail.getPathToThumbnail();
-
-            // Assert
-            expect(path).to.be.undefined;
-        });
+                    // Assert
+                    expect(path).to.be.undefined;
+                });
+            }
+        );
     });
 });


### PR DESCRIPTION
## Context
Will Moore reported that the thumbnails supplied via IDR were not rendering in BFF like they were previously. This was due to a recent change that was intended to broaden the amount of thumbnails rendered by attempting to render the path when the thumbnail wasn't available. However, the same changeset had the unintended inclusion of making the `getPathToThumbnail` method return `undefined` when the file path was of an unknown type which is the case for thumbnails supplied via IDR (ex. "https:/.../webclient/render_thumbnail/1921257/").

## Changes
This reverts the unintended portion of the changeset aforementioned by making `getPathToThumbnail` return the `thumbnail` property even when we aren't sure what the type is.

## Testing
Added several new tests to broaden coverage to hopefully prevent thumbnail feature regression like this going forward.

As of writing this, this is deployed to staging for triple checking. [Try it out here with the dataset with the issue](https://staging.bff.allencell.org/app?c=index%3A0.25%2Cimage_webclient_url%3A0.25%2CFile+Path%3A0.25%2CThumbnail%3A0.25&source=%7B%22uri%22%3A%22https%3A%2F%2Fidr.openmicroscopy.org%2Fsearchengine%2Fapi%2Fv1%2Fresources%2Fcontainer_bff_data%2F%3Fcontainer_name%3Didr0010-doil-dnadamage%2FscreenA%26container_type%3Dscreen%26file_type%3Dparquet%22%2C%22type%22%3A%22parquet%22%2C%22name%22%3A%22idr0010-doil-dnadamage%2FscreenA.parquet%22%7D)

### Before
<img width="616" height="386" alt="Screenshot 2026-03-16 at 11 07 43 AM" src="https://github.com/user-attachments/assets/1fb9b6d9-7c96-4e27-8a79-8185e7965e76" />

### After
<img width="811" height="449" alt="Screenshot 2026-03-16 at 11 09 24 AM" src="https://github.com/user-attachments/assets/bfe86a58-76d7-40ba-8a78-a1b9d47efa8a" />
