### PR TITLE
Fix number range picker blocking input for out-of-bounds intermediate values

### DIFF
--- a/packages/core/components/NumberRangePicker/NumberField.tsx
+++ b/packages/core/components/NumberRangePicker/NumberField.tsx
@@ -26,7 +26,9 @@ export default function NumberField(props: NumberFieldProps) {
             ((props?.max && Number(event.target.value) > props?.max) ||
                 (props?.min && Number(event.target.value) < props?.min))
         ) {
-            return event.target.setCustomValidity("Value out of bounds");
+            event?.target?.setCustomValidity("Value out of bounds");
+        } else {
+            event?.target?.setCustomValidity("");
         }
         props.onChange(event);
     }


### PR DESCRIPTION
## Summary
Fixes an issue where typing in the number range picker would reset the input on every keystroke, making it impossible to enter values.

The root cause was an early `return` in `validateInput` that prevented `props.onChange` from firing when a value was temporarily out of bounds. React treats this as a controlled input with no change, so it reset the field back to its previous value on each keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)