### PR TITLE
Fix improper merge: No quotes around parquet_scan()

### DIFF
--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -86,8 +86,6 @@ export function getParquetFileNameSelectPart(
  */
 export default abstract class DatabaseService {
     public static readonly LIST_DELIMITER = ",";
-    // Name of the hidden column BFF uses to uniquely identify rows
-    public static readonly HIDDEN_UID_ANNOTATION = "hidden_bff_uid";
     protected readonly SOURCE_METADATA_TABLE = "source_metadata";
     protected readonly SOURCE_PROVENANCE_TABLE = "source_provenance";
     private static readonly ANNOTATION_TYPE_SET = new Set(Object.values(AnnotationType));
@@ -544,8 +542,8 @@ export default abstract class DatabaseService {
         // Note: we don't use this.getColumnsOnDataSource, since that expects a
         // fully built data source, and this function is used for creating a
         // data source.
-        const sql = new SQLBuilder().describe().from(`parquet_scan("${name}")`);
-        const rows = await this.query(sql.toSQL()).promise;
+        const sql = `DESCRIBE SELECT * FROM parquet_scan("${name}")`;
+        const rows = await this.query(sql).promise;
         const rawColumns = rows.map((row) => row["column_name"] as string);
         // 2. Determine which columns need to be renamed, if any
         const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);


### PR DESCRIPTION
## Context
When I merged #671 I resolved a merge conflict improperly and didn't do manual testing afterwards!

## Changes
* Don't use SQLBuilder for queries from `parquet_scan()` because it will put double quotes around the `parquet_scan()`
* Remove unused HIDDEN_UID_ANNOTATION variabl

## Testing
* Open a [parquet from S3](http://localhost:9001/app?c=File+Name%3A0.25%2Cabundance_stoichiometry%3A0.25%2CCell+Line%3A0.25%2CColony+Position%3A0.25&source=%7B%22name%22%3A%22ibid.parquet+%282%2F9%2F2026+12%3A39%3A37+PM%29.parquet%22%2C%22type%22%3A%22parquet%22%2C%22uri%22%3A%22https%3A%2F%2Fstaging-biofile-finder-datasets.s3.us-west-2.amazonaws.com%2Fibid.parquet%22%2C%22mode%22%3A%22DIRECT_FROM_PARQUET%22%7D), then copy-paste the URL into a new tab. (This is failing on main.)