### PR TITLE
Fuzzy search -> Is exactly or contains

### DIFF
--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/SearchBoxForm.module.css
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/SearchBoxForm.module.css
@@ -1,54 +1,13 @@
-.toggle {
+.checkbox {
     margin-bottom: 6px;
 }
 
-.toggle-hidden {
+.checkbox > label > span {
+    font-size: 14px;
+}
+
+.checkbox-hidden {
     display: none;
-}
-
-.toggle input:disabled + label {
-    cursor: not-allowed;
-    opacity: 0.5;
-}
-
-.toggle :is(input, label, span), .toggle-label {
-    color: var(--primary-text-color);
-    font-size: var(--l-paragraph-size);
-    font-weight: 500;
-}
-
-.toggle label:hover > span {
-    color: var(--highlight-text-color) !important;
-}
-
-.toggle-pill-off {
-    border-color: var(--border-color) !important;
-    background-color: unset !important;
-}
-
-.toggle-pill-off {
-    border-color: var(--border-color) !important;
-}
-
-.toggle-pill-off > span {
-    background-color: var(--border-color) !important;
-}
-
-.toggle-pill-off:hover > span {
-    background-color: var(--primary-text-color) !important;
-}
-
-.toggle-pill-on {
-    border: none !important;
-    background-color: var(--aqua) !important;
-}
-
-.toggle-pill-on > span {
-    background-color: var(--highlight-hover-text-color) !important;
-}
-
-.toggle-pill-on:hover {
-    background-color: var(--dark-aqua) !important;
 }
 
 .container {

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
@@ -38,7 +38,7 @@ export default function SearchBoxForm(props: SearchBoxFormProps) {
         <div className={classNames(props.className, styles.container)}>
             <h3 className={styles.title}>{props.title}</h3>
             <Toggle
-                label="Fuzzy search"
+                label="Is exactly or contains"
                 className={classNames(styles.toggle, {
                     [styles.toggleHidden]: !!props?.hideFuzzyToggle,
                 })}

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
@@ -1,7 +1,7 @@
-import { Toggle } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
+import Checkbox from "../../Checkbox";
 import { ListItem } from "../../ListPicker/ListRow";
 import SearchBox from "../../SearchBox";
 import FileFilter, { FilterType } from "../../../entity/FileFilter";
@@ -37,21 +37,17 @@ export default function SearchBoxForm(props: SearchBoxFormProps) {
     return (
         <div className={classNames(props.className, styles.container)}>
             <h3 className={styles.title}>{props.title}</h3>
-            <Toggle
-                label="Is exactly or contains"
-                className={classNames(styles.toggle, {
-                    [styles.toggleHidden]: !!props?.hideFuzzyToggle,
+            <Checkbox
+                className={classNames(styles.checkbox, {
+                    // [styles.checkboxHidden]: !!props?.hideFuzzyToggle,
                 })}
-                defaultChecked={isFuzzySearching}
-                onText="On"
-                inlineLabel
-                offText="Off"
-                onChange={(_, checked?) => setIsFuzzySearching(!!checked)}
-                title={`Turn ${isFuzzySearching ? "off" : "on"} fuzzy search (non-exact searching)`}
-                styles={{
-                    label: styles.toggleLabel,
-                    pill: isFuzzySearching ? styles.togglePillOn : styles.togglePillOff,
-                }}
+                initialValue={isFuzzySearching}
+                onChange={(ev, isChecked) => setIsFuzzySearching(!!isChecked)}
+                label={
+                    isFuzzySearching
+                        ? "Disable fuzzy (non-exact) matching"
+                        : "Enable fuzzy (non-exact) matching"
+                }
             />
             <SearchBox
                 defaultValue={props.defaultValue}

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/test/SearchBoxForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/test/SearchBoxForm.test.tsx
@@ -22,11 +22,11 @@ describe("<SearchBoxForm/>", () => {
         );
 
         // Consistency checks
-        expect(getByText("Off")).to.exist;
+        expect(getByText("Enable fuzzy (non-exact) matching")).to.exist;
         expect(onSearch.called).to.equal(false);
 
         // Act
-        fireEvent.click(getByRole("switch"));
+        fireEvent.click(getByRole("checkbox"));
         // Enter values
         fireEvent.change(getByRole("searchbox"), {
             target: {
@@ -41,7 +41,7 @@ describe("<SearchBoxForm/>", () => {
         });
 
         // Assert
-        expect(getByText("On")).to.exist;
+        expect(getByText("Disable fuzzy (non-exact) matching")).to.exist;
         expect(onSearch.called).to.equal(true);
     });
 
@@ -58,12 +58,12 @@ describe("<SearchBoxForm/>", () => {
             />
         );
         // Consistency check
-        expect(getByText("On")).to.exist;
+        expect(getByText("Disable fuzzy (non-exact) matching")).to.exist;
 
         // Act
-        fireEvent.click(getByRole("switch"));
+        fireEvent.click(getByRole("checkbox"));
 
         // Assert
-        expect(getByText("Off")).to.exist;
+        expect(getByText("Enable fuzzy (non-exact) matching")).to.exist;
     });
 });


### PR DESCRIPTION
Fuzzy search is kind of a dev specific term, this updates the label to say "Is exactly or contains" instead.

Resolves #545 

Example
<img width="645" height="154" alt="Screenshot 2026-05-04 at 2 07 16 PM" src="https://github.com/user-attachments/assets/e6aef389-dede-4251-b950-bf2c4df769bf" />

