### PR TITLE
Add provenance file option to data source prompt

### DIFF
--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -25,6 +25,14 @@
 }
 
 .advanced-options-button {
+    padding: 0 8px;
+}
+
+.advanced-options-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    align-content: center;
     align-self: flex-start;
 }
 

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -43,24 +43,23 @@ export default function DataSourcePrompt(props: Props) {
 
     const [dataSource, setDataSource] = React.useState<Source>();
     const [metadataSource, setMetadataSource] = React.useState<Source>();
-    const [showAdvancedOptions, setShowAdvancedOptions] = React.useState(false);
+    const [provenanceSource, setProvenanceSource] = React.useState<Source>();
+    const [showMetadataPrompt, setShowMetadataPrompt] = React.useState(false);
+    const [showProvenancePrompt, setShowProvenancePrompt] = React.useState(false);
     const [isDataSourceDetailExpanded, setIsDataSourceDetailExpanded] = React.useState(false);
 
     const onDismiss = () => {
         dispatch(interaction.actions.hideVisibleModal());
     };
 
-    const onSubmit = (dataSource: Source, metadataSource?: Source) => {
-        if (sourceType === DataSourceType.provenance) {
-            if (dataSource) {
-                dispatch(selection.actions.changeProvenanceSource(dataSource));
-            }
-            // To do: include provenance source in query as with metadatasource
-            return onDismiss();
-        }
+    const onSubmit = () => {
+        if (!dataSource) return; // TO DO: Allow users to add just a prov/metadata descriptor files without adding a dataSource
         if (requiresDataSourceReload || query) {
             if (metadataSource) {
                 dispatch(selection.actions.changeSourceMetadata(metadataSource));
+            }
+            if (provenanceSource) {
+                dispatch(selection.actions.changeProvenanceSource(provenanceSource));
             }
 
             if (requiresDataSourceReload) {
@@ -69,10 +68,15 @@ export default function DataSourcePrompt(props: Props) {
                 dispatch(selection.actions.changeDataSources([...selectedDataSources, dataSource]));
             }
         } else {
+            // brand new query
             dispatch(
                 selection.actions.addQuery({
                     name: `New ${dataSource.name} Query`,
-                    parts: { sources: [dataSource], sourceMetadata: metadataSource },
+                    parts: {
+                        sources: [dataSource],
+                        sourceMetadata: metadataSource,
+                        prov: provenanceSource,
+                    },
                     loading: true,
                 })
             );
@@ -81,7 +85,7 @@ export default function DataSourcePrompt(props: Props) {
         onDismiss();
     };
 
-    const advancedOptions = (
+    const metadataDescriptorPrompt = (
         <div
             className={classNames(
                 styles.fullWidth,
@@ -96,7 +100,7 @@ export default function DataSourcePrompt(props: Props) {
                         iconName="Cancel"
                         onClick={() => {
                             setMetadataSource(undefined);
-                            setShowAdvancedOptions(false);
+                            setShowMetadataPrompt(false);
                         }}
                     />
                 </div>
@@ -108,6 +112,39 @@ export default function DataSourcePrompt(props: Props) {
                     selectedFile={metadataSource}
                     parentId={`file-prompt-metadata-${props.isModal ? "modal" : "main"}`}
                     fileLabel={"Metadata descriptor file: "}
+                    lightBackground={props.isModal}
+                />
+            </div>
+        </div>
+    );
+
+    const provenanceFilePrompt = (
+        <div
+            className={classNames(
+                styles.fullWidth,
+                provenanceSource ? styles.advancedOptionsFilled : styles.advancedOptionsEmpty
+            )}
+        >
+            {!provenanceSource && (
+                <div className={styles.advancedOptionsHeader}>
+                    <h4 className={styles.fullWidth}>Add provenance descriptor file (optional)</h4>
+                    <TransparentIconButton
+                        className={styles.iconButton}
+                        iconName="Cancel"
+                        onClick={() => {
+                            setProvenanceSource(undefined);
+                            setShowProvenancePrompt(false);
+                        }}
+                    />
+                </div>
+            )}
+            <div className={styles.filePromptWrapper}>
+                <FilePrompt
+                    className={classNames(styles.filePrompt, styles.filePromptWide)}
+                    onSelectFile={setProvenanceSource}
+                    selectedFile={provenanceSource}
+                    parentId={`file-prompt-provenance-${props.isModal ? "modal" : "main"}`}
+                    fileLabel={"Provenance descriptor file: "}
                     lightBackground={props.isModal}
                 />
             </div>
@@ -133,21 +170,34 @@ export default function DataSourcePrompt(props: Props) {
                     parentId={`file-prompt-${props.isModal ? "modal" : "main"}`}
                     lightBackground={props.isModal}
                 />
-                {showAdvancedOptions
-                    ? advancedOptions
-                    : sourceType === DataSourceType.default && (
-                          <LinkLikeButton
-                              className={styles.advancedOptionsButton}
-                              onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-                              text="Add metadata descriptor file (optional)"
-                          />
-                      )}
+                <div className={styles.advancedOptionsButtons}>
+                    {!(showMetadataPrompt && showProvenancePrompt) && <p>Optional includes: </p>}
+                    {!showMetadataPrompt && (
+                        <LinkLikeButton
+                            className={styles.advancedOptionsButton}
+                            onClick={() => setShowMetadataPrompt(!showMetadataPrompt)}
+                            text="Metadata descriptor file"
+                            title="Select a file that describes your metadata columns"
+                        />
+                    )}
+                    {!(showMetadataPrompt || showProvenancePrompt) && <p>|</p>}
+                    {!showProvenancePrompt && (
+                        <LinkLikeButton
+                            className={styles.advancedOptionsButton}
+                            onClick={() => setShowProvenancePrompt(!showProvenancePrompt)}
+                            text="Provenance descriptor file"
+                            title="Select a file that describes provenance relationships"
+                        />
+                    )}
+                </div>
+                {showMetadataPrompt && metadataDescriptorPrompt}
+                {showProvenancePrompt && provenanceFilePrompt}
                 <div className={styles.loadButtonContainer}>
                     <PrimaryButton
                         className={classNames(styles.loadButton)}
-                        disabled={!dataSource && !metadataSource}
+                        disabled={!dataSource} // TO DO: Allow users to upload just metadata/prov files
                         text="LOAD"
-                        onClick={() => dataSource && onSubmit(dataSource, metadataSource)}
+                        onClick={onSubmit}
                     />
                 </div>
             </div>

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -53,7 +53,9 @@ export default function DataSourcePrompt(props: Props) {
     };
 
     const onSubmit = () => {
-        if (!dataSource) return; // TO DO: Allow users to add just a prov/metadata descriptor files without adding a dataSource
+        // TO DO: https://github.com/AllenInstitute/biofile-finder/issues/742
+        // Allow users to add just prov/metadata descriptor files without adding a dataSource
+        if (!dataSource) return;
         if (requiresDataSourceReload || query) {
             if (metadataSource) {
                 dispatch(selection.actions.changeSourceMetadata(metadataSource));
@@ -195,7 +197,8 @@ export default function DataSourcePrompt(props: Props) {
                 <div className={styles.loadButtonContainer}>
                     <PrimaryButton
                         className={classNames(styles.loadButton)}
-                        disabled={!dataSource} // TO DO: Allow users to upload just metadata/prov files
+                        // TO DO: https://github.com/AllenInstitute/biofile-finder/issues/742 Allow users to upload just metadata/prov files
+                        disabled={!dataSource}
                         text="LOAD"
                         onClick={onSubmit}
                     />

--- a/packages/core/components/DataSourcePrompt/test/DataSourcePrompt.test.tsx
+++ b/packages/core/components/DataSourcePrompt/test/DataSourcePrompt.test.tsx
@@ -46,7 +46,7 @@ describe("<DataSourcePrompt />", () => {
         expect(loadButton?.hasAttribute("disabled")).to.be.false;
     });
 
-    it("can distinguish between two FilePrompt components when advanced options are open", () => {
+    it("can distinguish between all FilePrompt components when advanced options are open", () => {
         const { store } = configureMockStore({ state: initialState, reducer });
         const { getByText, getByTestId, getAllByText, getAllByRole } = render(
             <Provider store={store}>
@@ -55,12 +55,14 @@ describe("<DataSourcePrompt />", () => {
         );
 
         // Expand advanced options
-        fireEvent.click(getByText(/Add metadata descriptor file/));
+        fireEvent.click(getByText(/Metadata descriptor file/));
+        fireEvent.click(getByText(/Provenance descriptor file/));
 
         // Two separate prompts render
-        expect(getAllByText(/click to browse/).length).to.equal(2);
+        expect(getAllByText(/click to browse/).length).to.equal(3);
         expect(getByTestId("urlform-file-prompt-main")).to.exist;
         expect(getByTestId("urlform-file-prompt-metadata-main")).to.exist;
+        expect(getByTestId("urlform-file-prompt-provenance-main")).to.exist;
 
         const urlForm = getAllByRole("textbox").at(1);
         // Enter values in the second form
@@ -75,8 +77,9 @@ describe("<DataSourcePrompt />", () => {
         }
 
         // Only the first prompt still renders
-        expect(getAllByText(/click to browse/).length).to.equal(1);
+        expect(getAllByText(/click to browse/).length).to.equal(2);
         expect(getByTestId("urlform-file-prompt-main")).to.exist;
+        expect(getByTestId("urlform-file-prompt-provenance-main")).to.exist;
         expect(() => getByTestId("urlform-file-prompt-metadata-main")).to.throw;
     });
 

--- a/packages/core/components/QueryPart/QueryDataSource.tsx
+++ b/packages/core/components/QueryPart/QueryDataSource.tsx
@@ -83,21 +83,6 @@ export default function QueryDataSource(props: Props) {
                         );
                     },
                 },
-                // TODO: Hide this for now until we have better docs for explaining this
-                // Temporary menu item for adding provenance data
-                // {
-                //     key: "New Provenance Data Source",
-                //     text: "New provenance data source",
-                //     onClick: () => {
-                //         dispatch(
-                //             interaction.actions.promptForDataSource({
-                //                 query: selectedQuery,
-                //                 source: selectedDataSources[0],
-                //                 sourceType: DataSourceType.provenance,
-                //             })
-                //         );
-                //     },
-                // },
             ]}
             rows={[
                 ...props.dataSources.map((dataSource) => ({


### PR DESCRIPTION
## Context
Adds back the ability for users to load provenance files. There's a more significant redesign coming, so this is mostly a temporary measure

## Changes
In the data source prompt, adds a provenance file option that matches what we currently provide for metadata descriptor files, with minor styling changes that are more similar to what the eventual final design looks like. Made sure that users can add both types of optional files for the same data source

### To do:
We don't currently allow users to add a metadata descriptor or provenance file on its own without also adding a data source, which I imagine folks will want (e.g., if they're adding it to an existing query). Allowing this is going to rely on/interfere with some of the changes in #732, so to keep things clean, I'll wait on that & then make a separate ticket (#742).

## Testing
Manually tested creating new queries with one or both of the optional files. Made sure the provenance graph still gets generated and that descriptors do get added.

## Screenshots 
<img width="767" height="822" alt="image" src="https://github.com/user-attachments/assets/0047417d-ce09-4942-b6d8-0dd3e4baf486" />
