### PR TITLE
Bugfix/group with types

### DIFF
--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -128,7 +128,12 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
             dispatch(
                 selection.actions.setFileFilters([
                     ...allFilters.filter((filter) => filter.name !== props.annotation.name),
-                    new FileFilter(props.annotation.name, filterValue, type),
+                    new FileFilter(
+                        props.annotation.name,
+                        filterValue,
+                        type,
+                        props.annotation.type as AnnotationType
+                    ),
                 ])
             );
         }

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -61,10 +61,10 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
 
     // Propagate regular file filter values from state into UI
     const items = React.useMemo<ListItem[]>(() => {
-        const appliedFilters = new Set(filtersForAnnotation.map((filter) => filter.value));
+        const appliedFilters = new Set(filtersForAnnotation.map((filter) => String(filter.value)));
 
         return (annotationValues || []).map((value) => ({
-            selected: appliedFilters.has(value),
+            selected: appliedFilters.has(String(value)),
             displayValue: props.annotation.getDisplayValue(value) || value,
             value,
         }));
@@ -96,7 +96,8 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
             isNil(props.annotation.valueOf(item.value))
                 ? item.value
                 : props.annotation.valueOf(item.value),
-            filterType
+            filterType,
+            props.annotation.type as AnnotationType
         );
     };
 
@@ -159,9 +160,21 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
         />
     );
 
