### PR TITLE
Manage localstorage cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "redux": "4.0.x",
         "redux-logic": "3.x",
         "reselect": "4.0.x",
+        "semver": "7.7.x",
         "streamsaver": "2.0.x",
         "string-natural-compare": "3.0.x"
       },
@@ -73,6 +74,7 @@
         "@types/react-syntax-highlighter": "13.5.x",
         "@types/react-window": "1.8.x",
         "@types/react-window-infinite-loader": "1.0.x",
+        "@types/semver": "7.7.x",
         "@types/sinon": "10.x",
         "@types/streamsaver": "2.0.x",
         "@types/string-natural-compare": "3.0.x",
@@ -273,6 +275,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
@@ -320,6 +332,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
@@ -342,6 +364,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
@@ -358,6 +390,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1839,6 +1881,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -2439,6 +2491,16 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@electron/notarize": {
@@ -4357,19 +4419,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
@@ -4486,19 +4535,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
@@ -4524,19 +4560,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -5249,19 +5272,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -5851,6 +5861,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-loader/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
@@ -5864,6 +5884,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
@@ -7113,18 +7143,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/conf/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/config-file-ts": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
@@ -7468,19 +7486,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/css-modules-require-hook": {
@@ -10010,6 +10015,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -10919,19 +10934,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -11419,20 +11421,6 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -14920,6 +14908,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
@@ -16639,19 +16637,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
@@ -18346,13 +18331,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -18747,19 +18734,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -21495,18 +21469,16 @@
     },
     "packages/desktop": {
       "name": "fms-file-explorer-desktop",
-      "version": "8.8.1",
+      "version": "8.9.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",
         "@aics/frontend-insights-plugin-amplitude-node": "0.2.x",
         "electron-store": "8.0.x",
         "regenerator-runtime": "0.13.x",
-        "semver": "7.3.x",
         "webpack-node-externals": "^3.0.0"
       },
       "devDependencies": {
-        "@types/semver": "7.3.x",
         "babel-loader": "8.2.x",
         "clean-webpack-plugin": "4.x",
         "css-loader": "6.x",
@@ -21528,40 +21500,6 @@
         "webpack-dev-server": "4.x",
         "xvfb-maybe": "0.2.x"
       }
-    },
-    "packages/desktop/node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/desktop/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/desktop/node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/desktop/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "packages/web": {
       "name": "biofile-finder",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21495,7 +21495,7 @@
     },
     "packages/desktop": {
       "name": "fms-file-explorer-desktop",
-      "version": "8.8.0",
+      "version": "8.8.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/react-syntax-highlighter": "13.5.x",
     "@types/react-window": "1.8.x",
     "@types/react-window-infinite-loader": "1.0.x",
+    "@types/semver": "7.7.x",
     "@types/sinon": "10.x",
     "@types/streamsaver": "2.0.x",
     "@types/string-natural-compare": "3.0.x",
@@ -100,6 +101,7 @@
     "redux": "4.0.x",
     "redux-logic": "3.x",
     "reselect": "4.0.x",
+    "semver": "7.7.x",
     "streamsaver": "2.0.x",
     "string-natural-compare": "3.0.x"
   }

--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -13,6 +13,7 @@ import TutorialTooltip from "./components/TutorialTooltip";
 import { Environment } from "./constants";
 import useCheckForScreenSizeChange from "./hooks/useCheckForScreenSizeChange";
 import useCheckForUpdates from "./hooks/useCheckForUpdates";
+import useUpdateHasUsedApp from "./hooks/useUpdateHasUsedApp";
 import useLayoutMeasurements from "./hooks/useLayoutMeasurements";
 import useUnsavedDataWarning from "./hooks/useUnsavedDataWarning";
 import { interaction, selection } from "./state";
