### PR TITLE
Fix loading metadata descriptor files

### DIFF
--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -7,11 +7,13 @@ import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import Annotation from "../../../entity/Annotation";
 import FileFilter from "../../../entity/FileFilter";
 import IncludeFilter from "../../../entity/FileFilter/IncludeFilter";
+import { Source } from "../../../entity/SearchParams";
 import SQLBuilder from "../../../entity/SQLBuilder";
 
 interface Config {
     databaseService: DatabaseService;
     dataSourceNames: string[];
+    metadataSource?: Source;
 }
 
 interface QueryResult {
@@ -24,19 +26,21 @@ interface QueryResult {
 export default class DatabaseAnnotationService implements AnnotationService {
     private readonly databaseService: DatabaseService;
     private readonly dataSourceNames: string[];
+    private readonly metadataSource: Source | undefined;
 
     constructor(
         config: Config = { dataSourceNames: [], databaseService: new DatabaseServiceNoop() }
     ) {
         this.dataSourceNames = config.dataSourceNames;
         this.databaseService = config.databaseService;
+        this.metadataSource = config.metadataSource;
     }
 
     /**
      * Fetch all annotations.
      */
     public fetchAnnotations(): Promise<Annotation[]> {
-        return this.databaseService.fetchAnnotations(this.dataSourceNames);
+        return this.databaseService.fetchAnnotations(this.dataSourceNames, this.metadataSource);
     }
 
     /**

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -470,11 +470,9 @@ export default abstract class DatabaseService {
         }
     }
 
-    public async deleteSourceMetadata(name?: string): Promise<void> {
-        // If a specific metadata file name is passed, delete it
-        // Otherwise, delete the currently selected one
-        if (name) await this.deleteDataSource(name);
-        else if (this.sourceMetadataName) this.deleteDataSource(this.sourceMetadataName);
+    public async deleteSourceMetadata(): Promise<void> {
+        // Avoid trying to delete a file that doesn't exist
+        if (this.sourceMetadataName) await this.deleteDataSource(this.sourceMetadataName);
         this.dataSourceToAnnotationsMap.clear();
     }
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -374,7 +374,7 @@ export default abstract class DatabaseService {
         if (isPreviousSource && this.hasDataSource(sourceMetadata.name)) {
             return;
         }
-        // If the data source needs replacing (e.g., we've been passed a new source with a URI), delete the old instance before preparing the new one
+        // If the metadata source is being replaced, delete the old instance before preparing the new one
         if (sourceMetadata.uri) {
             await this.deleteSourceMetadata();
             // Make sure we don't still have a cached version of the metadata source
@@ -388,6 +388,7 @@ export default abstract class DatabaseService {
                 );
             }
         }
+        // If the source doesn't have a uri, we should instead try to use the cached table
         this.sourceMetadataName = sourceMetadata.name;
     }
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -110,10 +110,9 @@ export async function initializeDuckDB(logLevel: duckdb.LogLevel): Promise<duckd
  */
 export default abstract class DatabaseService {
     public static readonly LIST_DELIMITER = ",";
-    protected readonly SOURCE_METADATA_TABLE = "source_metadata";
     protected readonly SOURCE_PROVENANCE_TABLE = "source_provenance";
     private static readonly ANNOTATION_TYPE_SET = new Set(Object.values(AnnotationType));
-    private sourceMetadataName?: string;
+    protected sourceMetadataName?: string;
     public sourceProvenanceName?: string;
     private currentAggregateSource?: string;
     // Initialize with AICS FMS data source name to pretend it always exists
@@ -288,7 +287,7 @@ export default abstract class DatabaseService {
 
         if (!type || !uri) {
             throw new DataSourcePreparationError(
-                `Lost access to the data source.\
+                `Lost access to data source "${name}".\
                 </br> \
                 Local data sources must be re-uploaded with each \
                 page refresh to gain access to the data source file \
@@ -334,7 +333,7 @@ export default abstract class DatabaseService {
 
         if (!type || !uri) {
             throw new DataSourcePreparationError(
-                `Lost access to the data source.\
+                `Lost access to data source "${name}".\
                 </br> \
                 Local data sources must be re-uploaded with each \
                 page refresh to gain access to the data source file \
@@ -372,18 +371,23 @@ export default abstract class DatabaseService {
 
     public async prepareSourceMetadata(sourceMetadata: Source): Promise<void> {
         const isPreviousSource = sourceMetadata.name === this.sourceMetadataName;
-        if (isPreviousSource) {
+        if (isPreviousSource && this.hasDataSource(sourceMetadata.name)) {
             return;
         }
-
-        await this.deleteSourceMetadata();
-        await this.prepareDataSourceWrapper(
-            {
-                ...sourceMetadata,
-                name: this.SOURCE_METADATA_TABLE,
-            },
-            true
-        );
+        // If the data source needs replacing (e.g., we've been passed a new source with a URI), delete the old instance before preparing the new one
+        if (sourceMetadata.uri) {
+            await this.deleteSourceMetadata();
+            // Make sure we don't still have a cached version of the metadata source
+            if (!this.hasDataSource(sourceMetadata.name)) {
+                await this.prepareDataSourceWrapper(
+                    {
+                        ...sourceMetadata,
+                        name: sourceMetadata.name,
+                    },
+                    true
+                );
+            }
+        }
         this.sourceMetadataName = sourceMetadata.name;
     }
 
@@ -411,8 +415,11 @@ export default abstract class DatabaseService {
         }
     }
 
-    public async deleteSourceMetadata(): Promise<void> {
-        await this.deleteDataSource(this.SOURCE_METADATA_TABLE);
+    public async deleteSourceMetadata(name?: string): Promise<void> {
+        // If a specific metadata file name is passed, delete it
+        // Otherwise, delete the currently selected one
+        if (name) await this.deleteDataSource(name);
+        else if (this.sourceMetadataName) this.deleteDataSource(this.sourceMetadataName);
         this.dataSourceToAnnotationsMap.clear();
     }
 
@@ -964,14 +971,19 @@ export default abstract class DatabaseService {
         }
     }
 
-    public async fetchAnnotations(dataSourceNames: string[]): Promise<Annotation[]> {
+    public async fetchAnnotations(
+        dataSourceNames: string[],
+        metadataSource?: Source
+    ): Promise<Annotation[]> {
         const aggregateDataSourceName = dataSourceNames.sort().join(", ");
         const hasAnnotations = this.dataSourceToAnnotationsMap.has(aggregateDataSourceName);
         const hasDescriptions = this.dataSourceToAnnotationsMap
             .get(aggregateDataSourceName)
             ?.some((annotation) => !!annotation.description);
-        const shouldHaveDescriptions = dataSourceNames.includes(this.SOURCE_METADATA_TABLE);
+        const shouldHaveDescriptions =
+            metadataSource && this.existingDataSources.has(metadataSource?.name);
         if (!hasAnnotations || (!hasDescriptions && shouldHaveDescriptions)) {
+            this.sourceMetadataName = metadataSource?.name;
             const sql = new SQLBuilder()
                 .select("column_name, data_type")
                 .from('information_schema"."columns')
@@ -1019,13 +1031,13 @@ export default abstract class DatabaseService {
 
     protected async fetchAnnotationDescriptions(): Promise<Record<string, string>> {
         // Unless we have actually added the source metadata table we can't fetch the descriptions
-        if (!this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+        if (!this.sourceMetadataName || !this.existingDataSources.has(this.sourceMetadataName)) {
             return {};
         }
 
         const sql = new SQLBuilder()
             .select('"Column Name", "Description"')
-            .from(this.SOURCE_METADATA_TABLE)
+            .from(this.sourceMetadataName)
             .toSQL();
         try {
             const rows = await this.query(sql).promise;
@@ -1046,13 +1058,13 @@ export default abstract class DatabaseService {
 
     public async fetchAnnotationTypes(): Promise<Record<string, string>> {
         // Unless we have actually added the source metadata table we can't fetch the types
-        if (!this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+        if (!this.sourceMetadataName || !this.existingDataSources.has(this.sourceMetadataName)) {
             return {};
         }
 
         const sql = new SQLBuilder()
             .select('"Column Name", "Type"')
-            .from(this.SOURCE_METADATA_TABLE)
+            .from(this.sourceMetadataName)
             .toSQL();
 
         try {
@@ -1087,9 +1099,13 @@ export default abstract class DatabaseService {
         // Cache is now invalid since we added a column
         this.dataSourceToAnnotationsMap.delete(datasourceName);
 
-        if (description?.trim() && this.existingDataSources.has(this.SOURCE_METADATA_TABLE)) {
+        if (
+            description?.trim() &&
+            this.sourceMetadataName &&
+            this.existingDataSources.has(this.sourceMetadataName)
+        ) {
             await this
-                .execute(`INSERT INTO "${this.SOURCE_METADATA_TABLE}" ("Column Name", "Description")
+                .execute(`INSERT INTO "${this.sourceMetadataName}" ("Column Name", "Description")
                     VALUES ('${columnName}', '${description}');`);
         }
     }

--- a/packages/core/state/interaction/selectors.ts
+++ b/packages/core/state/interaction/selectors.ts
@@ -18,7 +18,11 @@ import {
     getDataSources,
     getEdgeDefinitions,
 } from "../metadata/selectors";
-import { getSelectedDataSources, getPythonConversion } from "../selection/selectors";
+import {
+    getSelectedDataSources,
+    getPythonConversion,
+    getSelectedSourceMetadata,
+} from "../selection/selectors";
 import { AnnotationService, FileService } from "../../services";
 import DatasetService, {
     DataSource,
@@ -231,6 +235,7 @@ export const getAnnotationService = createSelector(
         getFileExplorerServiceBaseUrl,
         getMetadataManagementServiceBaseUrl,
         getSelectedDataSources,
+        getSelectedSourceMetadata,
         getPlatformDependentServices,
         getRefreshKey,
     ],
@@ -240,12 +245,14 @@ export const getAnnotationService = createSelector(
         fileExplorerServiceBaseUrl,
         metadataManagementServiceBaseUrl,
         dataSources,
+        metadataSource,
         platformDependentServices
     ): AnnotationService => {
         if (dataSources.length && dataSources[0]?.name !== AICS_FMS_DATA_SOURCE_NAME) {
             return new DatabaseAnnotationService({
                 databaseService: platformDependentServices.databaseService,
                 dataSourceNames: dataSources.map((source) => source.name),
+                metadataSource,
             });
         }
         return new HttpAnnotationService({

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -649,13 +649,14 @@ const changeSourceMetadataLogic = createLogic({
                 await databaseService.deleteSourceMetadata();
             }
         } catch (err) {
-            const errMsg = (err as Error).message || "Unknown error while adding query";
+            const errMsg = (err as Error).message || "Unknown error while adding metadata source";
             if (err instanceof DataSourcePreparationError) {
                 dispatch(addDataSourceReloadError(err.sourceName, errMsg) as AnyAction);
             } else {
                 dispatch(interaction.actions.processError("dataSourcePreparationError", errMsg));
             }
         }
+
         dispatch(metadata.actions.requestAnnotations());
         done();
     },

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -642,12 +642,20 @@ const changeSourceMetadataLogic = createLogic({
         const { databaseService } = interaction.selectors.getPlatformDependentServices(
             deps.getState()
         );
-        if (selectedSourceMetadata) {
-            await databaseService.prepareSourceMetadata(selectedSourceMetadata);
-        } else {
-            await databaseService.deleteSourceMetadata();
+        try {
+            if (selectedSourceMetadata) {
+                await databaseService.prepareSourceMetadata(selectedSourceMetadata);
+            } else {
+                await databaseService.deleteSourceMetadata();
+            }
+        } catch (err) {
+            const errMsg = (err as Error).message || "Unknown error while adding query";
+            if (err instanceof DataSourcePreparationError) {
+                dispatch(addDataSourceReloadError(err.sourceName, errMsg) as AnyAction);
+            } else {
+                dispatch(interaction.actions.processError("dataSourcePreparationError", errMsg));
+            }
         }
-
         dispatch(metadata.actions.requestAnnotations());
         done();
     },

--- a/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
@@ -108,12 +108,16 @@ const messageHandler: { [T in WorkerMsgType]: MessageHandler<T> } = {
             });
         }
     },
-    [WorkerMsgType.ANNOTATIONS]: async ({ dataSourceNames, id }) => {
+    [WorkerMsgType.ANNOTATIONS]: async ({ dataSourceNames, metadataSource, id }) => {
         try {
             if (!databaseService) {
                 throw new Error("DuckDB not initialized");
             }
-            const rows = await databaseService.fetchAnnotationsWorker(dataSourceNames, id);
+            const rows = await databaseService.fetchAnnotationsWorker(
+                dataSourceNames,
+                metadataSource,
+                id
+            );
             // Annotation rows need to be converted into flat AnnotationResponse objects for worker
             // since message cannot contain functions
             const result: AnnotationResponse[] = rows.map(
@@ -278,13 +282,17 @@ export default class DatabaseServiceWebWorker extends DatabaseService {
         this.deleteDataSource(dataSource);
     }
 
-    public async fetchAnnotations(dataSourceNames: string[]): Promise<Annotation[]> {
-        return await this.fetchAnnotationsWorker(dataSourceNames);
+    public async fetchAnnotations(
+        dataSourceNames: string[],
+        metadataSource?: Source
+    ): Promise<Annotation[]> {
+        return await this.fetchAnnotationsWorker(dataSourceNames, metadataSource);
     }
 
     // Custom method to allow us to take an id and call the worker version of query; otherwise the same as parent fn
     public async fetchAnnotationsWorker(
         dataSourceNames: string[],
+        metadataSource: Source | undefined,
         id?: string
     ): Promise<Annotation[]> {
         const aggregateDataSourceName = dataSourceNames.sort().join(", ");
@@ -294,8 +302,11 @@ export default class DatabaseServiceWebWorker extends DatabaseService {
             .get(aggregateDataSourceName)
             ?.some((annotation) => !!annotation.description);
 
-        const shouldHaveDescriptions = dataSourceNames.includes(this.SOURCE_METADATA_TABLE);
+        const shouldHaveDescriptions =
+            metadataSource && this.existingDataSources.has(metadataSource.name);
         if (!hasAnnotations || (!hasDescriptions && shouldHaveDescriptions)) {
+            // Make sure dbservice is referencing the correct metadata source
+            this.sourceMetadataName = metadataSource?.name;
             const sql = new SQLBuilder()
                 .select("column_name, data_type")
                 .from('information_schema"."columns')

--- a/packages/web/src/services/DatabaseServiceWeb/index.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/index.ts
@@ -202,14 +202,13 @@ export default class DatabaseServiceWeb extends DatabaseService {
                 payload: { name: dataSource },
             });
         });
-        const wrappedPromise = promise.finally(() => {
-            this.existingDataSources.delete(dataSource);
-            this.dataSourceToAnnotationsMap.delete(dataSource);
-        });
-        return wrappedPromise;
+        return promise;
     }
 
-    public async fetchAnnotations(dataSourceNames: string[]): Promise<Annotation[]> {
+    public async fetchAnnotations(
+        dataSourceNames: string[],
+        metadataSource?: Source
+    ): Promise<Annotation[]> {
         if (!this.ready) {
             throw new Error("Database failed to initialize in fetchAnnotations");
         }
@@ -225,7 +224,7 @@ export default class DatabaseServiceWeb extends DatabaseService {
             try {
                 this.worker.postMessage({
                     type: WorkerMsgType.ANNOTATIONS,
-                    payload: { dataSourceNames, id },
+                    payload: { dataSourceNames, metadataSource, id },
                 });
             } catch (err) {
                 // Failure in posting message: reject and clean up

--- a/packages/web/src/services/DatabaseServiceWeb/types.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/types.ts
@@ -1,4 +1,4 @@
-import { ACCEPTED_SOURCE_TYPES } from "../../../../core/entity/SearchParams";
+import { ACCEPTED_SOURCE_TYPES, Source } from "../../../../core/entity/SearchParams";
 
 export enum WorkerMsgType {
     ADD_SOURCE = "add datasource",
@@ -65,6 +65,7 @@ export type WorkerReqPayload<T extends WorkerMsgType> = {
     };
     [WorkerMsgType.ANNOTATIONS]: {
         dataSourceNames: string[];
+        metadataSource: Source | undefined;
         id: string;
     };
     [WorkerMsgType.ADD_SOURCE]: {


### PR DESCRIPTION
## Context
The metadata descriptor files weren't being ingested/loaded for parquet files, because the only time we were properly checking for metadata descriptor files was during the normalization step (which doesn't happen for parquet). 
These descriptors *should* be loaded during the `fetchAnnotation` call, but we had an unsatisfiable conditional check for whether the data source should have descriptions: `dataSourceNames.includes(this.SOURCE_METADATA_TABLE)` is never true, because we don't include the metadata descriptor in the list of data sources for a query -- if we did, our current system would expect to see an aggregate table called "\<_name of actual data source_\>, \<_name of metadata descriptor file_\>".

We were also previously unable to allow two queries to have different metadata descriptor sources, because the `DatabaseService` always reused the name `this.SOURCE_METADATA_TABLE = "source_metadata"`.

resolves #727 

## Changes
Now includes the currently selected metadata source in the `DatabaseAnnotationService` so that we can pass it into the `fetchAnnotation` call to correctly check whether descriptors should be present. This also allows users to provide a different metadata descriptor file per query, and lets us keep track of which file we're currently referencing.

## Testing
Manually tested: 
- The parquet file mentioned in the tagged issue. Made sure descriptions show up now
- Open source datasets that have descriptions & custom links still work
- AICS FMS descriptions still show up
- Tested having two queries open with different metadata descriptor files, and verified can switch back and forth between them without losing access to the files.
