### PR TITLE
Feature/refined button menu

### DIFF
--- a/packages/core/components/Buttons/useButtonMenu.module.css
+++ b/packages/core/components/Buttons/useButtonMenu.module.css
@@ -52,7 +52,12 @@
     border-bottom: 1px solid var(--border-color);
     display: flex;
     margin: 0 16px;
-    padding: 4px 0 5px 0;
+    padding: 26px 0 5px 0;
+}
+
+/* The first header should have different top padding */
+.button-menu-header:first-of-type {
+    padding-top: 4px
 }
 
 .button-menu-header > div {

--- a/packages/core/components/Buttons/useButtonMenu.module.css
+++ b/packages/core/components/Buttons/useButtonMenu.module.css
@@ -57,7 +57,7 @@
 
 /* The first header should have different top padding */
 .button-menu-header:first-of-type {
-    padding-top: 4px
+    padding-top: 4px;
 }
 
 .button-menu-header > div {

--- a/packages/core/components/Buttons/useButtonMenu.module.css
+++ b/packages/core/components/Buttons/useButtonMenu.module.css
@@ -44,20 +44,28 @@
 
 .button-menu li:empty {
     display: none;
+    margin-bottom: 8px;
 }
 
 .button-menu-header {
     align-items: center;
     border-bottom: 1px solid var(--border-color);
     display: flex;
-    height: 40px;
-    padding: 0 10px;
+    margin: 0 16px;
+    padding: 4px 0 5px 0;
+}
+
+.button-menu-header > div {
+    height: unset;
+    padding: 0;
 }
 
 .button-menu-header span {
-    color: var(--highlight-text-color);
+    align-items: center;
+    display: flex;
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 700;
+    height: 1em;
     margin: 0;
 }
 

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -46,19 +46,30 @@ type AppOptions = {
     openInFiji: () => void;
 };
 
-const SUPPORTED_APPS_HEADER = {
-    key: "supported-apps-headers",
-    text: "SUPPORT FILE TYPE",
-    title: "Apps that are expected to support this file type",
+const RECOMMENDED_APPS_HEADER = {
+    key: "recommended-apps-header",
+    text: "RECOMMENDED",
+    title: "Apps that are recommended for this file type",
     itemType: ContextualMenuItemType.Header,
+    className: styles.sectionHeader,
 };
 
-const UNSUPPORTED_APPS_HEADER = {
-    key: "unsupported-apps-headers",
-    text: "DO NOT SUPPORT FILE TYPE",
+const COMPATIBLE_APPS_HEADER = {
+    key: "compatible-apps-header",
+    text: "COMPATIBLE WITH FILE TYPE",
+    title: "Apps that are expected to support this file type",
+    itemType: ContextualMenuItemType.Header,
+    className: styles.sectionHeader,
+};
+
+const INCOMPATIBLE_APPS_HEADER = {
+    key: "incompatible-apps-header",
+    text: "NOT COMPATIBLE WITH FILE TYPE",
     title: "Apps that are not expected to support this file type",
     itemType: ContextualMenuItemType.Header,
+    className: styles.sectionHeader,
 };
+// TODO: Remove secondary text style
 
 const APPS = (
     fileDetails: FileDetail | undefined,
@@ -67,7 +78,7 @@ const APPS = (
     [AppKeys.AGAVE]: {
         key: AppKeys.AGAVE,
         className: styles.desktopMenuItem,
-        text: "AGAVE",
+        text: "AGAVE (desktop)",
         title: "Open files with AGAVE v1.7.2+",
         href: `agave://?url=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
@@ -90,7 +101,6 @@ const APPS = (
                             <Icon iconName="OpenInNewWindow" />
                         </DefaultButton>
                     </a>
-                    <span className={styles.secondaryText}>| Desktop</span>
                 </>
             );
         },
@@ -102,14 +112,6 @@ const APPS = (
         href: fileDetails?.path,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.CFE]: {
         key: AppKeys.CFE,
@@ -117,19 +119,11 @@ const APPS = (
         title: `Open files with CFE`,
         onClick: options?.openInCfe,
         hidden: options?.openInCfe === undefined || !fileDetails?.path,
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.FIJI]: {
         key: AppKeys.FIJI,
         className: styles.desktopMenuItem,
-        text: "FIJI",
+        text: "FIJI (desktop)",
         title: "Open files with FIJI (may require updating FIJI)",
         onClick: options?.openInFiji,
         disabled: !fileDetails?.path,
@@ -153,7 +147,6 @@ const APPS = (
                             <Icon iconName="OpenInNewWindow" />
                         </DefaultButton>
                     </a>
-                    <span className={styles.secondaryText}>| Desktop</span>
                 </>
             );
         },
@@ -165,14 +158,6 @@ const APPS = (
         href: fileDetails?.path,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.NEUROGLANCER]: {
         key: AppKeys.NEUROGLANCER,
@@ -183,14 +168,6 @@ const APPS = (
         }://${fileDetails?.path}%22,%22name%22:%22${fileDetails?.name}%22}]}`,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.SIMULARIUM]: {
         key: AppKeys.SIMULARIUM,
@@ -199,14 +176,6 @@ const APPS = (
         href: `https://simularium.allencell.org/viewer?trajUrl=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.VALIDATOR]: {
         key: AppKeys.VALIDATOR,
@@ -215,14 +184,6 @@ const APPS = (
         href: `https://ome.github.io/ome-ngff-validator/?source=${fileDetails?.path}`,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.VOLE]: {
         key: AppKeys.VOLE,
@@ -231,14 +192,6 @@ const APPS = (
         onClick: options?.openInVolE,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
     [AppKeys.VOLVIEW]: {
         key: AppKeys.VOLVIEW,
@@ -247,14 +200,6 @@ const APPS = (
         href: `https://volview.kitware.app/?urls=[${fileDetails?.path}]`,
         disabled: !fileDetails?.path,
         target: "_blank",
-        onRenderContent(props, defaultRenders) {
-            return (
-                <>
-                    {defaultRenders.renderItemName(props)}
-                    <span className={styles.secondaryText}>Web</span>
-                </>
-            );
-        },
     } as IContextualMenuItem,
 });
 
@@ -518,14 +463,6 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                 title: `Open link - ${name}`,
                 href: link,
                 target: "_blank",
-                onRenderContent(props, defaultRenders) {
-                    return (
-                        <>
-                            {defaultRenders.renderItemName(props)}
-                            <span className={styles.secondaryText}>Web</span>
-                        </>
-                    );
-                },
             } as IContextualMenuItem)
     );
 
@@ -624,14 +561,6 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             title: "Open this plate in the Plate UI",
             href: plateLink,
             target: "_blank",
-            onRenderContent(props, defaultRenders) {
-                return (
-                    <>
-                        {defaultRenders.renderItemName(props)}
-                        <span className={styles.secondaryText}>Web</span>
-                    </>
-                );
-            },
         } as IContextualMenuItem);
     }
 
@@ -639,7 +568,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     if (!supportedApps.length) {
         supportedApps.push({
             key: "no-supported-apps-found",
-            text: "None",
+            text: "None available",
             title: "No applications found that are expected to support this file type",
             disabled: true,
         });
@@ -648,7 +577,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     if (!unsupportedApps.length) {
         unsupportedApps.push({
             key: "no-unsupported-apps-found",
-            text: "None",
+            text: "None available",
             title: "No applications found that are not expected to support this file type",
             disabled: true,
         });
@@ -659,13 +588,13 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     const menuItems: IContextualMenuItem[] = [];
     const subMenuItems: IContextualMenuItem[] = [];
     if (authorDefinedApps.length) {
-        menuItems.push(...authorDefinedApps);
-        subMenuItems.push(SUPPORTED_APPS_HEADER, ...supportedApps);
+        menuItems.push(RECOMMENDED_APPS_HEADER, ...authorDefinedApps);
+        subMenuItems.push(COMPATIBLE_APPS_HEADER, ...supportedApps);
     } else {
-        menuItems.push(SUPPORTED_APPS_HEADER, ...supportedApps);
+        menuItems.push(COMPATIBLE_APPS_HEADER, ...supportedApps);
     }
 
-    subMenuItems.push(UNSUPPORTED_APPS_HEADER, ...unsupportedApps);
+    subMenuItems.push(INCOMPATIBLE_APPS_HEADER, ...unsupportedApps);
 
     // Unable to open arbirary applications on the web
     // this adds to the bottom of the "Other apps" sub menu

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -69,7 +69,6 @@ const INCOMPATIBLE_APPS_HEADER = {
     itemType: ContextualMenuItemType.Header,
     className: styles.sectionHeader,
 };
-// TODO: Remove secondary text style
 
 const APPS = (
     fileDetails: FileDetail | undefined,

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -467,7 +467,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
             const name = executionEnvService.getFilename(app.filePath);
             return {
                 key: `open-with-${name}`,
-                text: name,
+                text: `${name} (desktop)`,
                 title: `Open files with ${name}`,
                 disabled:
                     (!filters && !fileDetails) ||
@@ -479,14 +479,6 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                     } else if (fileDetails) {
                         dispatch(interaction.actions.openWith(app, undefined, [fileDetails]));
                     }
-                },
-                onRenderContent(props, defaultRenders) {
-                    return (
-                        <>
-                            {defaultRenders.renderItemName(props)}
-                            <span className={styles.secondaryText}>Desktop</span>
-                        </>
-                    );
                 },
             } as IContextualMenuItem;
         })

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -51,7 +51,6 @@ const RECOMMENDED_APPS_HEADER = {
     text: "RECOMMENDED",
     title: "Apps that are recommended for this file type",
     itemType: ContextualMenuItemType.Header,
-    className: styles.sectionHeader,
 };
 
 const COMPATIBLE_APPS_HEADER = {
@@ -59,7 +58,6 @@ const COMPATIBLE_APPS_HEADER = {
     text: "COMPATIBLE WITH FILE TYPE",
     title: "Apps that are expected to support this file type",
     itemType: ContextualMenuItemType.Header,
-    className: styles.sectionHeader,
 };
 
 const INCOMPATIBLE_APPS_HEADER = {
@@ -67,7 +65,6 @@ const INCOMPATIBLE_APPS_HEADER = {
     text: "NOT COMPATIBLE WITH FILE TYPE",
     title: "Apps that are not expected to support this file type",
     itemType: ContextualMenuItemType.Header,
-    className: styles.sectionHeader,
 };
 
 const APPS = (
@@ -582,8 +579,9 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
         });
     }
 
-    // Priority apps are those that are known to work well with the file type
-    // or those defined by the author of the dataset
+    // Priority is given to apps recommended by the author then those that are
+    // compatible by file type.
+    // Files not compatible by file type are still shown but only ever in the sub-menu
     const menuItems: IContextualMenuItem[] = [];
     const subMenuItems: IContextualMenuItem[] = [];
     if (authorDefinedApps.length) {

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -55,12 +55,3 @@
 .view-link > button {
     transform: translateY(-8px);
 }
-
-.section-header {
-    padding-top: 12px;
-    padding-bottom: 5px;
-}
-
-.section-header + li {
-    padding-top: 5px;
-}

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -26,12 +26,6 @@
     opacity: 0.25;
 }
 
-.secondary-text {
-    color: var(--white);
-    font-size: 12px !important;
-    opacity: 0.5;
-}
-
 .desktop-menu-item .info-button > span {
     font-size: 12px;
 }

--- a/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
+++ b/packages/core/hooks/useOpenWithMenuItems/useOpenWithMenuItems.module.css
@@ -61,3 +61,12 @@
 .view-link > button {
     transform: translateY(-8px);
 }
+
+.section-header {
+    padding-top: 12px;
+    padding-bottom: 5px;
+}
+
+.section-header + li {
+    padding-top: 5px;
+}


### PR DESCRIPTION
## Context
Lyndsay made a refined button menu design
<img width="1045" height="625" alt="Screenshot 2026-05-11 at 3 13 53 PM" src="https://github.com/user-attachments/assets/e11d5ef1-09ec-4824-a493-4780db3f0adf" />

## Changes
Before/After shown below. Note the following intentional differences between the after and the intended design:
* No icons. Lyndsay decided she wanted these gone in an issue that is newer than this one
* Slight header wording difference. Lyndsay wanted it changed after seeing it.
* Addition of "Desktop" to desktop apps to separate them + slightly different "Info" button styling. This was discussed with Lyndsay.

### Before
<img width="853" height="616" alt="Screenshot 2026-05-11 at 3 14 37 PM" src="https://github.com/user-attachments/assets/76c908dd-746c-4066-8d52-ed73ccd942c1" />


### After
<img width="628" height="320" alt="Screenshot 2026-05-11 at 3 14 10 PM" src="https://github.com/user-attachments/assets/c7e1b074-e090-4967-87aa-1e737937f7f8" />


## Testing
Local testing.