@@ -50,6 +51,7 @@ export default function App(props: AppProps) {
     >();
 
     useCheckForUpdates();
+    useUpdateHasUsedApp();
     useUnsavedDataWarning();
     useCheckForScreenSizeChange(measuredWidth);
 

--- a/packages/core/hooks/useUpdateHasUsedApp.ts
+++ b/packages/core/hooks/useUpdateHasUsedApp.ts
@@ -1,15 +1,16 @@
 import * as React from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { PersistedConfigKeys } from "../services";
-import { markAsUsedApplicationBefore } from "../state/interaction/actions";
+import { interaction } from "../state";
 import { runAllTutorials } from "../state/selection/actions";
-import PersistentConfigServiceWeb from "../../web/src/services/PersistentConfigServiceWeb";
 
 export default () => {
     const dispatch = useDispatch();
+    const { persistentConfigService } = useSelector(
+        interaction.selectors.getPlatformDependentServices
+    );
     React.useEffect(() => {
-        const persistentConfigService = new PersistentConfigServiceWeb();
         // Check localstorage cookies
         const hasUsedApp = persistentConfigService.get(
             PersistedConfigKeys.HasUsedApplicationBefore
@@ -19,8 +20,8 @@ export default () => {
             dispatch(runAllTutorials());
 
             // Mark as true for next time
-            dispatch(markAsUsedApplicationBefore());
+            dispatch(interaction.actions.markAsUsedApplicationBefore());
             persistentConfigService.persist(PersistedConfigKeys.HasUsedApplicationBefore, true);
         }
-    }, [dispatch]);
+    }, [dispatch, persistentConfigService]);
 };

--- a/packages/core/hooks/useUpdateHasUsedApp.ts
+++ b/packages/core/hooks/useUpdateHasUsedApp.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { useDispatch } from "react-redux";
+
+import { PersistedConfigKeys } from "../services";
+import { markAsUsedApplicationBefore } from "../state/interaction/actions";
+import PersistentConfigServiceWeb from "../../web/src/services/PersistentConfigServiceWeb";
+
+export default () => {
+    const dispatch = useDispatch();
+    React.useEffect(() => {
+        const persistentConfigService = new PersistentConfigServiceWeb();
+        // Check localstorage cookies
+        const hasUsedApp = persistentConfigService.get(
+            PersistedConfigKeys.HasUsedApplicationBefore
+        );
+        if (!hasUsedApp) {
+            // Mark as true for next time
+            dispatch(markAsUsedApplicationBefore);
+            persistentConfigService.persist(PersistedConfigKeys.HasUsedApplicationBefore, true);
+        }
+    }, [dispatch]);
+};