+    // FILE_SIZE is excluded: range filtering is not yet supported for it in the backend.
+    const typeHasDedicatedPicker =
+        props.annotation.name !== AnnotationName.FILE_SIZE &&
+        [AnnotationType.NUMBER, AnnotationType.DATE, AnnotationType.DATETIME].includes(
+            props.annotation.type as AnnotationType
+        );
+
     const searchFormType = () => {
-        // Use the checkboxes if values exist and are few enough to reasonably scroll through
-        if (items.length > 0 && items.length <= 100) {
+        // Types with dedicated pickers (number, date, datetime) use their own UI.
+        // Non-string types without dedicated pickers fall back to the list picker when values are available.
+        if (
+            !typeHasDedicatedPicker &&
+            props.annotation.type !== AnnotationType.STRING &&
+            items.length > 0
+        ) {
             return listPickerComponent;
         }
 
@@ -178,38 +191,35 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                     />
                 );
             case AnnotationType.NUMBER:
-                // File size is a special case where we don't have
-                // the ability to filter by range in the backend yet
-                // so we'll just let that case fall through to the string below
-                if (props.annotation.name !== AnnotationName.FILE_SIZE) {
-                    return (
-                        <NumberRangePicker
-                            className={styles.picker}
-                            items={items}
-                            loading={isLoading}
-                            errorMessage={errorMessage}
-                            onSearch={onSearch}
-                            currentRange={filtersForAnnotation?.[0]}
-                            units={props.annotation.units}
-                        />
-                    );
-                }
+                return (
+                    <NumberRangePicker
+                        className={styles.picker}
+                        title={props.annotation.displayName}
+                        items={items}
+                        loading={isLoading}
+                        errorMessage={errorMessage}
+                        onSearch={onSearch}
+                        currentRange={filtersForAnnotation?.[0]}
+                        units={props.annotation.units}
+                    />
+                );
             case AnnotationType.STRING:
-                // Annotations without a scrollable list of values, e.g., File Path
-                if (items.length == 0) {
-                    return (
-                        <SearchBoxForm
-                            className={styles.picker}
-                            onSelectAll={onSelectAll}
-                            onDeselectAll={onDeselectAll}
-                            onSearch={onSearch}
-                            fuzzySearchEnabled={fuzzySearchEnabled}
-                            fieldName={props.annotation.displayName}
-                            defaultValue={filtersForAnnotation?.[0]}
-                            hideFuzzyToggle={!canFuzzySearch}
-                        />
-                    );
+                // Use list picker when there are a manageable number of values; fall back to search otherwise
+                if (items.length > 0 && items.length <= 100) {
+                    return listPickerComponent;
                 }
+                return (
+                    <SearchBoxForm
+                        className={styles.picker}
+                        onSelectAll={onSelectAll}
+                        onDeselectAll={onDeselectAll}
+                        onSearch={onSearch}
+                        fuzzySearchEnabled={fuzzySearchEnabled}
+                        fieldName={props.annotation.displayName}
+                        defaultValue={filtersForAnnotation?.[0]}
+                        hideFuzzyToggle={!canFuzzySearch}
+                    />
+                );
             case AnnotationType.DURATION:
             // prettier-ignore
             default: // FALL-THROUGH

--- a/packages/core/components/DateRangePicker/DateTimePicker.tsx
+++ b/packages/core/components/DateRangePicker/DateTimePicker.tsx
@@ -20,6 +20,11 @@ export default function DateTimePicker(props: DateTimePickerProps) {
     const [date, setDate] = React.useState<Date | undefined>(props?.defaultDate);
     const [time, setTime] = React.useState<string | undefined>("");
 
+    const onSelectDateRef = React.useRef(onSelectDate);
+    React.useLayoutEffect(() => {
+        onSelectDateRef.current = onSelectDate;
+    });
+
     React.useEffect(() => {
         if (!date && !time) return;
         // Prioritize the date from datePicked, otherwise set to today
@@ -29,8 +34,8 @@ export default function DateTimePicker(props: DateTimePickerProps) {
             combinedDateTime.setMinutes(Number(time.split(":")[1]));
             combinedDateTime.setSeconds(Number(time.split(":")[2]));
         }
-        onSelectDate(combinedDateTime);
-    }, [date, time, onSelectDate]);
+        onSelectDateRef.current(combinedDateTime);
+    }, [date, time]);
 
     return (
         <>

--- a/packages/core/components/DateRangePicker/index.tsx
+++ b/packages/core/components/DateRangePicker/index.tsx
@@ -116,7 +116,9 @@ export default function DateRangePicker(props: DateRangePickerProps) {
                     placeholder="Start of date range"
                     onSelectDate={(v) => (v ? onDateRangeSelection(v, null) : onReset())}
                     defaultDate={
-                        props.type == AnnotationType.DATE ? addTimeZoneOffset(startDate) : startDate
+                        props.type === AnnotationType.DATE
+                            ? addTimeZoneOffset(startDate)
+                            : startDate
                     }
                 />
                 <div className={styles.dateRangeSeparator}>
@@ -126,7 +128,7 @@ export default function DateRangePicker(props: DateRangePickerProps) {
                     placeholder="End of date range"
                     onSelectDate={(v) => (v ? onDateRangeSelection(null, v) : onReset())}
                     defaultDate={
-                        props?.type == AnnotationType.DATE ? addTimeZoneOffset(endDate) : endDate
+                        props?.type === AnnotationType.DATE ? addTimeZoneOffset(endDate) : endDate
                     }
                 />
                 <TertiaryButton

--- a/packages/core/components/DateRangePicker/index.tsx
+++ b/packages/core/components/DateRangePicker/index.tsx
@@ -125,7 +125,9 @@ export default function DateRangePicker(props: DateRangePickerProps) {
                 <DateTimePicker
                     placeholder="End of date range"
                     onSelectDate={(v) => (v ? onDateRangeSelection(null, v) : onReset())}
-                    defaultDate={AnnotationType.DATE ? addTimeZoneOffset(endDate) : endDate}
+                    defaultDate={
+                        props?.type == AnnotationType.DATE ? addTimeZoneOffset(endDate) : endDate
+                    }
                 />
                 <TertiaryButton
                     className={styles.clearButton}

--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -15,6 +15,7 @@ import {
 } from "./directory-hierarchy-state";
 import { findChildNodes } from "./findChildNodes";
 import FileList from "../FileList";
+import { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileFilter, { FilterType } from "../../entity/FileFilter";
 import FileSet from "../../entity/FileSet";
 import { ValueError } from "../../errors";
@@ -185,7 +186,14 @@ const useDirectoryHierarchy = (
                             take(pathToChildNode, depth + 1)
                         ).map((pair) => {
                             const [name, value] = pair as [string, string];
-                            return new FileFilter(name, value);
+                            const annotationType = annotations.find((ann) => ann.name === name)
+                                ?.type;
+                            return new FileFilter(
+                                name,
+                                value,
+                                FilterType.DEFAULT,
+                                annotationType as AnnotationType
+                            );
                         });
                         // If we are grouping by a field (e.g., barcode)
                         // and also have filters applied for that field (e.g., barcode=1234, barcode=1357),

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -40,11 +40,13 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
     const { errorMessage, items, loading, onSearch, currentRange, units } = props;
 
     const overallMin = React.useMemo(() => {
-        return items[0]?.displayValue.toString() ?? "";
+        return items[0]?.value?.toString() ?? "";
     }, [items]);
     const overallMax = React.useMemo(() => {
-        return items.at(-1)?.displayValue.toString() ?? "";
+        return items.at(-1)?.value?.toString() ?? "";
     }, [items]);
+    const overallMinDisplay = items[0]?.displayValue?.toString() ?? overallMin;
+    const overallMaxDisplay = items.at(-1)?.displayValue?.toString() ?? overallMax;
 
     const [searchMinValue, setSearchMinValue] = React.useState(
         extractValuesFromRangeOperatorFilterString(currentRange?.value).minValue ?? overallMin
@@ -57,7 +59,9 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
     function onResetSearch() {
         setSearchMinValue(overallMin);
         setSearchMaxValue(overallMax);
-        onSearch(`RANGE(${overallMin},${overallMax})`);
+        if (overallMin && overallMax) {
+            onSearch(`RANGE(${overallMin},${overallMax})`);
+        }
     }
 
     const onSubmitRange = () => {
@@ -145,7 +149,7 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                     <div className={styles.footerLeft}>
                         <div> Full range available: </div>
                         <div>
-                            {overallMin}, {overallMax}
+                            {overallMinDisplay}, {overallMaxDisplay}
                         </div>
                     </div>
                 )}

--- a/packages/core/entity/AnnotationFormatter/number-formatter.ts
+++ b/packages/core/entity/AnnotationFormatter/number-formatter.ts
@@ -5,7 +5,9 @@ export default {
         const { minValue, maxValue } = extractValuesFromRangeOperatorFilterString(value.toString());
         const formatNumber = (val: string | number) => {
             if (units === "bytes") {
-                return filesize(Number(val));
+                const num = Number(val);
+                if (isNaN(num)) return String(val);
+                return filesize(num);
             }
             return `${val}${units ? " " + units : ""}`;
         };

--- a/packages/core/entity/AnnotationFormatter/test/formatters.test.ts
+++ b/packages/core/entity/AnnotationFormatter/test/formatters.test.ts
@@ -61,6 +61,9 @@ describe("Annotation formatters", () => {
                 input: "RANGE(2018-05-24T00:00:00-08:00,2019-05-26T00:00:00-08:00)",
                 expected: "5/24/2018, 1:00:00 AM; 5/26/2019, 1:00:00 AM",
             },
+
+            // duckdb-wasm returns timestamp values as BigInt ms-since-epoch numeric strings
+            { input: "1645833600000", expected: "2/25/2022, 4:00:00 PM" },
         ];
 
         spec.forEach((testCase) =>
@@ -91,8 +94,11 @@ describe("Annotation formatters", () => {
                 input: "RANGE(2018-05-24T00:00:00+0000,2019-05-26T00:00:00+0000)",
                 expected: "2018-05-24, 2019-05-26",
             },
+
+            // duckdb-wasm returns date values as BigInt ms-since-epoch numeric strings
+            { input: "1645833600000", expected: "2022-02-26" },
         ];
-        6;
+
         spec.forEach((testCase) => {
             it(`formats ${testCase.input} as a date (expected: ${testCase.expected})`, () => {
                 expect(dateFormatter.displayValue(testCase.input)).to.equal(testCase.expected);

--- a/packages/core/entity/FileFilter/index.ts
+++ b/packages/core/entity/FileFilter/index.ts
@@ -1,7 +1,7 @@
 import SQLBuilder from "../SQLBuilder";
 import { extractValuesFromRangeOperatorFilterString } from "../AnnotationFormatter/number-formatter";
 import { extractDatesFromRangeOperatorFilterString } from "../AnnotationFormatter/date-time-formatter";
-import { AnnotationType } from "../AnnotationFormatter";
+import annotationFormatterFactory, { AnnotationType } from "../AnnotationFormatter";
 import { NO_VALUE_NODE } from "../../components/DirectoryTree/directory-hierarchy-state";
 
 // Matches the RANGE(min, max) filter encoding used by NumberRangePicker (numeric bounds)
@@ -98,36 +98,43 @@ export default class FileFilter {
             case FilterType.FUZZY:
                 return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
             default:
-                if (this.annotationType === AnnotationType.BOOLEAN) {
-                    return `"${this.annotationName}" = ${this.annotationValue}`;
-                }
-                if (
-                    this.annotationType === AnnotationType.NUMBER &&
-                    RANGE_OPERATOR_REGEX.test(this.annotationValue)
-                ) {
-                    const { minValue, maxValue } = extractValuesFromRangeOperatorFilterString(
-                        this.annotationValue
-                    );
-                    return `CAST("${this.annotationName}" AS DOUBLE) >= ${minValue} AND CAST("${this.annotationName}" AS DOUBLE) < ${maxValue}`;
-                }
-                if (
-                    (this.annotationType === AnnotationType.DATE ||
-                        this.annotationType === AnnotationType.DATETIME) &&
-                    DATE_RANGE_OPERATOR_REGEX.test(this.annotationValue)
-                ) {
-                    const { startDate, endDate } = extractDatesFromRangeOperatorFilterString(
-                        this.annotationValue
-                    );
-                    return `CAST("${
-                        this.annotationName
-                    }" AS TIMESTAMPTZ) >= CAST('${startDate?.toISOString()}' AS TIMESTAMPTZ) AND CAST("${
-                        this.annotationName
-                    }" AS TIMESTAMPTZ) < CAST('${endDate?.toISOString()}' AS TIMESTAMPTZ)`;
-                }
-                if (this.annotationType === AnnotationType.DURATION) {
-                    return `EXTRACT(epoch FROM "${this.annotationName}")::BIGINT * 1000 = ${Number(
-                        this.annotationValue
-                    )}`;
+                switch (this.annotationType) {
+                    case AnnotationType.BOOLEAN:
+                        return `"${this.annotationName}" = ${this.annotationValue}`;
+                    case AnnotationType.NUMBER:
+                        if (RANGE_OPERATOR_REGEX.test(this.annotationValue)) {
+                            const {
+                                minValue,
+                                maxValue,
+                            } = extractValuesFromRangeOperatorFilterString(this.annotationValue);
+                            return `CAST("${this.annotationName}" AS DOUBLE) >= ${minValue} AND CAST("${this.annotationName}" AS DOUBLE) < ${maxValue}`;
+                        }
+                        return `CAST("${this.annotationName}" AS DOUBLE) = ${this.annotationValue}`;
+                    case AnnotationType.DATE:
+                    case AnnotationType.DATETIME:
+                        if (DATE_RANGE_OPERATOR_REGEX.test(this.annotationValue)) {
+                            const {
+                                startDate,
+                                endDate,
+                            } = extractDatesFromRangeOperatorFilterString(this.annotationValue);
+                            return `CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) >= CAST('${startDate?.toISOString()}' AS TIMESTAMPTZ) AND CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) < CAST('${endDate?.toISOString()}' AS TIMESTAMPTZ)`;
+                        } else {
+                            const dateFormatter = annotationFormatterFactory(this.annotationType);
+                            const dateString = dateFormatter.displayValue(this.annotationValue);
+                            return `CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) =  CAST('${new Date(
+                                dateString
+                            ).toISOString()}' as TIMESTAMPTZ)`;
+                        }
+                    case AnnotationType.DURATION:
+                        return `EXTRACT(epoch FROM "${
+                            this.annotationName
+                        }")::BIGINT * 1000 = ${Number(this.annotationValue)}`;
                 }
                 return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
         }

--- a/packages/core/entity/FileFilter/index.ts
+++ b/packages/core/entity/FileFilter/index.ts
@@ -1,5 +1,13 @@
 import SQLBuilder from "../SQLBuilder";
+import { extractValuesFromRangeOperatorFilterString } from "../AnnotationFormatter/number-formatter";
+import { extractDatesFromRangeOperatorFilterString } from "../AnnotationFormatter/date-time-formatter";
+import { AnnotationType } from "../AnnotationFormatter";
 import { NO_VALUE_NODE } from "../../components/DirectoryTree/directory-hierarchy-state";
+
+// Matches the RANGE(min, max) filter encoding used by NumberRangePicker (numeric bounds)
+const RANGE_OPERATOR_REGEX = /^RANGE\([\d\-.]+,\s?[\d\-.]+\)$/;
+// Matches the RANGE(isoDate,isoDate) filter encoding used by DateRangePicker (ISO 8601 date strings)
+const DATE_RANGE_OPERATOR_REGEX = /^RANGE\([\d\-+:TZ.]+,[\d\-+:TZ.]+\)$/;
 
 export interface FileFilterJson {
     name: string;
@@ -30,6 +38,7 @@ export default class FileFilter {
     private readonly annotationName: string;
     private readonly annotationValue: any;
     private filterType: FilterType;
+    private readonly annotationType?: AnnotationType;
 
     public static isFileFilter(candidate: any): candidate is FileFilter {
         return candidate instanceof FileFilter;
@@ -38,11 +47,13 @@ export default class FileFilter {
     constructor(
         annotationName: string,
         annotationValue: any,
-        filterType: FilterType = FilterType.DEFAULT
+        filterType: FilterType = FilterType.DEFAULT,
+        annotationType?: AnnotationType
     ) {
         this.annotationName = annotationName;
         this.annotationValue = annotationValue;
         this.filterType = annotationValue === NO_VALUE_NODE ? FilterType.EXCLUDE : filterType;
+        this.annotationType = annotationType;
     }
 
     public get name() {
@@ -85,7 +96,39 @@ export default class FileFilter {
             case FilterType.EXCLUDE:
                 return `"${this.annotationName}" IS NULL`;
             case FilterType.FUZZY:
+                return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
             default:
+                if (this.annotationType === AnnotationType.BOOLEAN) {
+                    return `"${this.annotationName}" = ${this.annotationValue}`;
+                }
+                if (
+                    this.annotationType === AnnotationType.NUMBER &&
+                    RANGE_OPERATOR_REGEX.test(this.annotationValue)
+                ) {
+                    const { minValue, maxValue } = extractValuesFromRangeOperatorFilterString(
+                        this.annotationValue
+                    );
+                    return `CAST("${this.annotationName}" AS DOUBLE) >= ${minValue} AND CAST("${this.annotationName}" AS DOUBLE) < ${maxValue}`;
+                }
+                if (
+                    (this.annotationType === AnnotationType.DATE ||
+                        this.annotationType === AnnotationType.DATETIME) &&
+                    DATE_RANGE_OPERATOR_REGEX.test(this.annotationValue)
+                ) {
+                    const { startDate, endDate } = extractDatesFromRangeOperatorFilterString(
+                        this.annotationValue
+                    );
+                    return `CAST("${
+                        this.annotationName
+                    }" AS TIMESTAMPTZ) >= CAST('${startDate?.toISOString()}' AS TIMESTAMPTZ) AND CAST("${
+                        this.annotationName
+                    }" AS TIMESTAMPTZ) < CAST('${endDate?.toISOString()}' AS TIMESTAMPTZ)`;
+                }
+                if (this.annotationType === AnnotationType.DURATION) {
+                    return `EXTRACT(epoch FROM "${this.annotationName}")::BIGINT * 1000 = ${Number(
+                        this.annotationValue
+                    )}`;
+                }
                 return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
         }
     }

--- a/packages/core/entity/FileFilter/test/FileFilter.test.ts
+++ b/packages/core/entity/FileFilter/test/FileFilter.test.ts
@@ -1,11 +1,73 @@
 import { expect } from "chai";
 
 import FileFilter, { FilterType } from "../";
+import { AnnotationType } from "../../AnnotationFormatter";
 import IncludeFilter from "../IncludeFilter";
 import ExcludeFilter from "../ExcludeFilter";
 import FuzzyFilter from "../FuzzyFilter";
 
 describe("FileFilter", () => {
+    describe("toSQLWhereString", () => {
+        // BOOLEAN: direct equality avoids CAST/regex mismatch on true/false values
+        it("emits a boolean equality clause for boolean filter values", () => {
+            expect(
+                new FileFilter(
+                    "Is Control",
+                    true,
+                    FilterType.DEFAULT,
+                    AnnotationType.BOOLEAN
+                ).toSQLWhereString()
+            ).to.equal(`"Is Control" = true`);
+            expect(
+                new FileFilter(
+                    "Is Control",
+                    false,
+                    FilterType.DEFAULT,
+                    AnnotationType.BOOLEAN
+                ).toSQLWhereString()
+            ).to.equal(`"Is Control" = false`);
+        });
+
+        // NUMBER: RANGE(min,max) from NumberRangePicker must produce CAST AS DOUBLE comparison SQL
+        it("emits a numeric range SQL clause for RANGE() filter values", () => {
+            const filter = new FileFilter(
+                "Cell Count",
+                "RANGE(1, 50)",
+                FilterType.DEFAULT,
+                AnnotationType.NUMBER
+            );
+            expect(filter.toSQLWhereString()).to.equal(
+                `CAST("Cell Count" AS DOUBLE) >= 1 AND CAST("Cell Count" AS DOUBLE) < 50`
+            );
+        });
+
+        // DATE/DATETIME: RANGE(isoDate,isoDate) from DateRangePicker must produce TIMESTAMPTZ comparison SQL
+        it("emits a date range SQL clause for RANGE() filter values with ISO date strings", () => {
+            const filter = new FileFilter(
+                "Date Created",
+                "RANGE(2022-01-01T00:00:00.000Z,2022-01-31T00:00:00.000Z)",
+                FilterType.DEFAULT,
+                AnnotationType.DATETIME
+            );
+            expect(filter.toSQLWhereString()).to.equal(
+                `CAST("Date Created" AS TIMESTAMPTZ) >= CAST('2022-01-01T00:00:00.000Z' AS TIMESTAMPTZ) AND CAST("Date Created" AS TIMESTAMPTZ) < CAST('2022-01-31T00:00:00.000Z' AS TIMESTAMPTZ)`
+            );
+        });
+
+        // DURATION: INTERVAL columns use EXTRACT(epoch) to convert to ms for equality comparison
+        it("emits an epoch extraction SQL clause for DURATION annotation type", () => {
+            const filter = new FileFilter(
+                "Acquisition Duration",
+                60000,
+                FilterType.DEFAULT,
+                AnnotationType.DURATION
+            );
+            expect(filter.toSQLWhereString()).to.equal(
+                `EXTRACT(epoch FROM "Acquisition Duration")::BIGINT * 1000 = 60000`
+            );
+        });
+    });
+
     describe("equals", () => {
         it("is backwards compatible when no type argument is provided", () => {
             // Arrange

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -4,7 +4,8 @@ import { createSandbox } from "sinon";
 
 import FileSet from "../";
 import { FESBaseUrl } from "../../../constants";
-import FileFilter from "../../FileFilter";
+import FileFilter, { FilterType } from "../../FileFilter";
+import { AnnotationType } from "../../AnnotationFormatter";
 import FileSort, { SortOrder } from "../../FileSort";
 import { makeFileDetailMock } from "../../FileDetail/mocks";
 import FuzzyFilter from "../../FileFilter/FuzzyFilter";
@@ -16,7 +17,12 @@ import FileDownloadServiceNoop from "../../../services/FileDownloadService/FileD
 describe("FileSet", () => {
     const scientistEqualsJane = new FileFilter("scientist", "jane");
     const scientistEqualsJohn = new FileFilter("scientist", "john");
-    const matrigelIsHard = new FileFilter("matrigel_is_hardened", true);
+    const matrigelIsHard = new FileFilter(
+        "matrigel_is_hardened",
+        true,
+        FilterType.DEFAULT,
+        AnnotationType.BOOLEAN
+    );
     const dateCreatedDescending = new FileSort("date_created", SortOrder.DESC);
     const fuzzyFileName = new FuzzyFilter("file_name");
     const fuzzyFilePath = new FuzzyFilter("file_path");

--- a/packages/web/src/entity/PublicDataset/index.ts
+++ b/packages/web/src/entity/PublicDataset/index.ts
@@ -171,7 +171,7 @@ export default class PublicDataset {
     }
 
     public get featured(): boolean {
-        return this.datasetDetails.featured === "TRUE";
+        return this.datasetDetails.featured?.toLowerCase() === "true";
     }
 
     public getFirstAnnotationValue(annotationName: string): string | number | boolean | undefined {


### PR DESCRIPTION
Reopening with #731 

## Context
Graham identified a bug with https://tinyurl.com/Figure-1a where the file lists are no longer loading for numerical types.
Was able to replicate with other datasets by grouping on `Number` or `Date` types.

Also addresses a semi-related bug where the [open source dataset page](https://bff.allencell.org/datasets) is no longer loading the featured dataset because of the change in how we handle boolean values

## Changes
Makes sure that annotation types are passed into file filters in the directory hierarchy.
Also, the`toSQLWhereString` function was only accounting for when numbers/dates were in `RANGE` filters, and didn't have a case for single value filters.

## Testing
I was mostly manually testing on both Graham's dataset and the smoke tests from the data type PR. Ideally we should have automated regression tests for situations like this, but I'm unsure if there's a good option in this case