### PR TITLE
Bugfix/grouping with types

### DIFF
--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -15,6 +15,7 @@ import {
 } from "./directory-hierarchy-state";
 import { findChildNodes } from "./findChildNodes";
 import FileList from "../FileList";
+import { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileFilter, { FilterType } from "../../entity/FileFilter";
 import FileSet from "../../entity/FileSet";
 import { ValueError } from "../../errors";
@@ -185,7 +186,14 @@ const useDirectoryHierarchy = (
                             take(pathToChildNode, depth + 1)
                         ).map((pair) => {
                             const [name, value] = pair as [string, string];
-                            return new FileFilter(name, value);
+                            const annotationType = annotations.find((ann) => ann.name === name)
+                                ?.type;
+                            return new FileFilter(
+                                name,
+                                value,
+                                FilterType.DEFAULT,
+                                annotationType as AnnotationType
+                            );
                         });
                         // If we are grouping by a field (e.g., barcode)
                         // and also have filters applied for that field (e.g., barcode=1234, barcode=1357),

--- a/packages/core/entity/FileFilter/index.ts
+++ b/packages/core/entity/FileFilter/index.ts
@@ -1,7 +1,7 @@
 import SQLBuilder from "../SQLBuilder";
 import { extractValuesFromRangeOperatorFilterString } from "../AnnotationFormatter/number-formatter";
 import { extractDatesFromRangeOperatorFilterString } from "../AnnotationFormatter/date-time-formatter";
-import { AnnotationType } from "../AnnotationFormatter";
+import annotationFormatterFactory, { AnnotationType } from "../AnnotationFormatter";
 import { NO_VALUE_NODE } from "../../components/DirectoryTree/directory-hierarchy-state";
 
 // Matches the RANGE(min, max) filter encoding used by NumberRangePicker (numeric bounds)
@@ -98,36 +98,43 @@ export default class FileFilter {
             case FilterType.FUZZY:
                 return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
             default:
-                if (this.annotationType === AnnotationType.BOOLEAN) {
-                    return `"${this.annotationName}" = ${this.annotationValue}`;
-                }
-                if (
-                    this.annotationType === AnnotationType.NUMBER &&
-                    RANGE_OPERATOR_REGEX.test(this.annotationValue)
-                ) {
-                    const { minValue, maxValue } = extractValuesFromRangeOperatorFilterString(
-                        this.annotationValue
-                    );
-                    return `CAST("${this.annotationName}" AS DOUBLE) >= ${minValue} AND CAST("${this.annotationName}" AS DOUBLE) < ${maxValue}`;
-                }
-                if (
-                    (this.annotationType === AnnotationType.DATE ||
-                        this.annotationType === AnnotationType.DATETIME) &&
-                    DATE_RANGE_OPERATOR_REGEX.test(this.annotationValue)
-                ) {
-                    const { startDate, endDate } = extractDatesFromRangeOperatorFilterString(
-                        this.annotationValue
-                    );
-                    return `CAST("${
-                        this.annotationName
-                    }" AS TIMESTAMPTZ) >= CAST('${startDate?.toISOString()}' AS TIMESTAMPTZ) AND CAST("${
-                        this.annotationName
-                    }" AS TIMESTAMPTZ) < CAST('${endDate?.toISOString()}' AS TIMESTAMPTZ)`;
-                }
-                if (this.annotationType === AnnotationType.DURATION) {
-                    return `EXTRACT(epoch FROM "${this.annotationName}")::BIGINT * 1000 = ${Number(
-                        this.annotationValue
-                    )}`;
+                switch (this.annotationType) {
+                    case AnnotationType.BOOLEAN:
+                        return `"${this.annotationName}" = ${this.annotationValue}`;
+                    case AnnotationType.NUMBER:
+                        if (RANGE_OPERATOR_REGEX.test(this.annotationValue)) {
+                            const {
+                                minValue,
+                                maxValue,
+                            } = extractValuesFromRangeOperatorFilterString(this.annotationValue);
+                            return `CAST("${this.annotationName}" AS DOUBLE) >= ${minValue} AND CAST("${this.annotationName}" AS DOUBLE) < ${maxValue}`;
+                        }
+                        return `CAST("${this.annotationName}" AS DOUBLE) = ${this.annotationValue}`;
+                    case AnnotationType.DATE:
+                    case AnnotationType.DATETIME:
+                        if (DATE_RANGE_OPERATOR_REGEX.test(this.annotationValue)) {
+                            const {
+                                startDate,
+                                endDate,
+                            } = extractDatesFromRangeOperatorFilterString(this.annotationValue);
+                            return `CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) >= CAST('${startDate?.toISOString()}' AS TIMESTAMPTZ) AND CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) < CAST('${endDate?.toISOString()}' AS TIMESTAMPTZ)`;
+                        } else {
+                            const dateFormatter = annotationFormatterFactory(this.annotationType);
+                            const dateString = dateFormatter.displayValue(this.annotationValue);
+                            return `CAST("${
+                                this.annotationName
+                            }" AS TIMESTAMPTZ) =  CAST('${new Date(
+                                dateString
+                            ).toISOString()}' as TIMESTAMPTZ)`;
+                        }
+                    case AnnotationType.DURATION:
+                        return `EXTRACT(epoch FROM "${
+                            this.annotationName
+                        }")::BIGINT * 1000 = ${Number(this.annotationValue)}`;
                 }
                 return SQLBuilder.regexMatchValueInList(this.annotationName, this.annotationValue);
         }

--- a/packages/web/src/entity/PublicDataset/index.ts
+++ b/packages/web/src/entity/PublicDataset/index.ts
@@ -171,7 +171,7 @@ export default class PublicDataset {
     }
 
     public get featured(): boolean {
-        return this.datasetDetails.featured === "TRUE";
+        return this.datasetDetails.featured?.toLowerCase() === "true";
     }
 
     public getFirstAnnotationValue(annotationName: string): string | number | boolean | undefined {


### PR DESCRIPTION
## Context
Graham identified a bug with https://tinyurl.com/Figure-1a where the file lists are no longer loading for numerical types.
Was able to replicate with other datasets by grouping on `Number` or `Date` types.

Also addresses a semi-related bug where the [open source dataset page](https://bff.allencell.org/datasets) is no longer loading the featured dataset because of the change in how we handle boolean values

## Changes
Makes sure that annotation types are passed into file filters in the directory hierarchy.
Also, the`toSQLWhereString` function was only accounting for when numbers/dates were in `RANGE` filters, and didn't have a case for single value filters.

## Testing
I was mostly manually testing on both Graham's dataset and the smoke tests from the data type PR. Ideally we should have automated regression tests for situations like this, but I'm unsure if there's a good option in this case