--- a/packages/core/hooks/useUpdateHasUsedApp.ts
+++ b/packages/core/hooks/useUpdateHasUsedApp.ts
@@ -2,8 +2,7 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { PersistedConfigKeys } from "../services";
-import { interaction } from "../state";
-import { runAllTutorials } from "../state/selection/actions";
+import { interaction, selection } from "../state";
 
 export default () => {
     const dispatch = useDispatch();
@@ -17,7 +16,7 @@ export default () => {
         );
         if (!hasUsedApp) {
             // If first time using app, start running tutorials
-            dispatch(runAllTutorials());
+            dispatch(selection.actions.runAllTutorials());
 
             // Mark as true for next time
             dispatch(interaction.actions.markAsUsedApplicationBefore());

--- a/packages/core/hooks/useUpdateHasUsedApp.ts
+++ b/packages/core/hooks/useUpdateHasUsedApp.ts
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 
 import { PersistedConfigKeys } from "../services";
 import { markAsUsedApplicationBefore } from "../state/interaction/actions";
+import { runAllTutorials } from "../state/selection/actions";
 import PersistentConfigServiceWeb from "../../web/src/services/PersistentConfigServiceWeb";
 
 export default () => {
@@ -14,6 +15,9 @@ export default () => {
             PersistedConfigKeys.HasUsedApplicationBefore
         );
         if (!hasUsedApp) {
+            // If first time using app, start running tutorials
+            dispatch(runAllTutorials());
+
             // Mark as true for next time
             dispatch(markAsUsedApplicationBefore());
             persistentConfigService.persist(PersistedConfigKeys.HasUsedApplicationBefore, true);

--- a/packages/core/hooks/useUpdateHasUsedApp.ts
+++ b/packages/core/hooks/useUpdateHasUsedApp.ts
@@ -15,7 +15,7 @@ export default () => {
         );
         if (!hasUsedApp) {
             // Mark as true for next time
-            dispatch(markAsUsedApplicationBefore);
+            dispatch(markAsUsedApplicationBefore());
             persistentConfigService.persist(PersistedConfigKeys.HasUsedApplicationBefore, true);
         }
     }, [dispatch]);

--- a/packages/core/services/PersistentConfigService/PersistentConfigServiceNoop.ts
+++ b/packages/core/services/PersistentConfigService/PersistentConfigServiceNoop.ts
@@ -1,0 +1,19 @@
+import PersistentConfigService, { PersistedConfig } from ".";
+
+export default class PersistentConfigServiceNoop implements PersistentConfigService {
+    public get() {
+        return Promise.resolve();
+    }
+
+    public getAll(): PersistedConfig {
+        return {};
+    }
+
+    public clear() {
+        return Promise.resolve();
+    }
+
+    public persist() {
+        return Promise.resolve();
+    }
+}

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -5,6 +5,7 @@ import ExecutionEnvService from "./ExecutionEnvService";
 import FileDownloadService from "./FileDownloadService";
 import FileViewerService from "./FileViewerService";
 import NotificationService from "./NotificationService";
+import PersistentConfigService from "./PersistentConfigService";
 
 export { default as AnnotationService } from "./AnnotationService";
 export type { default as ApplicationInfoService } from "./ApplicationInfoService";
@@ -36,4 +37,5 @@ export interface PlatformDependentServices {
     frontendInsights: FrontendInsights;
     executionEnvService: ExecutionEnvService;
     notificationService: NotificationService;
+    persistentConfigService: PersistentConfigService;
 }

--- a/packages/core/state/interaction/reducer.ts
+++ b/packages/core/state/interaction/reducer.ts
@@ -52,6 +52,7 @@ import FileDownloadServiceNoop from "../../services/FileDownloadService/FileDown
 import FileViewerServiceNoop from "../../services/FileViewerService/FileViewerServiceNoop";
 import ExecutionEnvServiceNoop from "../../services/ExecutionEnvService/ExecutionEnvServiceNoop";
 import { UserSelectedApplication } from "../../services/PersistentConfigService";
+import PersistentConfigServiceNoop from "../../services/PersistentConfigService/PersistentConfigServiceNoop";
 import NotificationServiceNoop from "../../services/NotificationService/NotificationServiceNoop";
 import DatabaseServiceNoop from "../../services/DatabaseService/DatabaseServiceNoop";
 import PublicDataset from "../../../web/src/entity/PublicDataset";
@@ -124,6 +125,7 @@ export const initialState: InteractionStateBranch = {
         }),
         executionEnvService: new ExecutionEnvServiceNoop(),
         notificationService: new NotificationServiceNoop(),
+        persistentConfigService: new PersistentConfigServiceNoop(),
     },
     extractMetadataPythonSnippet: { setup: "", code: "" },
     convertFilesSnippet: { setup: "", code: "", options: {} },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -61,7 +61,6 @@
   "author": "Allen Institute for Cell Science",
   "license": "SEE LICENSE IN LICENSE.txt",
   "devDependencies": {
-    "@types/semver": "7.3.x",
     "babel-loader": "8.2.x",
     "clean-webpack-plugin": "4.x",
     "css-loader": "6.x",
@@ -88,7 +87,6 @@
     "@aics/frontend-insights-plugin-amplitude-node": "0.2.x",
     "electron-store": "8.0.x",
     "regenerator-runtime": "0.13.x",
-    "semver": "7.3.x",
     "webpack-node-externals": "^3.0.0"
   }
 }

