### PR TITLE
Feature/718 read deltalake

### DIFF
--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -6,8 +6,7 @@ import { useDropzone } from "react-dropzone";
 
 import { SecondaryButton, TertiaryButton, TransparentIconButton } from "../Buttons";
 import Tooltip from "../Tooltip";
-import { Source, parseSourceUrl } from "../../entity/SearchParams";
-import DeltaTableService from "../../services/DeltaTableService";
+import { Source, resolveNameAndTypeFromSourceUrl } from "../../entity/SearchParams";
 
 import styles from "./FilePrompt.module.css";
 
@@ -78,27 +77,8 @@ export default function FilePrompt(props: Props) {
         async (evt?: React.FormEvent) => {
             evt?.preventDefault();
             if (dataSourceURL) {
-                const parsed = parseSourceUrl(dataSourceURL);
-                const deltaTableService = new DeltaTableService();
-                let type: Source["type"];
-
-                if (parsed.shouldProbeForDelta) {
-                    const isDelta = await deltaTableService.isDeltaTableRoot(
-                        parsed.pathWithoutParams
-                    );
-                    type = isDelta ? "delta" : "csv";
-                } else {
-                    type = parsed.extensionGuess || "csv";
-                    if (!parsed.extensionGuess) {
-                        console.warn(
-                            "Assuming the source is csv since no extension was recognized"
-                        );
-                    }
-                }
-
                 props.onSelectFile({
-                    name: parsed.name,
-                    type,
+                    ...(await resolveNameAndTypeFromSourceUrl(dataSourceURL)),
                     uri: dataSourceURL,
                 });
             }

--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -6,7 +6,12 @@ import { useDropzone } from "react-dropzone";
 
 import { SecondaryButton, TertiaryButton, TransparentIconButton } from "../Buttons";
 import Tooltip from "../Tooltip";
-import { Source, getNameAndTypeFromSourceUrl } from "../../entity/SearchParams";
+import {
+    Source,
+    getNameAndTypeFromSourceUrl,
+    resolveNameAndTypeFromSourceUrl,
+    shouldProbeForDeltaSourceUrl,
+} from "../../entity/SearchParams";
 
 import styles from "./FilePrompt.module.css";
 
@@ -74,9 +79,17 @@ export default function FilePrompt(props: Props) {
     }, [fileRejections]);
 
     const onEnterURL = throttle(
-        (evt?: React.FormEvent) => {
+        async (evt?: React.FormEvent) => {
             evt?.preventDefault();
             if (dataSourceURL) {
+                if (shouldProbeForDeltaSourceUrl(dataSourceURL)) {
+                    props.onSelectFile({
+                        ...(await resolveNameAndTypeFromSourceUrl(dataSourceURL)),
+                        uri: dataSourceURL,
+                    });
+                    return;
+                }
+
                 props.onSelectFile({
                     ...getNameAndTypeFromSourceUrl(dataSourceURL),
                     uri: dataSourceURL,

--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -6,12 +6,8 @@ import { useDropzone } from "react-dropzone";
 
 import { SecondaryButton, TertiaryButton, TransparentIconButton } from "../Buttons";
 import Tooltip from "../Tooltip";
-import {
-    Source,
-    getNameAndTypeFromSourceUrl,
-    resolveNameAndTypeFromSourceUrl,
-    shouldProbeForDeltaSourceUrl,
-} from "../../entity/SearchParams";
+import { Source, parseSourceUrl } from "../../entity/SearchParams";
+import DeltaTableService from "../../services/DeltaTableService";
 
 import styles from "./FilePrompt.module.css";
 
@@ -82,16 +78,27 @@ export default function FilePrompt(props: Props) {
         async (evt?: React.FormEvent) => {
             evt?.preventDefault();
             if (dataSourceURL) {
-                if (shouldProbeForDeltaSourceUrl(dataSourceURL)) {
-                    props.onSelectFile({
-                        ...(await resolveNameAndTypeFromSourceUrl(dataSourceURL)),
-                        uri: dataSourceURL,
-                    });
-                    return;
+                const parsed = parseSourceUrl(dataSourceURL);
+                const deltaTableService = new DeltaTableService();
+                let type: Source["type"];
+
+                if (parsed.shouldProbeForDelta) {
+                    const isDelta = await deltaTableService.isDeltaTableRoot(
+                        parsed.pathWithoutParams
+                    );
+                    type = isDelta ? "delta" : "csv";
+                } else {
+                    type = parsed.extensionGuess || "csv";
+                    if (!parsed.extensionGuess) {
+                        console.warn(
+                            "Assuming the source is csv since no extension was recognized"
+                        );
+                    }
                 }
 
                 props.onSelectFile({
-                    ...getNameAndTypeFromSourceUrl(dataSourceURL),
+                    name: parsed.name,
+                    type,
                     uri: dataSourceURL,
                 });
             }

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -122,7 +122,7 @@ export default function DataSourcePrompt(props: Props) {
                     [styles.datasourceSubhead]: !props?.isModal,
                 })}
             >
-                Load a CSV, Parquet, or JSON file containing the metadata key-value pairs
+                Load a CSV, Parquet, JSON, or Delta table containing metadata key-value pairs
                 (annotations) associated with your files.
             </p>
             <div className={styles.filePromptOuterWrapper}>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -122,8 +122,8 @@ export default function DataSourcePrompt(props: Props) {
                     [styles.datasourceSubhead]: !props?.isModal,
                 })}
             >
-                Load a CSV, Parquet, JSON, or Delta table containing metadata key-value pairs
-                (annotations) associated with your files.
+                Load a CSV, Parquet(PyArrow or Deltalake), or JSON table containing metadata
+                key-value pairs (annotations) associated with your files.
             </p>
             <div className={styles.filePromptOuterWrapper}>
                 <FilePrompt

--- a/packages/core/components/DataSourcePrompt/test/DataSourcePrompt.test.tsx
+++ b/packages/core/components/DataSourcePrompt/test/DataSourcePrompt.test.tsx
@@ -1,5 +1,5 @@
 import { configureMockStore } from "@aics/redux-utils";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { expect } from "chai";
 import * as React from "react";
 import { Provider } from "react-redux";
@@ -20,7 +20,7 @@ describe("<DataSourcePrompt />", () => {
         expect(loadButton?.hasAttribute("disabled")).to.be.true;
     });
 
-    it("enables the load button after a file is selected", () => {
+    it("enables the load button after a file is selected", async () => {
         // Arrange
         const { store } = configureMockStore({ state: initialState });
         const { getByText, getByRole, getByTestId } = render(
@@ -43,10 +43,12 @@ describe("<DataSourcePrompt />", () => {
 
         // Assert
         const loadButton = getByText(/LOAD/).closest("button");
-        expect(loadButton?.hasAttribute("disabled")).to.be.false;
+        await waitFor(() => {
+            expect(loadButton?.hasAttribute("disabled")).to.be.false;
+        });
     });
 
-    it("can distinguish between two FilePrompt components when advanced options are open", () => {
+    it("can distinguish between two FilePrompt components when advanced options are open", async () => {
         const { store } = configureMockStore({ state: initialState, reducer });
         const { getByText, getByTestId, getAllByText, getAllByRole } = render(
             <Provider store={store}>
@@ -75,9 +77,11 @@ describe("<DataSourcePrompt />", () => {
         }
 
         // Only the first prompt still renders
-        expect(getAllByText(/click to browse/).length).to.equal(1);
-        expect(getByTestId("urlform-file-prompt-main")).to.exist;
-        expect(() => getByTestId("urlform-file-prompt-metadata-main")).to.throw;
+        await waitFor(() => {
+            expect(getAllByText(/click to browse/).length).to.equal(1);
+            expect(getByTestId("urlform-file-prompt-main")).to.exist;
+            expect(() => getByTestId("urlform-file-prompt-metadata-main")).to.throw;
+        });
     });
 
     it("hides the advanced guidance info by default", () => {

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -28,7 +28,6 @@ type ParsedSourceUrl = {
     extensionGuess?: ResolvedSourceType;
     name: string;
     pathWithoutParams: string;
-    shouldProbeForDelta: boolean;
 };
 
 // Components of the application state this captures
@@ -95,11 +94,7 @@ export function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
         (validSourcetype) => validSourcetype === uriResource.split(".").pop()
     );
 
-    // For directory-like URLs (trailing slash, no recognised extension), probe the network
-    // to determine whether the root is a delta table.
-    const shouldProbeForDelta = extensionGuess === undefined && dataSourceURL.endsWith("/");
-
-    return { extensionGuess, name, pathWithoutParams, shouldProbeForDelta };
+    return { extensionGuess, name, pathWithoutParams };
 }
 
 export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
@@ -110,25 +105,23 @@ export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
     return { name, type: extensionGuess || "csv" };
 };
 
-export const shouldProbeForDeltaSourceUrl = (dataSourceURL: string) =>
-    parseSourceUrl(dataSourceURL).shouldProbeForDelta;
-
 export const resolveNameAndTypeFromSourceUrl = async (
     dataSourceURL: string,
     deltaTableService: Pick<DeltaTableService, "isDeltaTableRoot"> = new DeltaTableService()
 ) => {
-    const { extensionGuess, name, pathWithoutParams, shouldProbeForDelta } = parseSourceUrl(
-        dataSourceURL
-    );
+    const { extensionGuess, name, pathWithoutParams } = parseSourceUrl(dataSourceURL);
     if (extensionGuess) {
         return { name, type: extensionGuess };
     }
 
-    if (shouldProbeForDelta && (await deltaTableService.isDeltaTableRoot(pathWithoutParams))) {
+    if (
+        pathWithoutParams.endsWith("/") &&
+        (await deltaTableService.isDeltaTableRoot(pathWithoutParams))
+    ) {
         return { name, type: "delta" as const };
     }
 
-    console.warn("Assuming the source is csv since no extension was recognized");
+    console.warn("Assuming the source is csv since no extension/format was recognized");
     return { name, type: "csv" as const };
 };
 

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -83,12 +83,11 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 
-function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
+export function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
     const pathWithoutParams = dataSourceURL.split(/[?#]/)[0];
     const pathSegments = pathWithoutParams.split("/").filter(Boolean);
     const lastSegment = pathSegments[pathSegments.length - 1] || pathWithoutParams;
-    const uriResource =
-        pathSegments.length > 1 ? pathSegments[pathSegments.length - 2] : lastSegment;
+    const uriResource = lastSegment;
     const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
 
     // Try to detect type from the file extension.

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -87,19 +87,9 @@ function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
     const pathWithoutParams = dataSourceURL.split(/[?#]/)[0];
     const pathSegments = pathWithoutParams.split("/").filter(Boolean);
     const lastSegment = pathSegments[pathSegments.length - 1] || pathWithoutParams;
-    const isDeltaLogPath =
-        lastSegment === "_delta_log" || pathWithoutParams.includes("/_delta_log/");
     const uriResource =
-        isDeltaLogPath && pathSegments.length > 1
-            ? pathSegments[pathSegments.length - 2]
-            : lastSegment;
+        pathSegments.length > 1 ? pathSegments[pathSegments.length - 2] : lastSegment;
     const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
-
-    // If the URL explicitly references a delta log directory, commit to delta immediately —
-    // no network probe needed.
-    if (isDeltaLogPath) {
-        return { extensionGuess: "delta", name, pathWithoutParams, shouldProbeForDelta: false };
-    }
 
     // Try to detect type from the file extension.
     const extensionGuess = ACCEPTED_SOURCE_TYPES.find(
@@ -289,10 +279,7 @@ export default class SearchParams {
         const unparsedURLs = params.getAll("url");
         return {
             ...EMPTY_QUERY_COMPONENTS,
-            sources: unparsedURLs.map((uri) => ({
-                uri,
-                ...getNameAndTypeFromSourceUrl(uri),
-            })),
+            sources: unparsedURLs.map((uri) => ({ uri, ...getNameAndTypeFromSourceUrl(uri) })),
         };
     }
 

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -3,6 +3,7 @@ import FileFilter from "../FileFilter";
 import FileFolder from "../FileFolder";
 import FileSort, { SortOrder } from "../FileSort";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
+import DeltaTableService from "../../services/DeltaTableService";
 import { Column } from "../../state/selection/actions";
 
 // These values CANNOT change otherwise it would break compatibility
@@ -20,6 +21,15 @@ export interface Source {
     type?: typeof ACCEPTED_SOURCE_TYPES[number];
     uri?: string | File;
 }
+
+type ResolvedSourceType = typeof ACCEPTED_SOURCE_TYPES[number];
+
+type ParsedSourceUrl = {
+    extensionGuess?: ResolvedSourceType;
+    name: string;
+    pathWithoutParams: string;
+    shouldProbeForDelta: boolean;
+};
 
 // Components of the application state this captures
 export interface SearchParamsComponents {
@@ -73,7 +83,7 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 
-export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
+function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
     const pathWithoutParams = dataSourceURL.split(/[?#]/)[0];
     const pathSegments = pathWithoutParams.split("/").filter(Boolean);
     const lastSegment = pathSegments[pathSegments.length - 1] || pathWithoutParams;
@@ -88,20 +98,73 @@ export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
         (validSourcetype) => validSourcetype === uriResource.split(".").pop()
     );
     if (!extensionGuess) {
-        const looksLikeDelta =
-            isDeltaLogPath ||
-            pathWithoutParams.includes("/_delta_log/") ||
-            (pathWithoutParams.endsWith("/") && uriResource.toLowerCase().includes("delta"));
+        const looksLikeDelta = isDeltaLogPath || pathWithoutParams.includes("/_delta_log/");
 
         if (looksLikeDelta) {
             extensionGuess = "delta";
-        } else {
-            console.warn("Assuming the source is csv since no extension was recognized");
-            extensionGuess = "csv";
         }
     }
-    return { name, type: extensionGuess };
+
+    const shouldProbeForDelta =
+        extensionGuess === undefined &&
+        (isDeltaLogPath ||
+            pathWithoutParams.includes("/_delta_log/") ||
+            dataSourceURL.endsWith("/"));
+
+    return { extensionGuess, name, pathWithoutParams, shouldProbeForDelta };
+}
+
+export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
+    const { extensionGuess, name } = parseSourceUrl(dataSourceURL);
+    if (!extensionGuess) {
+        console.warn("Assuming the source is csv since no extension was recognized");
+    }
+    return { name, type: extensionGuess || "csv" };
 };
+
+export const shouldProbeForDeltaSourceUrl = (dataSourceURL: string) =>
+    parseSourceUrl(dataSourceURL).shouldProbeForDelta;
+
+export const resolveNameAndTypeFromSourceUrl = async (
+    dataSourceURL: string,
+    deltaTableService: Pick<DeltaTableService, "isDeltaTableRoot"> = new DeltaTableService()
+) => {
+    const { extensionGuess, name, pathWithoutParams, shouldProbeForDelta } = parseSourceUrl(
+        dataSourceURL
+    );
+    if (extensionGuess) {
+        return { name, type: extensionGuess };
+    }
+
+    if (shouldProbeForDelta && (await deltaTableService.isDeltaTableRoot(pathWithoutParams))) {
+        return { name, type: "delta" as const };
+    }
+
+    console.warn("Assuming the source is csv since no extension was recognized");
+    return { name, type: "csv" as const };
+};
+
+export const resolveSourcesFromUrls = async (sources: Source[]): Promise<Source[]> =>
+    Promise.all(
+        sources.map(async (source) => {
+            if (typeof source.uri !== "string") {
+                return source;
+            }
+
+            if (source.name && source.type) {
+                return source;
+            }
+
+            const resolved = await resolveNameAndTypeFromSourceUrl(source.uri);
+
+            return {
+                ...resolved,
+                ...source,
+                name: source.name || resolved.name,
+                type: source.type || resolved.type,
+            };
+        })
+    );
 
 // We want to eventually use shorthands and other tricks to
 // try to shortern the resulting URL however we can

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -87,29 +87,28 @@ function parseSourceUrl(dataSourceURL: string): ParsedSourceUrl {
     const pathWithoutParams = dataSourceURL.split(/[?#]/)[0];
     const pathSegments = pathWithoutParams.split("/").filter(Boolean);
     const lastSegment = pathSegments[pathSegments.length - 1] || pathWithoutParams;
-    const isDeltaLogPath = lastSegment === "_delta_log";
+    const isDeltaLogPath =
+        lastSegment === "_delta_log" || pathWithoutParams.includes("/_delta_log/");
     const uriResource =
         isDeltaLogPath && pathSegments.length > 1
             ? pathSegments[pathSegments.length - 2]
             : lastSegment;
     const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
-    // Returns undefined if can't find a match
-    let extensionGuess = ACCEPTED_SOURCE_TYPES.find(
-        (validSourcetype) => validSourcetype === uriResource.split(".").pop()
-    );
-    if (!extensionGuess) {
-        const looksLikeDelta = isDeltaLogPath || pathWithoutParams.includes("/_delta_log/");
 
-        if (looksLikeDelta) {
-            extensionGuess = "delta";
-        }
+    // If the URL explicitly references a delta log directory, commit to delta immediately —
+    // no network probe needed.
+    if (isDeltaLogPath) {
+        return { extensionGuess: "delta", name, pathWithoutParams, shouldProbeForDelta: false };
     }
 
-    const shouldProbeForDelta =
-        extensionGuess === undefined &&
-        (isDeltaLogPath ||
-            pathWithoutParams.includes("/_delta_log/") ||
-            dataSourceURL.endsWith("/"));
+    // Try to detect type from the file extension.
+    const extensionGuess = ACCEPTED_SOURCE_TYPES.find(
+        (validSourcetype) => validSourcetype === uriResource.split(".").pop()
+    );
+
+    // For directory-like URLs (trailing slash, no recognised extension), probe the network
+    // to determine whether the root is a delta table.
+    const shouldProbeForDelta = extensionGuess === undefined && dataSourceURL.endsWith("/");
 
     return { extensionGuess, name, pathWithoutParams, shouldProbeForDelta };
 }

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -13,7 +13,7 @@ export enum FileView {
     LARGE_THUMBNAIL = "3",
 }
 
-export const ACCEPTED_SOURCE_TYPES = ["csv", "json", "parquet"] as const;
+export const ACCEPTED_SOURCE_TYPES = ["csv", "json", "parquet", "delta"] as const;
 
 export interface Source {
     name: string;
@@ -74,15 +74,31 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
 };
 
 export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
-    const uriResource = dataSourceURL.substring(dataSourceURL.lastIndexOf("/") + 1).split("?")[0];
+    const pathWithoutParams = dataSourceURL.split(/[?#]/)[0];
+    const pathSegments = pathWithoutParams.split("/").filter(Boolean);
+    const lastSegment = pathSegments[pathSegments.length - 1] || pathWithoutParams;
+    const isDeltaLogPath = lastSegment === "_delta_log";
+    const uriResource =
+        isDeltaLogPath && pathSegments.length > 1
+            ? pathSegments[pathSegments.length - 2]
+            : lastSegment;
     const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
     // Returns undefined if can't find a match
     let extensionGuess = ACCEPTED_SOURCE_TYPES.find(
         (validSourcetype) => validSourcetype === uriResource.split(".").pop()
     );
     if (!extensionGuess) {
-        console.warn("Assuming the source is csv since no extension was recognized");
-        extensionGuess = "csv";
+        const looksLikeDelta =
+            isDeltaLogPath ||
+            pathWithoutParams.includes("/_delta_log/") ||
+            (pathWithoutParams.endsWith("/") && uriResource.toLowerCase().includes("delta"));
+
+        if (looksLikeDelta) {
+            extensionGuess = "delta";
+        } else {
+            console.warn("Assuming the source is csv since no extension was recognized");
+            extensionGuess = "csv";
+        }
     }
     return { name, type: extensionGuess };
 };

--- a/packages/core/entity/SearchParams/test/searchparams.test.ts
+++ b/packages/core/entity/SearchParams/test/searchparams.test.ts
@@ -6,6 +6,7 @@ import SearchParams, {
     Source,
     EMPTY_QUERY_COMPONENTS,
     getNameAndTypeFromSourceUrl,
+    resolveNameAndTypeFromSourceUrl,
 } from "..";
 import AnnotationName from "../../Annotation/AnnotationName";
 import FileFilter from "../../FileFilter";
@@ -45,6 +46,36 @@ describe("SearchParams", () => {
 
             expect(result.type).to.equal("delta");
             expect(result.name).to.contain("delta-table-example");
+        });
+
+        it("uses the table root name for directory URLs", () => {
+            const result = getNameAndTypeFromSourceUrl(
+                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/"
+            );
+
+            expect(result.name).to.contain("run-42-output");
+        });
+    });
+
+    describe("resolveNameAndTypeFromSourceUrl", () => {
+        it("detects delta table roots even when the name does not mention delta", async () => {
+            const result = await resolveNameAndTypeFromSourceUrl(
+                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/",
+                {
+                    isDeltaTableRoot: async () => true,
+                }
+            );
+
+            expect(result.type).to.equal("delta");
+            expect(result.name).to.contain("run-42-output");
+        });
+
+        it("falls back to csv when the root does not look like delta", async () => {
+            const result = await resolveNameAndTypeFromSourceUrl("https://example.com/run-42/", {
+                isDeltaTableRoot: async () => false,
+            });
+
+            expect(result.type).to.equal("csv");
         });
     });
 

--- a/packages/core/entity/SearchParams/test/searchparams.test.ts
+++ b/packages/core/entity/SearchParams/test/searchparams.test.ts
@@ -1,6 +1,12 @@
 import { expect } from "chai";
 
-import SearchParams, { SearchParamsComponents, FileView, Source, EMPTY_QUERY_COMPONENTS } from "..";
+import SearchParams, {
+    SearchParamsComponents,
+    FileView,
+    Source,
+    EMPTY_QUERY_COMPONENTS,
+    getNameAndTypeFromSourceUrl,
+} from "..";
 import AnnotationName from "../../Annotation/AnnotationName";
 import FileFilter from "../../FileFilter";
 import ExcludeFilter from "../../FileFilter/ExcludeFilter";
@@ -21,6 +27,26 @@ describe("SearchParams", () => {
     };
 
     const mockOS = "Darwin";
+
+    describe("getNameAndTypeFromSourceUrl", () => {
+        it("treats exact _delta_log URLs as delta sources", () => {
+            const result = getNameAndTypeFromSourceUrl(
+                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/delta-table-example/_delta_log"
+            );
+
+            expect(result.type).to.equal("delta");
+            expect(result.name).to.contain("delta-table-example");
+        });
+
+        it("treats _delta_log directory URLs with trailing slash as delta sources", () => {
+            const result = getNameAndTypeFromSourceUrl(
+                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/delta-table-example/_delta_log/"
+            );
+
+            expect(result.type).to.equal("delta");
+            expect(result.name).to.contain("delta-table-example");
+        });
+    });
 
     describe("encode", () => {
         it("Encodes hierarchy, filters, open folders, and collection", () => {

--- a/packages/core/entity/SearchParams/test/searchparams.test.ts
+++ b/packages/core/entity/SearchParams/test/searchparams.test.ts
@@ -30,24 +30,6 @@ describe("SearchParams", () => {
     const mockOS = "Darwin";
 
     describe("getNameAndTypeFromSourceUrl", () => {
-        it("treats exact _delta_log URLs as delta sources", () => {
-            const result = getNameAndTypeFromSourceUrl(
-                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/delta-table-example/_delta_log"
-            );
-
-            expect(result.type).to.equal("delta");
-            expect(result.name).to.contain("delta-table-example");
-        });
-
-        it("treats _delta_log directory URLs with trailing slash as delta sources", () => {
-            const result = getNameAndTypeFromSourceUrl(
-                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/delta-table-example/_delta_log/"
-            );
-
-            expect(result.type).to.equal("delta");
-            expect(result.name).to.contain("delta-table-example");
-        });
-
         it("uses the table root name for directory URLs", () => {
             const result = getNameAndTypeFromSourceUrl(
                 "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/"

--- a/packages/core/entity/SearchParams/test/searchparams.test.ts
+++ b/packages/core/entity/SearchParams/test/searchparams.test.ts
@@ -5,7 +5,6 @@ import SearchParams, {
     FileView,
     Source,
     EMPTY_QUERY_COMPONENTS,
-    getNameAndTypeFromSourceUrl,
     resolveNameAndTypeFromSourceUrl,
 } from "..";
 import AnnotationName from "../../Annotation/AnnotationName";
@@ -29,17 +28,18 @@ describe("SearchParams", () => {
 
     const mockOS = "Darwin";
 
-    describe("getNameAndTypeFromSourceUrl", () => {
-        it("uses the table root name for directory URLs", () => {
-            const result = getNameAndTypeFromSourceUrl(
-                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/"
+    describe("resolveNameAndTypeFromSourceUrl", () => {
+        it("uses the table root name for directory URLs", async () => {
+            const result = await resolveNameAndTypeFromSourceUrl(
+                "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/",
+                {
+                    isDeltaTableRoot: async () => false,
+                }
             );
 
             expect(result.name).to.contain("run-42-output");
         });
-    });
 
-    describe("resolveNameAndTypeFromSourceUrl", () => {
         it("detects delta table roots even when the name does not mention delta", async () => {
             const result = await resolveNameAndTypeFromSourceUrl(
                 "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/run-42-output/",

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -107,11 +107,21 @@ export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckd
         },
     });
 
-    // Enable native Delta Lake support for DuckDB queries.
+    // Try enabling native Delta Lake support for DuckDB queries.
+    // In duckdb-wasm, this extension may not be published for every runtime build.
     const setupConnection = await db.connect();
     try {
         await setupConnection.query("INSTALL delta");
         await setupConnection.query("LOAD delta");
+    } catch (err) {
+        const message = (err as Error)?.message || String(err);
+        if (message.includes("delta.duckdb_extension.wasm is not available")) {
+            console.warn(
+                "DuckDB delta extension is unavailable for this WASM bundle; continuing without native delta extension."
+            );
+        } else {
+            throw err;
+        }
     } finally {
         await setupConnection.close();
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -9,6 +9,7 @@ import { EdgeDefinition } from "../../entity/Graph";
 import { Source } from "../../entity/SearchParams";
 import SQLBuilder from "../../entity/SQLBuilder";
 import DataSourcePreparationError from "../../errors/DataSourcePreparationError";
+import DeltaTableService from "../DeltaTableService";
 
 enum PreDefinedColumn {
     FILE_ID = "File ID",
@@ -62,6 +63,10 @@ function getFileNameFromPathExpression(quotedPathColumn: string): string {
     const stripOme = `REGEXP_REPLACE(${basename}, '(?i)\\\\.ome$', '')`;
 
     return `COALESCE(NULLIF(${stripOme}, ''), ${quotedPathColumn})`;
+}
+
+function escapeSqlString(value: string): string {
+    return value.replaceAll("'", "''");
 }
 
 /**
@@ -122,6 +127,8 @@ export default abstract class DatabaseService {
     private readonly dataSourceToProvenanceMap: Map<string, EdgeDefinition[]> = new Map();
     // Data source names that are views (parquet), so we DROP VIEW on delete
     private readonly parquetDirectViewNames = new Set<string>();
+    // Data source names that are views materialized from Delta logs
+    private readonly deltaDirectViewNames = new Set<string>();
 
     protected database: duckdb.AsyncDuckDB | undefined;
 
@@ -186,11 +193,40 @@ export default abstract class DatabaseService {
 
     protected async addDataSource(
         name: string,
-        type: "csv" | "json" | "parquet",
+        type: "csv" | "json" | "parquet" | "delta",
         uri: string | File
     ): Promise<void> {
         if (!this.database) {
             throw new Error("Database failed to initialize");
+        }
+
+        if (type === "delta") {
+            if (uri instanceof File) {
+                throw new Error(
+                    "Delta table loading from uploaded files is not supported yet. Use a Delta root URL."
+                );
+            }
+
+            const deltaTableService = this.getDeltaTableService();
+            const activeParquetFiles = await deltaTableService.resolveActiveParquetFiles(uri);
+            if (activeParquetFiles.length === 0) {
+                throw new Error(`Delta table has no active parquet files: ${uri}`);
+            }
+
+            const parquetRefs: string[] = [];
+            for (let idx = 0; idx < activeParquetFiles.length; idx++) {
+                const parquetUri = activeParquetFiles[idx];
+                const fileAlias = `${name}__delta__${idx}`;
+                const protocol = parquetUri.startsWith("s3")
+                    ? duckdb.DuckDBDataProtocol.S3
+                    : duckdb.DuckDBDataProtocol.HTTP;
+
+                await this.database.registerFileURL(fileAlias, parquetUri, protocol, false);
+                parquetRefs.push(fileAlias);
+            }
+
+            await this.createDeltaDirectView(name, parquetRefs);
+            return;
         }
 
         if (uri instanceof File) {
@@ -305,7 +341,10 @@ export default abstract class DatabaseService {
             let formattedError = (err as Error).message;
             // DuckDB does not provide informative server errors, so send a
             // separate 'get' call to retrieve error messages for URL data sources
-            if (!(uri instanceof File)) {
+            // For Delta sources, the root URI is often a virtual directory path
+            // and a direct GET can return 403 even when underlying objects are readable.
+            // Preserve the original Delta resolver error in that case.
+            if (!(uri instanceof File) && type !== "delta") {
                 await axios.get(uri).catch((error) => {
                     // Error responses can be formatted differently
                     // Get progressively less specific in where we look for the message
@@ -354,7 +393,7 @@ export default abstract class DatabaseService {
         // Unless skipped, this will ensure the table is prepared
         // for querying with the expected columns & uniqueness constraints
         if (!skipNormalization) {
-            if (type !== "parquet") {
+            if (type !== "parquet" && type !== "delta") {
                 await this.normalizeDataSourceColumnNames(name);
                 await this.renameNonprintableCharColumns(name);
             }
@@ -364,7 +403,7 @@ export default abstract class DatabaseService {
                 throw new DataSourcePreparationError(error, name);
             }
 
-            if (type !== "parquet") {
+            if (type !== "parquet" && type !== "delta") {
                 await this.addRequiredColumns(name);
             }
         }
@@ -422,9 +461,16 @@ export default abstract class DatabaseService {
         if (this.parquetDirectViewNames.has(dataSource)) {
             this.parquetDirectViewNames.delete(dataSource);
             await this.execute(`DROP VIEW IF EXISTS "${dataSource}"`);
+        } else if (this.deltaDirectViewNames.has(dataSource)) {
+            this.deltaDirectViewNames.delete(dataSource);
+            await this.execute(`DROP VIEW IF EXISTS "${dataSource}"`);
         } else {
             await this.execute(`DROP TABLE IF EXISTS "${dataSource}"`);
         }
+    }
+
+    protected getDeltaTableService(): DeltaTableService {
+        return new DeltaTableService();
     }
 
     /*
@@ -649,6 +695,45 @@ export default abstract class DatabaseService {
         this.parquetDirectViewNames.add(name);
     }
 
+    private async createDeltaDirectView(name: string, parquetRefs: string[]): Promise<void> {
+        const parquetArrayExpression = `[${parquetRefs
+            .map((ref) => `'${escapeSqlString(ref)}'`)
+            .join(", ")}]`;
+        const rawColumns = await this.getRawParquetColumnsFromArrayExpression(
+            parquetArrayExpression
+        );
+        const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
+        const hasFilePath = [...actualToPreDefined.values()].includes(PreDefinedColumn.FILE_PATH);
+        const hasFileName = [...actualToPreDefined.values()].includes(PreDefinedColumn.FILE_NAME);
+        const syntheticFilePathExpression = `CONCAT('delta://${escapeSqlString(
+            name
+        )}/', CAST(ROW_NUMBER() OVER () AS VARCHAR))`;
+
+        const selectParts = rawColumns.map((col) => {
+            const preDefined = actualToPreDefined.get(col);
+            if (preDefined !== undefined) {
+                return `"${col}" AS "${preDefined}"`;
+            }
+            return `"${col}"`;
+        });
+        if (!hasFilePath) {
+            selectParts.push(`${syntheticFilePathExpression} AS "${PreDefinedColumn.FILE_PATH}"`);
+        }
+        const fileNameSelectPart = getParquetFileNameSelectPart(actualToPreDefined);
+        if (fileNameSelectPart !== null) {
+            selectParts.push(fileNameSelectPart);
+        } else if (!hasFileName) {
+            selectParts.push(`${syntheticFilePathExpression} AS "${PreDefinedColumn.FILE_NAME}"`);
+        }
+        selectParts.push(`ROW_NUMBER() OVER () AS "${HIDDEN_UID_ANNOTATION}"`);
+
+        const createViewSql = `CREATE VIEW "${name}"
+            AS SELECT ${selectParts.join(", ")}
+            FROM parquet_scan(${parquetArrayExpression});`;
+        await this.execute(createViewSql);
+        this.deltaDirectViewNames.add(name);
+    }
+
     // Given a possibly-renamed column name, get the original column name used
     // in the input parquet.
     private async getOriginalParquetColumnName(
@@ -780,8 +865,10 @@ export default abstract class DatabaseService {
     }
 
     private async aggregateDataSources(dataSources: Source[]): Promise<void> {
-        if (dataSources.some((source) => source.type === "parquet")) {
-            throw new Error("Parquet tables cannot be combined to query multiple data sources.");
+        if (dataSources.some((source) => source.type === "parquet" || source.type === "delta")) {
+            throw new Error(
+                "Parquet and Delta tables cannot be combined to query multiple data sources."
+            );
         }
         const viewName = DatabaseService.combineSourceNames(dataSources);
 
@@ -1008,6 +1095,14 @@ export default abstract class DatabaseService {
     // data source preparation step.
     private async getRawParquetColumns(name: string): Promise<string[]> {
         const sql = `DESCRIBE SELECT * FROM parquet_scan("${name}")`;
+        const rows = await this.query(sql).promise;
+        return rows.map((row) => row["column_name"] as string);
+    }
+
+    private async getRawParquetColumnsFromArrayExpression(
+        parquetArrayExpression: string
+    ): Promise<string[]> {
+        const sql = `DESCRIBE SELECT * FROM parquet_scan(${parquetArrayExpression})`;
         const rows = await this.query(sql).promise;
         return rows.map((row) => row["column_name"] as string);
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -106,6 +106,16 @@ export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckd
             forceFullHTTPReads: false,
         },
     });
+
+    // Enable native Delta Lake support for DuckDB queries.
+    const setupConnection = await db.connect();
+    try {
+        await setupConnection.query("INSTALL delta");
+        await setupConnection.query("LOAD delta");
+    } finally {
+        await setupConnection.close();
+    }
+
     URL.revokeObjectURL(workerUrl);
     return db;
 }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -86,6 +86,24 @@ export function getParquetFileNameSelectPart(
     return `${getFileNameFromPathExpression(`"${pathColumn}"`)} AS "${PreDefinedColumn.FILE_NAME}"`;
 }
 
+function getDirectViewColumnProjection(
+    rawColumns: string[]
+): {
+    actualToPreDefined: Map<string, string>;
+    selectParts: string[];
+} {
+    const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
+    const selectParts = rawColumns.map((col) => {
+        const preDefined = actualToPreDefined.get(col);
+        if (preDefined !== undefined) {
+            return `"${col}" AS "${preDefined}"`;
+        }
+        return `"${col}"`;
+    });
+
+    return { actualToPreDefined, selectParts };
+}
+
 export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckdb.AsyncDuckDB> {
     const allBundles = duckdb.getJsDelivrBundles();
 
@@ -109,6 +127,8 @@ export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckd
 
     // Try enabling native Delta Lake support for DuckDB queries.
     // In duckdb-wasm, this extension may not be published for every runtime build.
+    // If unavailable, we fall back to manual Delta table support via DeltaTableService,
+    // which recovers active parquet files by replaying _delta_log entries.
     const setupConnection = await db.connect();
     try {
         await setupConnection.query("INSTALL delta");
@@ -117,7 +137,7 @@ export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckd
         const message = (err as Error)?.message || String(err);
         if (message.includes("delta.duckdb_extension.wasm is not available")) {
             console.warn(
-                "DuckDB delta extension is unavailable for this WASM bundle; continuing without native delta extension."
+                "DuckDB delta extension is unavailable for this WASM bundle; falling back to manual Delta log replay."
             );
         } else {
             throw err;
@@ -145,10 +165,9 @@ export default abstract class DatabaseService {
     protected readonly existingDataSources = new Set([AICS_FMS_DATA_SOURCE_NAME]);
     protected readonly dataSourceToAnnotationsMap: Map<string, Annotation[]> = new Map();
     private readonly dataSourceToProvenanceMap: Map<string, EdgeDefinition[]> = new Map();
-    // Data source names that are views (parquet), so we DROP VIEW on delete
-    private readonly parquetDirectViewNames = new Set<string>();
-    // Data source names that are views materialized from Delta logs
-    private readonly deltaDirectViewNames = new Set<string>();
+    // Data source names that are direct views and their underlying type.
+    // This lets us use one tracking structure while preserving parquet-specific behavior.
+    private readonly directViewKinds = new Map<string, "parquet" | "delta">();
 
     protected database: duckdb.AsyncDuckDB | undefined;
     protected readonly deltaTableService: DeltaTableService;
@@ -534,11 +553,8 @@ export default abstract class DatabaseService {
     protected async deleteDataSource(dataSource: string): Promise<void> {
         this.existingDataSources.delete(dataSource);
         this.dataSourceToAnnotationsMap.delete(dataSource);
-        if (this.parquetDirectViewNames.has(dataSource)) {
-            this.parquetDirectViewNames.delete(dataSource);
-            await this.execute(`DROP VIEW IF EXISTS "${dataSource}"`);
-        } else if (this.deltaDirectViewNames.has(dataSource)) {
-            this.deltaDirectViewNames.delete(dataSource);
+        if (this.directViewKinds.has(dataSource)) {
+            this.directViewKinds.delete(dataSource);
             await this.execute(`DROP VIEW IF EXISTS "${dataSource}"`);
         } else {
             await this.execute(`DROP TABLE IF EXISTS "${dataSource}"`);
@@ -647,7 +663,7 @@ export default abstract class DatabaseService {
             // For large parquet tables, attempt to bypass the expensive
             // getRowsWhereColumnIsBlank query.
             if (
-                this.parquetDirectViewNames.has(name) &&
+                this.directViewKinds.get(name) === "parquet" &&
                 (await this.totalRowCount(name)) > 500000
             ) {
                 const originalColumn = await this.getOriginalParquetColumnName(
@@ -750,16 +766,8 @@ export default abstract class DatabaseService {
         // fully built data source, and this function is used for creating a
         // data source.
         const rawColumns = await this.getRawParquetColumns(name);
-        // 2. Determine which columns need to be renamed, if any
-        const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
-        // 3. Prepare the SQL for renaming columns in the CREATE VIEW
-        const selectParts = rawColumns.map((col) => {
-            const preDefined = actualToPreDefined.get(col);
-            if (preDefined !== undefined) {
-                return `"${col}" AS "${preDefined}"`;
-            }
-            return `"${col}"`;
-        });
+        // 2. Determine which columns need to be renamed and build base projection.
+        const { actualToPreDefined, selectParts } = getDirectViewColumnProjection(rawColumns);
         const fileNameSelectPart = getParquetFileNameSelectPart(actualToPreDefined);
         if (fileNameSelectPart !== null) {
             selectParts.push(fileNameSelectPart);
@@ -770,7 +778,7 @@ export default abstract class DatabaseService {
             AS SELECT ${selectParts.join(", ")}
             FROM parquet_scan('${name}');`;
         await this.execute(createViewSql);
-        this.parquetDirectViewNames.add(name);
+        this.directViewKinds.set(name, "parquet");
     }
 
     private async createDeltaDirectView(name: string, parquetRefs: string[]): Promise<void> {
@@ -780,20 +788,12 @@ export default abstract class DatabaseService {
         const rawColumns = await this.getRawParquetColumnsFromArrayExpression(
             parquetArrayExpression
         );
-        const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
+        const { actualToPreDefined, selectParts } = getDirectViewColumnProjection(rawColumns);
         const hasFilePath = [...actualToPreDefined.values()].includes(PreDefinedColumn.FILE_PATH);
         const hasFileName = [...actualToPreDefined.values()].includes(PreDefinedColumn.FILE_NAME);
         const syntheticFilePathExpression = `CONCAT('delta://${escapeSqlString(
             name
         )}/', CAST(ROW_NUMBER() OVER () AS VARCHAR))`;
-
-        const selectParts = rawColumns.map((col) => {
-            const preDefined = actualToPreDefined.get(col);
-            if (preDefined !== undefined) {
-                return `"${col}" AS "${preDefined}"`;
-            }
-            return `"${col}"`;
-        });
         if (!hasFilePath) {
             selectParts.push(`${syntheticFilePathExpression} AS "${PreDefinedColumn.FILE_PATH}"`);
         }
@@ -809,7 +809,7 @@ export default abstract class DatabaseService {
             AS SELECT ${selectParts.join(", ")}
             FROM parquet_scan(${parquetArrayExpression});`;
         await this.execute(createViewSql);
-        this.deltaDirectViewNames.add(name);
+        this.directViewKinds.set(name, "delta");
     }
 
     // Given a possibly-renamed column name, get the original column name used

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -141,8 +141,10 @@ export default abstract class DatabaseService {
     private readonly deltaDirectViewNames = new Set<string>();
 
     protected database: duckdb.AsyncDuckDB | undefined;
+    protected readonly deltaTableService: DeltaTableService;
 
-    constructor() {
+    constructor(deltaTableService: DeltaTableService = new DeltaTableService()) {
+        this.deltaTableService = deltaTableService;
         this.addDataSource = this.addDataSource.bind(this);
         this.execute = this.execute.bind(this);
         this.query = this.query.bind(this);
@@ -236,7 +238,7 @@ export default abstract class DatabaseService {
                 );
             }
 
-            const deltaTableService = this.getDeltaTableService();
+            const deltaTableService = this.deltaTableService;
             const activeParquetFiles = await deltaTableService.resolveActiveParquetFiles(uri);
             if (activeParquetFiles.length === 0) {
                 throw new Error(`Delta table has no active parquet files: ${uri}`);
@@ -531,10 +533,6 @@ export default abstract class DatabaseService {
         } else {
             await this.execute(`DROP TABLE IF EXISTS "${dataSource}"`);
         }
-    }
-
-    protected getDeltaTableService(): DeltaTableService {
-        return new DeltaTableService();
     }
 
     /*

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -115,6 +115,123 @@ describe("DatabaseService", () => {
             });
         });
 
+        describe("delta", () => {
+            class DeltaMockDatabaseService extends DatabaseService {
+                public executedSql: string[] = [];
+                private readonly resolvedFiles: string[];
+
+                constructor(resolvedFiles: string[]) {
+                    super();
+                    this.resolvedFiles = resolvedFiles;
+                    // Minimal database mock for registerFileURL usage in addDataSource
+                    this.database = ({
+                        registerFileURL: async () => Promise.resolve(),
+                    } as unknown) as duckdb.AsyncDuckDB;
+                }
+
+                protected getDeltaTableService() {
+                    return {
+                        resolveActiveParquetFiles: async () => this.resolvedFiles,
+                    } as any;
+                }
+
+                execute(sql: string): Promise<void> {
+                    this.executedSql.push(sql);
+                    return Promise.resolve();
+                }
+
+                query(): { promise: Promise<any> } {
+                    return {
+                        promise: Promise.resolve([
+                            { column_name: "File Path" },
+                            { column_name: "Gene" },
+                        ]),
+                    };
+                }
+            }
+
+            it("creates a view from resolved active parquet files", async () => {
+                const service = new DeltaMockDatabaseService([
+                    "https://example-bucket.s3.us-west-2.amazonaws.com/delta/part-0000.parquet",
+                    "https://example-bucket.s3.us-west-2.amazonaws.com/delta/part-0001.parquet",
+                ]);
+
+                await service.prepareDataSources(
+                    [
+                        {
+                            name: "delta_source",
+                            type: "delta",
+                            uri: "https://example-bucket.s3.us-west-2.amazonaws.com/delta/",
+                        },
+                    ],
+                    true
+                );
+
+                expect(service.hasDataSource("delta_source")).to.equal(true);
+                expect(service.executedSql.join("\n")).to.contain('CREATE VIEW "delta_source"');
+                expect(service.executedSql.join("\n")).to.contain(
+                    "parquet_scan(['delta_source__delta__0', 'delta_source__delta__1'])"
+                );
+            });
+
+            it("throws when no active parquet files are resolved", async () => {
+                const service = new DeltaMockDatabaseService([]);
+
+                let caughtError;
+                try {
+                    await service.prepareDataSources(
+                        [
+                            {
+                                name: "delta_source",
+                                type: "delta",
+                                uri: "https://example-bucket.s3.us-west-2.amazonaws.com/delta/",
+                            },
+                        ],
+                        true
+                    );
+                } catch (error) {
+                    caughtError = error;
+                }
+
+                expect(caughtError).to.not.be.undefined;
+                expect(`${caughtError}`).to.contain("DataSourcePreparationError");
+                expect(`${caughtError}`).to.contain("no active parquet files");
+            });
+
+            it("synthesizes File Path when delta data has no path-like columns", async () => {
+                class DeltaNoPathMockDatabaseService extends DeltaMockDatabaseService {
+                    query(): { promise: Promise<any> } {
+                        return {
+                            promise: Promise.resolve([
+                                { column_name: "Gene" },
+                                { column_name: "Cell Line" },
+                            ]),
+                        };
+                    }
+                }
+
+                const service = new DeltaNoPathMockDatabaseService([
+                    "https://example-bucket.s3.us-west-2.amazonaws.com/delta/part-0000.parquet",
+                ]);
+
+                await service.prepareDataSources(
+                    [
+                        {
+                            name: "delta_source",
+                            type: "delta",
+                            uri: "https://example-bucket.s3.us-west-2.amazonaws.com/delta/",
+                        },
+                    ],
+                    true
+                );
+
+                const allSql = service.executedSql.join("\n");
+                expect(allSql).to.contain('AS "File Path"');
+                expect(allSql).to.contain('AS "File Name"');
+                expect(allSql).to.contain("delta://delta_source/");
+            });
+        });
+
         it("throws error when missing File Path column", async () => {
             // Arrange
             sinon.stub(service, "fetchAnnotations").returns(Promise.resolve(mockAnnotations));

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -12,6 +12,7 @@ import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import AnnotationName from "../../../entity/Annotation/AnnotationName";
 
 import DatabaseService, { getParquetFileNameSelectPart } from "..";
+import DeltaTableService from "../../DeltaTableService";
 
 describe("DatabaseService", () => {
     describe("fetchAnnotations", () => {
@@ -118,21 +119,15 @@ describe("DatabaseService", () => {
         describe("delta", () => {
             class DeltaMockDatabaseService extends DatabaseService {
                 public executedSql: string[] = [];
-                private readonly resolvedFiles: string[];
 
                 constructor(resolvedFiles: string[]) {
-                    super();
-                    this.resolvedFiles = resolvedFiles;
+                    super(({
+                        resolveActiveParquetFiles: async () => resolvedFiles,
+                    } as unknown) as DeltaTableService);
                     // Minimal database mock for registerFileURL usage in addDataSource
                     this.database = ({
                         registerFileURL: async () => Promise.resolve(),
                     } as unknown) as duckdb.AsyncDuckDB;
-                }
-
-                protected getDeltaTableService() {
-                    return {
-                        resolveActiveParquetFiles: async () => this.resolvedFiles,
-                    } as any;
                 }
 
                 execute(sql: string): Promise<void> {

--- a/packages/core/services/DeltaTableService/index.ts
+++ b/packages/core/services/DeltaTableService/index.ts
@@ -1,0 +1,277 @@
+import axios from "axios";
+import { parseS3Url } from "amazon-s3-url";
+
+type DeltaLogObject = {
+    add?: {
+        path?: string;
+    };
+    remove?: {
+        path?: string;
+    };
+};
+
+export type DeltaResolverIO = {
+    fetchText?: (url: string) => Promise<string>;
+    listDeltaLogJsonFiles?: (rootUri: string) => Promise<string[]>;
+};
+
+function stripQueryAndFragment(uri: string): string {
+    return uri.split(/[?#]/)[0];
+}
+
+function stripTrailingSlash(uri: string): string {
+    return uri.replace(/\/+$/, "");
+}
+
+function pathJoin(base: string, child: string): string {
+    const normalizedChild = child.replace(/^\.\//, "").replace(/^\//, "");
+    return `${stripTrailingSlash(base)}/${normalizedChild}`;
+}
+
+function parseVersionFromDeltaLogFile(uri: string): number {
+    const filename = stripQueryAndFragment(uri).split("/").pop() || "";
+    const match = filename.match(/^(\d+)\.json$/);
+    if (!match) {
+        return Number.MAX_SAFE_INTEGER;
+    }
+    return Number(match[1]);
+}
+
+function isHttpUrl(uri: string): boolean {
+    return /^https?:\/\//i.test(uri);
+}
+
+function isS3ProtocolUrl(uri: string): boolean {
+    return /^s3:\/\//i.test(uri);
+}
+
+function isS3HttpUrl(uri: string): boolean {
+    return isHttpUrl(uri) && uri.includes("amazonaws.com");
+}
+
+function getS3HostBucketAndPrefix(
+    rootUri: string
+): { host: string; bucket: string; prefix: string } {
+    if (isS3ProtocolUrl(rootUri)) {
+        const parsed = parseS3Url(rootUri);
+        return {
+            host: `s3.${parsed.region ? `${parsed.region}.` : ""}amazonaws.com`,
+            bucket: parsed.bucket,
+            prefix: parsed.key,
+        };
+    }
+
+    const url = new URL(rootUri);
+    const parsed = parseS3Url(rootUri);
+    const normalizedPath = url.pathname.replace(/^\/+/, "");
+
+    if (parsed.bucket && url.hostname.startsWith(`${parsed.bucket}.`)) {
+        return {
+            host: url.hostname.slice(parsed.bucket.length + 1),
+            bucket: parsed.bucket,
+            prefix: parsed.key || "",
+        };
+    }
+
+    const [bucketFromPath, ...restPath] = normalizedPath.split("/");
+    return {
+        host: url.hostname,
+        bucket: parsed.bucket || bucketFromPath,
+        prefix: parsed.key || restPath.join("/"),
+    };
+}
+
+function normalizeTableRootUri(rootUri: string): string {
+    const normalized = stripTrailingSlash(stripQueryAndFragment(rootUri));
+    if (normalized.endsWith("/_delta_log")) {
+        return normalized.slice(0, -"/_delta_log".length);
+    }
+    return normalized;
+}
+
+function toHttpsTableRootUri(rootUri: string): string {
+    if (isHttpUrl(rootUri)) {
+        return normalizeTableRootUri(rootUri);
+    }
+
+    if (isS3ProtocolUrl(rootUri)) {
+        const { host, bucket, prefix } = getS3HostBucketAndPrefix(rootUri);
+        const tableRoot = `https://${host}/${bucket}${prefix ? `/${prefix}` : ""}`;
+        return normalizeTableRootUri(tableRoot);
+    }
+
+    return normalizeTableRootUri(rootUri);
+}
+
+function buildDeltaLogDir(tableRootUri: string): string {
+    return `${stripTrailingSlash(tableRootUri)}/_delta_log`;
+}
+
+function buildDeltaLogVersionFileUrl(deltaLogDir: string, version: number): string {
+    return `${stripTrailingSlash(deltaLogDir)}/${String(version).padStart(20, "0")}.json`;
+}
+
+function isMissingObjectError(err: unknown): boolean {
+    const status = (err as any)?.response?.status;
+    if (status === 404 || status === 403) {
+        return true;
+    }
+
+    const message = String((err as any)?.message || err || "").toLowerCase();
+    return (
+        message.includes("404") ||
+        message.includes("nosuchkey") ||
+        message.includes("not found") ||
+        message.includes("accessdenied")
+    );
+}
+
+function parseLastCheckpointVersion(rawCheckpoint: string): number | null {
+    try {
+        const parsed = JSON.parse(rawCheckpoint) as { version?: number };
+        return typeof parsed.version === "number" ? parsed.version : null;
+    } catch (_err) {
+        return null;
+    }
+}
+
+export default class DeltaTableService {
+    private readonly fetchText: (url: string) => Promise<string>;
+    private readonly listDeltaLogJsonFiles: (rootUri: string) => Promise<string[]>;
+
+    constructor(io: DeltaResolverIO = {}) {
+        this.fetchText =
+            io.fetchText ||
+            (async (url: string) => {
+                const response = await axios.get(url, { responseType: "text" });
+                return response.data as string;
+            });
+
+        this.listDeltaLogJsonFiles = io.listDeltaLogJsonFiles || this.listDeltaLogJsonFilesDefault;
+    }
+
+    public async resolveActiveParquetFiles(rootUri: string): Promise<string[]> {
+        const normalizedRootUri = toHttpsTableRootUri(rootUri);
+        const logFiles = await this.listDeltaLogJsonFiles(normalizedRootUri);
+        if (logFiles.length === 0) {
+            throw new Error(`No delta log JSON files found at ${normalizedRootUri}/_delta_log`);
+        }
+
+        const sortedLogFiles = [...logFiles].sort(
+            (a, b) => parseVersionFromDeltaLogFile(a) - parseVersionFromDeltaLogFile(b)
+        );
+
+        const activeFiles = new Set<string>();
+
+        for (const logFile of sortedLogFiles) {
+            const rawText = await this.fetchText(logFile);
+            const lines = rawText
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean);
+
+            for (const line of lines) {
+                let parsed: DeltaLogObject;
+                try {
+                    parsed = JSON.parse(line) as DeltaLogObject;
+                } catch (err) {
+                    throw new Error(
+                        `Invalid delta log JSON line in ${logFile}: ${line.slice(0, 120)}`
+                    );
+                }
+
+                const addedPath = parsed.add?.path;
+                if (addedPath) {
+                    const resolvedPath = isHttpUrl(addedPath)
+                        ? addedPath
+                        : pathJoin(normalizedRootUri, addedPath);
+                    activeFiles.add(encodeURI(resolvedPath));
+                }
+
+                const removedPath = parsed.remove?.path;
+                if (removedPath) {
+                    const resolvedPath = isHttpUrl(removedPath)
+                        ? removedPath
+                        : pathJoin(normalizedRootUri, removedPath);
+                    activeFiles.delete(encodeURI(resolvedPath));
+                }
+            }
+        }
+
+        return [...activeFiles].sort();
+    }
+
+    private listDeltaLogJsonFilesDefault = async (rootUri: string): Promise<string[]> => {
+        if (!(isS3ProtocolUrl(rootUri) || isS3HttpUrl(rootUri))) {
+            throw new Error(
+                `Listing delta logs is currently supported only for S3 URLs. Received: ${rootUri}`
+            );
+        }
+
+        const tableRootUri = toHttpsTableRootUri(rootUri);
+        const deltaLogDir = buildDeltaLogDir(tableRootUri);
+        const existenceCache = new Map<number, boolean>();
+
+        const fetchTextIfExists = async (url: string): Promise<string | null> => {
+            try {
+                return await this.fetchText(url);
+            } catch (err) {
+                if (isMissingObjectError(err)) {
+                    return null;
+                }
+                throw err;
+            }
+        };
+
+        const hasLogVersion = async (version: number): Promise<boolean> => {
+            if (existenceCache.has(version)) {
+                return existenceCache.get(version) as boolean;
+            }
+
+            const raw = await fetchTextIfExists(buildDeltaLogVersionFileUrl(deltaLogDir, version));
+            const exists = raw !== null;
+            existenceCache.set(version, exists);
+            return exists;
+        };
+
+        const rawCheckpoint = await fetchTextIfExists(`${deltaLogDir}/_last_checkpoint`);
+        const checkpointVersion = rawCheckpoint ? parseLastCheckpointVersion(rawCheckpoint) : null;
+
+        let low = -1;
+        let high = 1;
+
+        if (checkpointVersion !== null && (await hasLogVersion(checkpointVersion))) {
+            low = checkpointVersion;
+            high = checkpointVersion + 1;
+        } else if (await hasLogVersion(0)) {
+            low = 0;
+            high = 1;
+        } else {
+            return [];
+        }
+
+        while (await hasLogVersion(high)) {
+            low = high;
+            high *= 2;
+        }
+
+        while (low + 1 < high) {
+            const mid = Math.floor((low + high) / 2);
+            if (await hasLogVersion(mid)) {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+
+        const latestVersion = low;
+        const files: string[] = [];
+        for (let version = 0; version <= latestVersion; version++) {
+            if (await hasLogVersion(version)) {
+                files.push(encodeURI(buildDeltaLogVersionFileUrl(deltaLogDir, version)));
+            }
+        }
+
+        return files;
+    };
+}

--- a/packages/core/services/DeltaTableService/index.ts
+++ b/packages/core/services/DeltaTableService/index.ts
@@ -29,6 +29,8 @@ function pathJoin(base: string, child: string): string {
     return `${stripTrailingSlash(base)}/${normalizedChild}`;
 }
 
+// Fallback-only: used to order _delta_log JSON files when native DuckDB delta
+// support is unavailable in WASM and we must replay the log ourselves.
 function parseVersionFromDeltaLogFile(uri: string): number {
     const filename = stripQueryAndFragment(uri).split("/").pop() || "";
     const match = filename.match(/^(\d+)\.json$/);
@@ -117,6 +119,8 @@ export default class DeltaTableService {
 
     public async isDeltaTableRoot(rootUri: string): Promise<boolean> {
         try {
+            // Fallback-only probe: checks for _delta_log presence when native delta
+            // reads are not available to DuckDB WASM.
             const normalizedRootUri = toHttpsTableRootUri(rootUri);
             const logFiles = await this.listDeltaLogJsonFiles(normalizedRootUri);
             return logFiles.length > 0;
@@ -126,6 +130,8 @@ export default class DeltaTableService {
     }
 
     public async resolveActiveParquetFiles(rootUri: string): Promise<string[]> {
+        // Fallback-only path: replay add/remove actions from _delta_log to produce
+        // the active parquet set for engines without native delta support.
         const normalizedRootUri = toHttpsTableRootUri(rootUri);
         const logFiles = await this.listDeltaLogJsonFiles(normalizedRootUri);
         if (logFiles.length === 0) {
@@ -177,6 +183,8 @@ export default class DeltaTableService {
     }
 
     private listDeltaLogJsonFilesDefault = async (rootUri: string): Promise<string[]> => {
+        // Fallback-only implementation: discovers available _delta_log versions
+        // directly in object storage for environments without native delta reads.
         if (!S3StorageService.isS3Url(rootUri)) {
             throw new Error(
                 `Listing delta logs is currently supported only for S3 URLs. Received: ${rootUri}`

--- a/packages/core/services/DeltaTableService/index.ts
+++ b/packages/core/services/DeltaTableService/index.ts
@@ -41,6 +41,10 @@ function isHttpUrl(uri: string): boolean {
     return /^https?:\/\//i.test(uri);
 }
 
+function isAbsoluteUri(uri: string): boolean {
+    return /^[a-z][a-z\d+\-.]*:\/\//i.test(uri);
+}
+
 function isS3ProtocolUrl(uri: string): boolean {
     return /^s3:\/\//i.test(uri);
 }
@@ -192,7 +196,7 @@ export default class DeltaTableService {
 
                 const addedPath = parsed.add?.path;
                 if (addedPath) {
-                    const resolvedPath = isHttpUrl(addedPath)
+                    const resolvedPath = isAbsoluteUri(addedPath)
                         ? addedPath
                         : pathJoin(normalizedRootUri, addedPath);
                     activeFiles.add(encodeURI(resolvedPath));
@@ -200,7 +204,7 @@ export default class DeltaTableService {
 
                 const removedPath = parsed.remove?.path;
                 if (removedPath) {
-                    const resolvedPath = isHttpUrl(removedPath)
+                    const resolvedPath = isAbsoluteUri(removedPath)
                         ? removedPath
                         : pathJoin(normalizedRootUri, removedPath);
                     activeFiles.delete(encodeURI(resolvedPath));
@@ -250,6 +254,9 @@ export default class DeltaTableService {
         let low = -1;
         let high = 1;
 
+        // this is a good place to start for performance optimization, as many tables
+        // will have a checkpoint and this can save multiple round trips to discover
+        // the latest version. Avoiding the complexity for now.  KPM 2026-04-08
         if (checkpointVersion !== null && (await hasLogVersion(checkpointVersion))) {
             low = checkpointVersion;
             high = checkpointVersion + 1;

--- a/packages/core/services/DeltaTableService/index.ts
+++ b/packages/core/services/DeltaTableService/index.ts
@@ -150,6 +150,16 @@ export default class DeltaTableService {
         this.listDeltaLogJsonFiles = io.listDeltaLogJsonFiles || this.listDeltaLogJsonFilesDefault;
     }
 
+    public async isDeltaTableRoot(rootUri: string): Promise<boolean> {
+        try {
+            const normalizedRootUri = toHttpsTableRootUri(rootUri);
+            const logFiles = await this.listDeltaLogJsonFiles(normalizedRootUri);
+            return logFiles.length > 0;
+        } catch (_err) {
+            return false;
+        }
+    }
+
     public async resolveActiveParquetFiles(rootUri: string): Promise<string[]> {
         const normalizedRootUri = toHttpsTableRootUri(rootUri);
         const logFiles = await this.listDeltaLogJsonFiles(normalizedRootUri);

--- a/packages/core/services/DeltaTableService/index.ts
+++ b/packages/core/services/DeltaTableService/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
-import { parseS3Url } from "amazon-s3-url";
+
+import S3StorageService from "../S3StorageService";
 
 type DeltaLogObject = {
     add?: {
@@ -45,46 +46,6 @@ function isAbsoluteUri(uri: string): boolean {
     return /^[a-z][a-z\d+\-.]*:\/\//i.test(uri);
 }
 
-function isS3ProtocolUrl(uri: string): boolean {
-    return /^s3:\/\//i.test(uri);
-}
-
-function isS3HttpUrl(uri: string): boolean {
-    return isHttpUrl(uri) && uri.includes("amazonaws.com");
-}
-
-function getS3HostBucketAndPrefix(
-    rootUri: string
-): { host: string; bucket: string; prefix: string } {
-    if (isS3ProtocolUrl(rootUri)) {
-        const parsed = parseS3Url(rootUri);
-        return {
-            host: `s3.${parsed.region ? `${parsed.region}.` : ""}amazonaws.com`,
-            bucket: parsed.bucket,
-            prefix: parsed.key,
-        };
-    }
-
-    const url = new URL(rootUri);
-    const parsed = parseS3Url(rootUri);
-    const normalizedPath = url.pathname.replace(/^\/+/, "");
-
-    if (parsed.bucket && url.hostname.startsWith(`${parsed.bucket}.`)) {
-        return {
-            host: url.hostname.slice(parsed.bucket.length + 1),
-            bucket: parsed.bucket,
-            prefix: parsed.key || "",
-        };
-    }
-
-    const [bucketFromPath, ...restPath] = normalizedPath.split("/");
-    return {
-        host: url.hostname,
-        bucket: parsed.bucket || bucketFromPath,
-        prefix: parsed.key || restPath.join("/"),
-    };
-}
-
 function normalizeTableRootUri(rootUri: string): string {
     const normalized = stripTrailingSlash(stripQueryAndFragment(rootUri));
     if (normalized.endsWith("/_delta_log")) {
@@ -98,9 +59,9 @@ function toHttpsTableRootUri(rootUri: string): string {
         return normalizeTableRootUri(rootUri);
     }
 
-    if (isS3ProtocolUrl(rootUri)) {
-        const { host, bucket, prefix } = getS3HostBucketAndPrefix(rootUri);
-        const tableRoot = `https://${host}/${bucket}${prefix ? `/${prefix}` : ""}`;
+    if (S3StorageService.isS3Url(rootUri)) {
+        const { hostname, bucket, key } = S3StorageService.parseS3Url(rootUri);
+        const tableRoot = `https://${hostname}/${bucket}${key ? `/${key}` : ""}`;
         return normalizeTableRootUri(tableRoot);
     }
 
@@ -216,7 +177,7 @@ export default class DeltaTableService {
     }
 
     private listDeltaLogJsonFilesDefault = async (rootUri: string): Promise<string[]> => {
-        if (!(isS3ProtocolUrl(rootUri) || isS3HttpUrl(rootUri))) {
+        if (!S3StorageService.isS3Url(rootUri)) {
             throw new Error(
                 `Listing delta logs is currently supported only for S3 URLs. Received: ${rootUri}`
             );

--- a/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
+++ b/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
@@ -4,6 +4,32 @@ import "mocha";
 import DeltaTableService from "..";
 
 describe("DeltaTableService", () => {
+    it("detects delta table roots when log files are discoverable", async () => {
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => [
+                "https://example-bucket.s3.us-west-2.amazonaws.com/table/_delta_log/00000000000000000000.json",
+            ],
+        });
+
+        const result = await service.isDeltaTableRoot(
+            "https://example-bucket.s3.us-west-2.amazonaws.com/table/"
+        );
+
+        expect(result).to.equal(true);
+    });
+
+    it("returns false for roots that cannot be resolved as delta", async () => {
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => {
+                throw new Error("not delta");
+            },
+        });
+
+        const result = await service.isDeltaTableRoot("https://example.com/table/");
+
+        expect(result).to.equal(false);
+    });
+
     it("replays add/remove actions across log versions", async () => {
         const rootUri = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
         const logFiles = [

--- a/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
+++ b/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
@@ -1,0 +1,140 @@
+import { expect } from "chai";
+import "mocha";
+
+import DeltaTableService from "..";
+
+describe("DeltaTableService", () => {
+    it("replays add/remove actions across log versions", async () => {
+        const rootUri = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
+        const logFiles = [
+            `${rootUri}/_delta_log/00000000000000000001.json`,
+            `${rootUri}/_delta_log/00000000000000000000.json`,
+        ];
+
+        const logContents: Record<string, string> = {
+            [`${rootUri}/_delta_log/00000000000000000000.json`]: [
+                JSON.stringify({ add: { path: "part-0000.parquet" } }),
+                JSON.stringify({ add: { path: "part-0001.parquet" } }),
+            ].join("\n"),
+            [`${rootUri}/_delta_log/00000000000000000001.json`]: [
+                JSON.stringify({ remove: { path: "part-0000.parquet" } }),
+                JSON.stringify({ add: { path: "part-0002.parquet" } }),
+            ].join("\n"),
+        };
+
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => logFiles,
+            fetchText: async (url) => logContents[url],
+        });
+
+        const files = await service.resolveActiveParquetFiles(rootUri);
+
+        expect(files).to.deep.equal([
+            `${rootUri}/part-0001.parquet`,
+            `${rootUri}/part-0002.parquet`,
+        ]);
+    });
+
+    it("supports absolute paths in add/remove actions", async () => {
+        const rootUri = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
+        const absolutePath =
+            "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example/part-abs.parquet";
+
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => [`${rootUri}/_delta_log/00000000000000000000.json`],
+            fetchText: async () =>
+                [
+                    JSON.stringify({ add: { path: absolutePath } }),
+                    JSON.stringify({ remove: { path: absolutePath } }),
+                ].join("\n"),
+        });
+
+        const files = await service.resolveActiveParquetFiles(rootUri);
+
+        expect(files).to.deep.equal([]);
+    });
+
+    it("throws when log listing is empty", async () => {
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => [],
+            fetchText: async () => "",
+        });
+
+        let error: Error | undefined;
+        try {
+            await service.resolveActiveParquetFiles("https://example.com/delta-root");
+        } catch (err) {
+            error = err as Error;
+        }
+
+        expect(error).to.not.equal(undefined);
+        expect(error?.message).to.contain("No delta log JSON files found");
+    });
+
+    it("throws on malformed JSON lines", async () => {
+        const rootUri = "https://example.com/delta-root";
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => [`${rootUri}/_delta_log/00000000000000000000.json`],
+            fetchText: async () => "this is not json",
+        });
+
+        let error: Error | undefined;
+        try {
+            await service.resolveActiveParquetFiles(rootUri);
+        } catch (err) {
+            error = err as Error;
+        }
+
+        expect(error).to.not.equal(undefined);
+        expect(error?.message).to.contain("Invalid delta log JSON line");
+    });
+
+    it("discovers logs with getObject-only access using checkpoint and version probing", async () => {
+        const rootUri = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
+        const deltaLog = `${rootUri}/_delta_log`;
+        const log0 = `${deltaLog}/00000000000000000000.json`;
+        const log1 = `${deltaLog}/00000000000000000001.json`;
+        const log2 = `${deltaLog}/00000000000000000002.json`;
+        const checkpoint = `${deltaLog}/_last_checkpoint`;
+
+        const service = new DeltaTableService({
+            fetchText: async (url) => {
+                if (url === checkpoint) {
+                    return JSON.stringify({ version: 1 });
+                }
+                if (url === log0) {
+                    return JSON.stringify({ add: { path: "part-0000.parquet" } });
+                }
+                if (url === log1) {
+                    return JSON.stringify({ add: { path: "part-0001.parquet" } });
+                }
+                if (url === log2) {
+                    return JSON.stringify({ remove: { path: "part-0000.parquet" } });
+                }
+
+                throw { response: { status: 404 } };
+            },
+        });
+
+        const files = await service.resolveActiveParquetFiles(rootUri);
+        expect(files).to.deep.equal([`${rootUri}/part-0001.parquet`]);
+    });
+
+    it("accepts _delta_log URI directly and resolves against table root", async () => {
+        const tableRoot = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
+        const deltaLogRoot = `${tableRoot}/_delta_log`;
+        const log0 = `${deltaLogRoot}/00000000000000000000.json`;
+
+        const service = new DeltaTableService({
+            fetchText: async (url) => {
+                if (url === log0) {
+                    return JSON.stringify({ add: { path: "part-0000.parquet" } });
+                }
+                throw { response: { status: 404 } };
+            },
+        });
+
+        const files = await service.resolveActiveParquetFiles(deltaLogRoot);
+        expect(files).to.deep.equal([`${tableRoot}/part-0000.parquet`]);
+    });
+});

--- a/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
+++ b/packages/core/services/DeltaTableService/test/DeltaTableService.test.ts
@@ -80,6 +80,24 @@ describe("DeltaTableService", () => {
         expect(files).to.deep.equal([]);
     });
 
+    it("supports absolute non-http URI paths in add/remove actions", async () => {
+        const rootUri = "https://example-bucket.s3.us-west-2.amazonaws.com/delta-table-example";
+        const absolutePath = "s3://example-bucket/delta-table-example/part-abs.parquet";
+
+        const service = new DeltaTableService({
+            listDeltaLogJsonFiles: async () => [`${rootUri}/_delta_log/00000000000000000000.json`],
+            fetchText: async () =>
+                [
+                    JSON.stringify({ add: { path: absolutePath } }),
+                    JSON.stringify({ remove: { path: absolutePath } }),
+                ].join("\n"),
+        });
+
+        const files = await service.resolveActiveParquetFiles(rootUri);
+
+        expect(files).to.deep.equal([]);
+    });
+
     it("throws when log listing is empty", async () => {
         const service = new DeltaTableService({
             listDeltaLogJsonFiles: async () => [],

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -1,4 +1,4 @@
-import { parseS3Url, isS3Url } from "amazon-s3-url";
+import { parseS3Url, isS3Url as isS3UrlLib } from "amazon-s3-url";
 import axios from "axios";
 
 import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
@@ -9,7 +9,7 @@ import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
 export const isMultiObjectFile = (url: string) =>
     [".zarr", ".zarr/", ".sldy", ".sldy/"].some((ext) => url.endsWith(ext));
 
-interface ParsedUrl {
+export interface ParsedUrl {
     hostname: string;
     bucket: string;
     key: string;
@@ -30,20 +30,20 @@ export default class S3StorageService extends HttpServiceBase {
     }
 
     /**
-     * Return true if s3 file.
+     * Return true if this is a recognised S3 URL (s3:// protocol or HTTP amazonaws.com).
      */
-    private static isSimpleS3Url(url: string): boolean {
+    public static isS3Url(url: string): boolean {
         try {
-            return isS3Url(url);
+            return isS3UrlLib(url);
         } catch (error) {
             return false;
         }
     }
 
     /**
-     * Break down S3 URL to host, bucket, and path (key).
+     * Break down an S3 URL (s3:// or HTTP amazonaws.com) into host, bucket, and key.
      */
-    private static parseSimpleUrl(url: string): ParsedUrl {
+    public static parseS3Url(url: string): ParsedUrl {
         const { protocol, hostname } = new URL(url);
         const { region, bucket, key } = parseS3Url(url);
         let parsedHost = hostname;
@@ -192,8 +192,8 @@ export default class S3StorageService extends HttpServiceBase {
      * Parse URL into hostname, bucket, key from a url
      */
     private parseUrl(url: string): Promise<ParsedUrl | undefined> {
-        return S3StorageService.isSimpleS3Url(url)
-            ? Promise.resolve(S3StorageService.parseSimpleUrl(url))
+        return S3StorageService.isS3Url(url)
+            ? Promise.resolve(S3StorageService.parseS3Url(url))
             : // TODO: what about virtualized objects not directories???
               this.parseVirtualizedDirectory(url);
     }

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -9,6 +9,7 @@ import NotificationService from "./NotificationService";
 export { default as AnnotationService } from "./AnnotationService";
 export type { default as ApplicationInfoService } from "./ApplicationInfoService";
 export { default as DatabaseService } from "./DatabaseService";
+export { default as DeltaTableService } from "./DeltaTableService";
 export { default as DatasetService } from "./DataSourceService";
 export type { default as ExecutionEnvService } from "./ExecutionEnvService";
 export { ExecutableEnvCancellationToken, SystemDefaultAppLocation } from "./ExecutionEnvService";

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -61,7 +61,7 @@ import * as selectionSelectors from "./selectors";
 import { findChildNodes } from "../../components/DirectoryTree/findChildNodes";
 import { NO_VALUE_NODE, ROOT_NODE } from "../../components/DirectoryTree/directory-hierarchy-state";
 import Annotation from "../../entity/Annotation";
-import SearchParams from "../../entity/SearchParams";
+import SearchParams, { resolveSourcesFromUrls } from "../../entity/SearchParams";
 import FileFilter, { FilterType } from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
 import FileSelection from "../../entity/FileSelection";
@@ -434,9 +434,10 @@ const decodeSearchParamsLogics = createLogic({
             sourceMetadata,
             prov,
         } = SearchParams.decode(encodedURL);
+        const resolvedSources = await resolveSourcesFromUrls(sources);
 
         batch(() => {
-            dispatch(changeDataSources(sources));
+            dispatch(changeDataSources(resolvedSources));
             dispatch(setAnnotationHierarchy(hierarchy));
             columns && dispatch(setColumns(columns));
             dispatch(setFileFilters(filters));
@@ -580,6 +581,7 @@ const changeDataSourceLogic = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         dispatch(setIsLoadingSource(true) as AnyAction);
         const { payload: selectedDataSources } = deps.action as ChangeDataSourcesAction;
+        const resolvedSelectedDataSources = await resolveSourcesFromUrls(selectedDataSources);
         const dataSources = interaction.selectors.getAllDataSources(deps.getState());
         const { databaseService } = interaction.selectors.getPlatformDependentServices(
             deps.getState()
@@ -591,7 +593,7 @@ const changeDataSourceLogic = createLogic({
 
         const newSelectedDataSources: DataSource[] = [];
         const existingSelectedDataSources: DataSource[] = [];
-        selectedDataSources.forEach((source) => {
+        resolvedSelectedDataSources.forEach((source) => {
             const existingSource = dataSources.find((s) => s.name === source.name);
             if (existingSource) {
                 existingSelectedDataSources.push(existingSource);
@@ -601,7 +603,7 @@ const changeDataSourceLogic = createLogic({
         });
 
         // It is possible the user was sent a novel data source in the URL
-        if (selectedDataSources.length > existingSelectedDataSources.length) {
+        if (resolvedSelectedDataSources.length > existingSelectedDataSources.length) {
             dispatch(
                 metadata.actions.receiveDataSources([...dataSources, ...newSelectedDataSources])
             );
@@ -609,7 +611,7 @@ const changeDataSourceLogic = createLogic({
 
         // Prepare the data sources ahead of querying against them below
         try {
-            await databaseService.prepareDataSources(selectedDataSources);
+            await databaseService.prepareDataSources(resolvedSelectedDataSources);
             // Hide warning pop-up if present and remove datasource error from state
             dispatch(removeDataSourceReloadError());
         } catch (err) {
@@ -689,15 +691,23 @@ const changeProvenanceSourceLogic = createLogic({
 const addQueryLogic = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const { payload: newQuery } = deps.action as AddQuery;
+        const resolvedSources = await resolveSourcesFromUrls(newQuery.parts.sources);
+        const resolvedQuery = {
+            ...newQuery,
+            parts: {
+                ...newQuery.parts,
+                sources: resolvedSources,
+            },
+        };
         const { databaseService } = interaction.selectors.getPlatformDependentServices(
             deps.getState()
         );
 
         // Prepare the data sources ahead of querying against them below
         try {
-            await databaseService.prepareDataSources(newQuery.parts.sources);
-            if (newQuery.parts.sourceMetadata) {
-                await databaseService.prepareSourceMetadata(newQuery.parts.sourceMetadata);
+            await databaseService.prepareDataSources(resolvedQuery.parts.sources);
+            if (resolvedQuery.parts.sourceMetadata) {
+                await databaseService.prepareSourceMetadata(resolvedQuery.parts.sourceMetadata);
             } else {
                 await databaseService.deleteSourceMetadata();
             }
@@ -713,7 +723,7 @@ const addQueryLogic = createLogic({
             }
         }
 
-        dispatch(changeQuery(deps.action.payload));
+        dispatch(changeQuery(resolvedQuery));
         done();
     },
     transform(deps: ReduxLogicDeps, next) {

--- a/packages/web/src/components/DatasetDetails/index.tsx
+++ b/packages/web/src/components/DatasetDetails/index.tsx
@@ -18,7 +18,7 @@ import {
 import styles from "./DatasetDetails.module.css";
 
 interface DatasetDetailsProps {
-    onLoadDataset: (datasetDetails: PublicDataset | undefined) => void;
+    onLoadDataset: (datasetDetails: PublicDataset | undefined) => void | Promise<void>;
 }
 
 export default function DatasetDetails(props: DatasetDetailsProps) {
@@ -108,7 +108,7 @@ export default function DatasetDetails(props: DatasetDetailsProps) {
                         iconName="View"
                         title="View dataset in the app"
                         text="VIEW"
-                        onClick={() => props.onLoadDataset(datasetDetails)}
+                        onClick={() => void props.onLoadDataset(datasetDetails)}
                     />
                     <a href={datasetDetails?.path} target="_blank" rel="noreferrer">
                         <SecondaryButton

--- a/packages/web/src/components/OpenSourceDatasets/DatasetRow.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetRow.tsx
@@ -12,7 +12,7 @@ import styles from "./DatasetRow.module.css";
 interface DatasetRowProps {
     rowProps: IDetailsRowProps;
     defaultRender: IRenderFunction<IDetailsRowProps>;
-    onLoadDataset: (dataset: PublicDataset) => void;
+    onLoadDataset: (dataset: PublicDataset) => void | Promise<void>;
 }
 
 export default function DatasetRow(props: DatasetRowProps) {
@@ -48,7 +48,7 @@ export default function DatasetRow(props: DatasetRowProps) {
                     iconName="Upload"
                     title="Load dataset"
                     text="LOAD"
-                    onClick={() => props.onLoadDataset(dataset)}
+                    onClick={() => void props.onLoadDataset(dataset)}
                 />
             </div>
         </div>

--- a/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/DatasetTable.tsx
@@ -24,7 +24,7 @@ import FileSort, { SortOrder } from "../../../../core/entity/FileSort";
 import styles from "./DatasetTable.module.css";
 
 interface DatasetTableProps {
-    onLoadDataset: (dataset: PublicDataset) => void;
+    onLoadDataset: (dataset: PublicDataset) => void | Promise<void>;
     featured?: boolean; // Flag to filter down to only the featured datasets
 }
 

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -9,7 +9,7 @@ import Modal from "../../../../core/components/Modal";
 import { metadata, selection } from "../../../../core/state";
 import SearchParams, {
     SearchParamsComponents,
-    getNameAndTypeFromSourceUrl,
+    resolveNameAndTypeFromSourceUrl,
     Source,
 } from "../../../../core/entity/SearchParams";
 
@@ -50,7 +50,7 @@ export default function OpenSourceDatasets() {
         });
     };
 
-    const loadDataset = (datasetDetails?: PublicDataset) => {
+    const loadDataset = async (datasetDetails?: PublicDataset) => {
         if (!datasetDetails) throw new Error("No dataset provided");
 
         const dataSourceURL = datasetDetails.path;
@@ -58,7 +58,7 @@ export default function OpenSourceDatasets() {
         openDatasetInApp(
             datasetDetails.name,
             {
-                ...getNameAndTypeFromSourceUrl(dataSourceURL),
+                ...(await resolveNameAndTypeFromSourceUrl(dataSourceURL)),
                 uri: dataSourceURL,
             },
             url

--- a/packages/web/src/services/DatabaseServiceWeb/types.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/types.ts
@@ -1,5 +1,7 @@
 import { ACCEPTED_SOURCE_TYPES } from "../../../../core/entity/SearchParams";
 
+type SaveFormat = "csv" | "json" | "parquet";
+
 export enum WorkerMsgType {
     ADD_SOURCE = "add datasource",
     ANNOTATIONS = "fetch annotations",
@@ -59,7 +61,7 @@ export type WorkerReqPayload<T extends WorkerMsgType> = {
     };
     [WorkerMsgType.SAVE]: {
         destination: string;
-        format: typeof ACCEPTED_SOURCE_TYPES[number];
+        format: SaveFormat;
         id: string;
         sql: string;
     };


### PR DESCRIPTION
## Context
Update to allow opening delta lake tables from URIs
https://github.com/AllenInstitute/biofile-finder/issues/718 actual issue
https://github.com/aics-int/fms-mongo-etl/issues/70 x-repo parent
https://github.com/aics-int/fms-mongo-etl/issues/69 Parent

## Changes
Some changes to file type detection

## Testing
Limited manual testing was done pointing at 
https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/delta-table-example-file_path/
Which should have contents similar to
Index,Name,Age,file_path
1,Alice,25,/tmp/Alice
2,Bob,30,/tmp/Bob
3,Charlie,28,/tmp/Charlie
4,Diana,35,/tmp/Diana
5,Ethan,22,/tmp/Ethan
6,Fiona,31,/tmp/Fiona
7,George,27,/tmp/George
8,Scott,29,/tmp/Scott