### PR TITLE
test: source-level query regressions to verify benchmark detection

### DIFF
--- a/packages/core/entity/SQLBuilder/index.ts
+++ b/packages/core/entity/SQLBuilder/index.ts
@@ -26,7 +26,7 @@ export default class SQLBuilder {
     ): string {
         // Escape special characters for regex
         const escapedValue = `${value}`.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-        return `REGEXP_MATCHES(CAST("${column}" AS VARCHAR), '(,\\s*${escapedValue}\\s*,)|(^\\s*${escapedValue}\\s*,)|(,\\s*${escapedValue}\\s*$)|(^\\s*${escapedValue}\\s*$)') = true`;
+        return `REGEXP_MATCHES(LOWER(CAST("${column}" AS VARCHAR)), '(,\\s*${escapedValue.toLowerCase()}\\s*,)|(^\\s*${escapedValue.toLowerCase()}\\s*,)|(,\\s*${escapedValue.toLowerCase()}\\s*$)|(^\\s*${escapedValue.toLowerCase()}\\s*$)') = true`;
     }
 
     public describe(): SQLBuilder {

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -18,7 +18,10 @@ export function buildDistinctValuesSQL(
     dataSourceNames: string | string[],
     filters: FileFilter[] = []
 ): string {
-    const builder = new SQLBuilder().select(`DISTINCT "${annotation}"`).from(dataSourceNames);
+    const builder = new SQLBuilder()
+        .select(`DISTINCT "${annotation}"`)
+        .from(dataSourceNames)
+        .orderBy("1");
     const filtersByAnnotation = filters.reduce(
         (map, filter) => ({
             ...map,

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -88,6 +88,7 @@ export function buildFetchAnnotationsSQL(tableName: string): string {
         .from('information_schema"."columns')
         .where(`table_name = '${tableName}'`)
         .where(`column_name != '${HIDDEN_UID_ANNOTATION}'`)
+        .orderBy("column_name")
         .toSQL();
 }
 

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -31,6 +31,7 @@ export function buildGetFilesSQL(
     return fileSet
         .toQuerySQLBuilder()
         .from(dataSourceNames)
+        .orderBy(`MD5(CAST("${HIDDEN_UID_ANNOTATION}" AS VARCHAR))`)
         .offset(from * limit)
         .limit(limit)
         .toSQL();
@@ -40,7 +41,7 @@ export function buildGetFilesSQL(
 export function buildGetCountSQL(dataSourceNames: string | string[], fileSet: FileSet): string {
     return fileSet
         .toQuerySQLBuilder()
-        .select("COUNT(*) AS num_files")
+        .select(`COUNT(DISTINCT "${HIDDEN_UID_ANNOTATION}") AS num_files`)
         .from(dataSourceNames)
         .removeOrderBy()
         .toSQL();


### PR DESCRIPTION
## Summary

Regression test PR for the benchmark system (PR #739). Introduces five realistic source-level changes — the kind a developer might plausibly commit — to verify the benchmark detects them automatically against parquet-backed views at realistic data scales.

Because `queries.ts` calls the same `build*SQL` functions as the app, no changes to the benchmark code were needed. All regressions are picked up purely from changes to `packages/core/`.

## Changes (all in `packages/core/`)

**1. `SQLBuilder.regexMatchValueInList` — wrap column in `LOWER()` for case-insensitive matching**
```ts
// Before
REGEXP_MATCHES(CAST("col" AS VARCHAR), '...')
// After
REGEXP_MATCHES(LOWER(CAST("col" AS VARCHAR)), LOWER('...'))
```
Forces a per-row `LOWER()` call on every scanned row. Affects: `text_search`, `multi_column_filter`.

**2. `buildDistinctValuesSQL` — add `ORDER BY 1` for sorted dropdown values**
```ts
// Before: SELECT DISTINCT "cell_line" FROM "table"
// After:  SELECT DISTINCT "cell_line" FROM "table" ORDER BY 1
```
Adds a sort pass after hash-distinct. Affects: `distinct_values` (especially wide schema with high-cardinality columns).

**3. `buildFetchAnnotationsSQL` — add `ORDER BY column_name` for predictable schema ordering**
```ts
// Before: SELECT column_name, data_type FROM information_schema.columns WHERE ...
// After:  ... ORDER BY column_name
```
Adds a sort pass on the schema introspection result. Affects: `fetch_annotations`.

**4. `buildGetCountSQL` — use `COUNT(DISTINCT hidden_bff_uid)` instead of `COUNT(*)`**
```ts
// Before: SELECT COUNT(*) AS num_files FROM "table"
// After:  SELECT COUNT(DISTINCT "hidden_bff_uid") AS num_files FROM "table"
```
Forces full hash aggregation over all rows instead of a simple counter. Affects: `count_all`. Regression scales dramatically with row count — at 10M rows: 6ms → 1001ms (+16,000%).

**5. `buildGetFilesSQL` — add `MD5(CAST(hidden_bff_uid AS VARCHAR))` as secondary sort key**
```ts
// Before: ORDER BY "File Size" DESC, hidden_bff_uid
// After:  ORDER BY "File Size" DESC, hidden_bff_uid, MD5(CAST("hidden_bff_uid" AS VARCHAR))
```
Forces MD5 computation for every row before the top-N can be returned. Affects: `sort_and_paginate`. At 10M rows: 2662ms → 4451ms (+67%).

## Observed results (vs PR #739, latest run)

| Query | Scale | Delta |
|-------|-------|-------|
| `count_all` | 10M rows | +16,209% ❌ |
| `count_all` | 1M rows | +2,976% ❌ |
| `count_all` | 100k rows | +208% ❌ |
| `sort_and_paginate` | 10M rows | +67% ❌ |
| `sort_and_paginate` | 1M rows | +76% ❌ |
| `sort_and_paginate` | 100k rows | +66% ❌ |
| `distinct_values` (wide) | 1M rows | +73% ❌ |
| `text_search` | all scales | ~+16-19% |
| `multi_column_filter` | all scales | ~+7-9% |
| `fetch_annotations` | all scales | ~+4-8% |
| `filter_by_size` | all scales | ~0% (correctly unaffected) |

Cloud queries (100k and 1M rows over HTTP) show the same regression pattern, confirming the HTTP range-request code path is also covered.

## Test plan

- [x] Benchmark workflow triggered against PR #739 (base) and this branch (compare)
- [x] `count_all` shows massive regression from `COUNT(DISTINCT)` at all scales
- [x] `sort_and_paginate` shows large regression from MD5 secondary sort at all scales
- [x] `text_search` and `multi_column_filter` show consistent ~15-19% regression from `LOWER()` overhead
- [x] `distinct_values` wide schema shows large regression from added sort pass on high-cardinality data
- [x] `fetch_annotations` shows modest regression from added sort pass
- [x] `filter_by_size` shows near-zero delta (correctly unaffected)
- [x] Cloud results at 100k and 1M rows show same regression pattern as in-memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)