--- a/packages/web/src/components/Header/Menu.tsx
+++ b/packages/web/src/components/Header/Menu.tsx
@@ -1,12 +1,11 @@
 import { DirectionalHint, PrimaryButton as PrimaryFluent } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { Link, useLocation } from "react-router-dom";
 
 import { PrimaryButton, TertiaryButton, useButtonMenu } from "../../../../core/components/Buttons";
 import useHelpOptions from "../../../../core/hooks/useHelpOptions";
-import { interaction, selection } from "../../../../core/state";
 
 import styles from "./Menu.module.css";
 
@@ -15,7 +14,6 @@ import styles from "./Menu.module.css";
  */
 export default function Menu() {
     const dispatch = useDispatch();
-    const navigate = useNavigate();
     const currentPath = useLocation().pathname;
     const isApp: boolean = currentPath == "/app";
     const helpMenuOptions = useHelpOptions(dispatch, true, isApp);
@@ -23,13 +21,6 @@ export default function Menu() {
         items: helpMenuOptions,
         directionalHint: DirectionalHint.bottomAutoEdge,
     });
-    const hasUsedApp = useSelector(interaction.selectors.hasUsedApplicationBefore);
-    const launchApp = () => {
-        navigate({ pathname: "/app" });
-        if (!hasUsedApp) {
-            dispatch(selection.actions.runAllTutorials());
-        }
-    };
 
     return (
         <>
@@ -59,12 +50,13 @@ export default function Menu() {
                     text="Help"
                 />
                 {currentPath !== "/app" && (
-                    <PrimaryButton
-                        onClick={launchApp}
-                        className={styles.startButton}
-                        title="Get started in the app"
-                        text="LAUNCH APP"
-                    />
+                    <Link to="app">
+                        <PrimaryButton
+                            className={styles.startButton}
+                            title="Get started in the app"
+                            text="LAUNCH APP"
+                        />
+                    </Link>
                 )}
             </div>
             <div className={styles.smallMenu}>

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -12,6 +12,7 @@ import DatabaseServiceWeb from "./services/DatabaseServiceWeb";
 import ExecutionEnvServiceWeb from "./services/ExecutionEnvServiceWeb";
 import FileViewerServiceWeb from "./services/FileViewerServiceWeb";
 import FileDownloadServiceWeb from "./services/FileDownloadServiceWeb";
+import PersistentConfigServiceWeb from "./services/PersistentConfigServiceWeb";
 import ErrorPage from "./components/ErrorPage";
 import Learn from "./components/Learn";
 import Home from "./components/Home";
@@ -58,6 +59,7 @@ const router = createBrowserRouter(
 );
 
 async function asyncRender() {
+    const persistentConfigService = new PersistentConfigServiceWeb();
     const databaseService = new DatabaseServiceWeb();
     await databaseService.initialize();
 
@@ -73,6 +75,7 @@ async function asyncRender() {
     }));
     const store = createReduxStore({
         isOnWeb: true,
+        persistedConfig: persistentConfigService.getAll(),
         platformDependentServices: collectPlatformDependentServices(),
     });
     render(

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -72,6 +72,7 @@ async function asyncRender() {
         applicationInfoService: new ApplicationInfoServiceWeb(),
         fileViewerService: new FileViewerServiceWeb(),
         fileDownloadService: new FileDownloadServiceWeb(new S3StorageService()),
+        persistentConfigService,
     }));
     const store = createReduxStore({
         isOnWeb: true,

--- a/packages/web/src/services/PersistentConfigServiceWeb.ts
+++ b/packages/web/src/services/PersistentConfigServiceWeb.ts
@@ -1,0 +1,49 @@
+import {
+    PersistentConfigService,
+    PersistedConfig,
+    PersistedConfigKeys,
+} from "../../../core/services";
+
+interface PersistentConfigServiceWebOptions {
+    clearExistingData?: boolean;
+}
+
+// Use browser localstorage to persist data between sessions
+export default class PersistentConfigServiceWeb implements PersistentConfigService {
+    public constructor(options: PersistentConfigServiceWebOptions = {}) {
+        if (options.clearExistingData) {
+            localStorage.clear();
+        }
+    }
+
+    public get(key: PersistedConfigKeys): any {
+        return localStorage.getItem(key);
+    }
+
+    public getAll(): PersistedConfig {
+        return Object.values(PersistedConfigKeys).reduce(
+            (config: PersistedConfig, key) => ({
+                ...config,
+                [key as string]: this.get(key),
+            }),
+            {}
+        );
+    }
+    public clear(): void {
+        localStorage.clear();
+    }
+
+    public persist(config: PersistedConfig): void;
+    public persist(key: PersistedConfigKeys, value: any): void;
+    public persist(arg: PersistedConfigKeys | PersistedConfig, value?: any) {
+        if (typeof arg === "object") {
+            Object.entries(arg as PersistedConfig).forEach(([key, value]) => {
+                this.persist(key as PersistedConfigKeys, value);
+            });
+        } else if (value === undefined || value === null) {
+            localStorage.removeItem(arg);
+        } else {
+            localStorage.setItem(arg, value);
+        }
+    }
+}

--- a/packages/web/src/services/PersistentConfigServiceWeb.ts
+++ b/packages/web/src/services/PersistentConfigServiceWeb.ts
@@ -1,3 +1,5 @@
+import { lt, valid } from "semver";
+
 import {
     PersistentConfigService,
     PersistedConfig,
@@ -8,16 +10,44 @@ interface PersistentConfigServiceWebOptions {
     clearExistingData?: boolean;
 }
 
+// Manually manage version
+const CURRENT_VERSION = "1.0.0";
+const VERSION_KEY = "BFF_PERSISTED_CONFIG_VERSION";
+
 // Use browser localstorage to persist data between sessions
 export default class PersistentConfigServiceWeb implements PersistentConfigService {
     public constructor(options: PersistentConfigServiceWebOptions = {}) {
         if (options.clearExistingData) {
             localStorage.clear();
         }
+        // Check if localStorage has a stale version number
+        const storedVersion = localStorage.getItem(VERSION_KEY);
+        if (storedVersion !== CURRENT_VERSION) {
+            this.migrate(storedVersion);
+            // Update to new version
+            localStorage.setItem(VERSION_KEY, CURRENT_VERSION);
+        }
     }
 
-    public get(key: PersistedConfigKeys): any {
-        return localStorage.getItem(key);
+    // Handle version migrations.
+    // If we deprecate keys in the future, we can use this method to
+    // remove/update values as needed, e.g.,
+    //   if (gt(oldVersion, "1.0.1")) { // old version > 1.0.1
+    //.    if (localStorage.getItem(PersistedConfigKeys.DeprecatedKey)) {
+    //       localStorage.removeItem(PersistedConfigKeys.DeprecatedKey);
+    //     }
+    //   }
+    private migrate(oldVersion: string | null) {
+        // If invalid version, cannot validate stored keys
+        if (!oldVersion || lt(oldVersion, "0.0.0") || !valid(oldVersion)) {
+            this.clear();
+        }
+        return;
+    }
+
+    // localStorage only stores strings
+    public get(key: PersistedConfigKeys): string | undefined {
+        return localStorage.getItem(key) ?? undefined; // prefer undefined over null to match parent class
     }
 
     public getAll(): PersistedConfig {
@@ -29,12 +59,13 @@ export default class PersistentConfigServiceWeb implements PersistentConfigServi
             {}
         );
     }
+
     public clear(): void {
         localStorage.clear();
     }
 
     public persist(config: PersistedConfig): void;
-    public persist(key: PersistedConfigKeys, value: any): void;
+    public persist(key: PersistedConfigKeys, value?: string): void;
     public persist(arg: PersistedConfigKeys | PersistedConfig, value?: any) {
         if (typeof arg === "object") {
             Object.entries(arg as PersistedConfig).forEach(([key, value]) => {
@@ -43,6 +74,7 @@ export default class PersistentConfigServiceWeb implements PersistentConfigServi
         } else if (value === undefined || value === null) {
             localStorage.removeItem(arg);
         } else {
+            // setItem only accepts strings
             localStorage.setItem(arg, value);
         }
     }

--- a/packages/web/src/services/test/PersistentConfigServiceWeb.test.ts
+++ b/packages/web/src/services/test/PersistentConfigServiceWeb.test.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+
+import { PersistedConfigKeys } from "../../../../core/services";
+import PersistentConfigServiceWeb from "../PersistentConfigServiceWeb";
+
+describe("PersistentConfigServiceWeb", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe("get", () => {
+        it("retrieves from localStorage", () => {
+            // Arrange
+            const expectedValue = "test value";
+            const service = new PersistentConfigServiceWeb();
+            localStorage.setItem(PersistedConfigKeys.HasUsedApplicationBefore, expectedValue);
+
+            // Act
+            const actualValue = service.get(PersistedConfigKeys.HasUsedApplicationBefore);
+
+            // Assert
+            expect(actualValue).to.equal(expectedValue);
+        });
+
+        it("returns undefined when key does not exist", () => {
+            // Arrange
+            const service = new PersistentConfigServiceWeb({ clearExistingData: true });
+
+            // Act
+            const actual = service.get(PersistedConfigKeys.ImageJExecutable);
+
+            // Assert
+            expect(actual).to.be.undefined;
+        });
+    });
+
+    describe("getAll", () => {
+        // Currently just a smoke test since we only store one key so far in web
+        it("retrieves all persisted keys", () => {
+            // Arrange
+            const service = new PersistentConfigServiceWeb();
+            localStorage.setItem(PersistedConfigKeys.HasUsedApplicationBefore, "true");
+
+            // Act
+            const persistedKeys = service.getAll();
+            const keysWithValues = Object.values(persistedKeys).filter((val) => val != undefined);
+
+            // Assert
+            expect(Object.values(persistedKeys).length).to.equal(
+                Object.values(PersistedConfigKeys).length
+            );
+            expect(keysWithValues.length).to.equal(1);
+        });
+    });
+
+    describe("persist", () => {
+        it(`persists valid ${PersistedConfigKeys.HasUsedApplicationBefore}`, () => {
+            // Arrange
+            const service = new PersistentConfigServiceWeb({ clearExistingData: true });
+            const expected = "true";
+
+            // Act
+            service.persist(PersistedConfigKeys.HasUsedApplicationBefore, "true");
+
+            // Assert
+            const actual = service.get(PersistedConfigKeys.HasUsedApplicationBefore);
+            expect(actual).to.equal(expected);
+        });
+
+        it("clears keys when value is undefined", () => {
+            // Arrange
+            const service = new PersistentConfigServiceWeb();
+
+            // consistency check
+            service.persist(PersistedConfigKeys.HasUsedApplicationBefore, "true");
+            const intermediateValue = service.get(PersistedConfigKeys.HasUsedApplicationBefore);
+            expect(intermediateValue).to.equal("true");
+
+            // Act
+            service.persist(PersistedConfigKeys.HasUsedApplicationBefore, undefined);
+            const actual = service.get(PersistedConfigKeys.HasUsedApplicationBefore);
+
+            // Assert
+            expect(actual).to.be.undefined;
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     // Make sure specific type definition APIs are available on compile.
     // Specifically added for WebWorker API, but seems that listing that one
     // makes adding ESNext also necessary
-    "lib": ["WebWorker", "ESNext"],
+    "lib": ["WebWorker", "ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "preserveConstEnums": true,


### PR DESCRIPTION
## Context
Although we did have a variable in state for storing whether a user has visited the app before, we weren't actually using it. This meant that the tutorials were showing up every time a user navigated from the website to the app, instead of just their first time.

## Changes
Implements `PersistentConfigService` for web (previously only implemented for desktop) so that we can manage `localstorage` cookies.
Also adds a hook in the app that both updates the "has used app before" cookie and launches the tutorials. This means that the tutorials now also launch when a first-time user is sent a link that goes directly to the app itself.

## Testing
Manually verified (in incognito) that the tutorials launch when it's a user's first time visiting the app, and not any following times. 
