### PR TITLE
Bugfix/non-ascii character display

### DIFF
--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -155,7 +155,7 @@ export default class DatabaseAnnotationService implements AnnotationService {
 
         const queries = columnNames.map((columnName) => {
             const sql = new SQLBuilder()
-                .select(`'${columnName}' AS column_name`)
+                .select(`'${columnName.replace(/'/g, "''")}' AS column_name`)
                 .from(aggregateDataSourceName)
                 .where(`"${columnName}" IS NOT NULL`)
                 .where(annotations.map((annotation) => `"${annotation}" IS NOT NULL`))

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -657,11 +657,11 @@ export default abstract class DatabaseService {
             (val) => `${val.column_name}`
         );
         // Determine whether Javascript removes those characters by checking
-        // if the JS version of each column name still exists in the table
+        // if the JS version of each column name still exists in the DuckDB table
         const columnsExist = await this.checkColumnsExist(dataSourceName, columnsWithNonAscii);
         const columnsWithMismatch = columnsExist
             ?.filter((value) => value.column_exists === false)
-            .flatMap((val) => `${val.column_name}`);
+            .flatMap((val) => val.column_name);
         // If list is empty, there may be column names with non-ASCII characters,
         // but they don't get trimmed by JS, so we can return safely
         if (!columnsWithMismatch || columnsWithMismatch.length === 0) return;
@@ -709,7 +709,7 @@ export default abstract class DatabaseService {
     // Check if each column name in an array actually exists in table `dataSourceName`
     private async checkColumnsExist(dataSourceName: string, columnNames: string[]) {
         if (columnNames.length === 0) return;
-        const query = `
+        const sql = `
             WITH columns_to_check AS (
                 SELECT * FROM (
                 VALUES ${columnNames.map((col) => `('${col}')`).join(",")}) 
@@ -722,7 +722,7 @@ export default abstract class DatabaseService {
                 ON LOWER(cc.column_name) = LOWER(ic.column_name)
                 AND ic.table_name = '${dataSourceName}'
         `;
-        return await this.query(query).promise;
+        return await this.query(sql).promise;
     }
 
     /*

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -648,10 +648,43 @@ export default abstract class DatabaseService {
      */
     private async renameNonprintableCharColumns(dataSourceName: string): Promise<void> {
         // Query for columns that contain ASCII characters that are outside of the printable range
-        const findNonPrintableCharsSql = `
+        const findNonAsciiCharsSql = `
             SELECT column_name, regexp_replace(column_name, '[^ -~]+', '', 'g') as clean_name
             FROM "information_schema"."columns"
             WHERE (table_name = '${dataSourceName}') AND (regexp_matches(column_name, '[^ -~]+'))
+        `;
+        const columnsWithNonAscii = (await this.query(findNonAsciiCharsSql).promise).flatMap(
+            (val) => `${val.column_name}`
+        );
+        // Determine whether Javascript removes those characters by checking
+        // if the JS version of each column name still exists in the table
+        const columnsExist = await this.checkColumnsExist(dataSourceName, columnsWithNonAscii);
+        const columnsWithMismatch = columnsExist
+            ?.filter((value) => value.column_exists === false)
+            .flatMap((val) => `${val.column_name}`);
+        // If list is empty, there may be column names with non-ASCII characters,
+        // but they don't get trimmed by JS, so we can return safely
+        if (!columnsWithMismatch || columnsWithMismatch.length === 0) return;
+
+        // Only rename the columns that have a mismatch after being converted to JS
+        // since these are the ones that won't render correctly & will cause errors
+        const findMismatchedColumnsSql = `
+            WITH nonascii_columns AS (
+                SELECT * FROM (
+                VALUES ${columnsWithMismatch?.map((col) => `('${col}')`).join(",")}) 
+                AS t(column_name)
+            ),
+            table_columns AS (
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = '${dataSourceName}'
+            )
+            SELECT 
+                (SELECT column_name FROM table_columns tc
+                WHERE regexp_replace(column_name, '[^ -~]+', '', 'g') = nc.column_name
+                LIMIT 1) as column_name,
+                nc.column_name as clean_name
+            FROM nonascii_columns nc
         `;
         // Run the above query inside of a DuckDB command that generates `ALTER` statements
         // rather than running two separate queries,
@@ -659,7 +692,7 @@ export default abstract class DatabaseService {
         const alterCommandsSql = `
             SELECT string_agg('ALTER TABLE "${dataSourceName}" RENAME "' || column_name || '" TO "' || clean_name || '";', ' ') as sql_statement,
                 string_agg(column_name, ', ') as cols_to_rename
-            FROM (${findNonPrintableCharsSql}
+            FROM (${findMismatchedColumnsSql}
             ) problem_columns;
         `;
         // Retrieve the ALTER commands and names of columns that will be renamed
@@ -671,6 +704,25 @@ export default abstract class DatabaseService {
                 `Renamed columns with special characters: ${executeResult[0].cols_to_rename}`
             );
         }
+    }
+
+    // Check if each column name in an array actually exists in table `dataSourceName`
+    private async checkColumnsExist(dataSourceName: string, columnNames: string[]) {
+        if (columnNames.length === 0) return;
+        const query = `
+            WITH columns_to_check AS (
+                SELECT * FROM (
+                VALUES ${columnNames.map((col) => `('${col}')`).join(",")}) 
+                AS t(column_name)
+            )
+            SELECT cc.column_name,
+                ic.column_name IS NOT NULL as column_exists
+            FROM columns_to_check cc
+            LEFT JOIN information_schema.columns ic 
+                ON LOWER(cc.column_name) = LOWER(ic.column_name)
+                AND ic.table_name = '${dataSourceName}'
+        `;
+        return await this.query(query).promise;
     }
 
     /*

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -649,7 +649,7 @@ export default abstract class DatabaseService {
     private async renameNonprintableCharColumns(dataSourceName: string): Promise<void> {
         // Query for columns that contain ASCII characters that are outside of the printable range
         const findNonAsciiCharsSql = `
-            SELECT column_name, regexp_replace(column_name, '[^ -~]+', '', 'g') as clean_name
+            SELECT column_name
             FROM "information_schema"."columns"
             WHERE (table_name = '${dataSourceName}') AND (regexp_matches(column_name, '[^ -~]+'))
         `;
@@ -671,7 +671,9 @@ export default abstract class DatabaseService {
         const findMismatchedColumnsSql = `
             WITH nonascii_columns AS (
                 SELECT * FROM (
-                VALUES ${columnsWithMismatch?.map((col) => `('${col}')`).join(",")}) 
+                VALUES ${columnsWithMismatch
+                    ?.map((col) => `('${col.replace(/'/g, "''")}')`)
+                    .join(",")}) 
                 AS t(column_name)
             ),
             table_columns AS (
@@ -712,7 +714,7 @@ export default abstract class DatabaseService {
         const sql = `
             WITH columns_to_check AS (
                 SELECT * FROM (
-                VALUES ${columnNames.map((col) => `('${col}')`).join(",")}) 
+                VALUES ${columnNames.map((col) => `('${col.replace(/'/g, "''")}')`).join(",")}) 
                 AS t(column_name)
             )
             SELECT cc.column_name,

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -654,7 +654,7 @@ export default abstract class DatabaseService {
             WHERE (table_name = '${dataSourceName}') AND (regexp_matches(column_name, '[^ -~]+'))
         `;
         const columnsWithNonAscii = (await this.query(findNonAsciiCharsSql).promise).flatMap(
-            (val) => `${val.column_name}`
+            (val) => val.column_name
         );
         // Determine whether Javascript removes those characters by checking
         // if the JS version of each column name still exists in the DuckDB table

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -582,12 +582,21 @@ export default abstract class DatabaseService {
     private async checkDataSourceForErrors(name: string): Promise<string | null> {
         const columnsOnTable = await this.getColumnsOnDataSource(name);
 
+        // Double quotes in column names should not be allowed because of injection concerns
+        const columns = Array.from(columnsOnTable);
+        const columnsWithDoubleQuotes = columns.filter((col) => /"/.test(col));
+        if (columnsWithDoubleQuotes.length > 0) {
+            return `Found column names with disallowed double quote characters ("): ${columnsWithDoubleQuotes.join(
+                ", "
+            )}. 
+                Please rename these columns and try again.`;
+        }
+
         if (!columnsOnTable.has(PreDefinedColumn.FILE_PATH)) {
             let error = `"${PreDefinedColumn.FILE_PATH}" column is missing in the data source.
                 Check the data source header row for a "${PreDefinedColumn.FILE_PATH}" column name and try again.`;
 
             // Attempt to find a column with a similar name to "File Path"
-            const columns = Array.from(columnsOnTable);
             const filePathLikeColumn =
                 columns.find((column) => column.toLowerCase().includes("path")) ||
                 columns.find((column) => column.toLowerCase().includes("file"));

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -170,6 +170,40 @@ describe("DatabaseService", () => {
             expect(service.hasDataSource(tempFileName)).to.be.true;
         });
 
+        it("throws error when a column name contains double quotes", async () => {
+            // Arrange
+            const badColumnName = '"Bad" column name';
+            const doubleQuoteAnnotation = new Annotation({
+                annotationDisplayName: badColumnName,
+                annotationName: badColumnName,
+                description: "",
+                type: AnnotationType.STRING,
+                annotationId: 3,
+            });
+            sinon
+                .stub(service, "fetchAnnotations")
+                .returns(Promise.resolve([...mockAnnotations, doubleQuoteAnnotation]));
+            const tempFileName = "testFailure.csv";
+            const tempFile = path.resolve(tempDir, tempFileName);
+            await fs.promises.writeFile(tempFile, "a,b,c,d\n1,2,3,4\n5,6,7,8\n");
+            let caughtError;
+
+            // Act
+            try {
+                await service.prepareDataSources([
+                    { name: tempFileName, type: "csv", uri: tempFile },
+                ]);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            // Assert
+            expect(caughtError).to.not.be.undefined;
+            expect(caughtError).to.contain(/DataSourcePreparationError/);
+            expect((caughtError as Error)?.message).to.contain(badColumnName);
+            expect(service.hasDataSource(tempFileName)).to.be.false;
+        });
+
         describe("CORS error handling for URL data sources", () => {
             // A service where addDataSource always fails (simulates DuckDB failing to load a URL)
             class MockDatabaseServiceWithURLFailure extends MockDatabaseService {


### PR DESCRIPTION
## Context
When addressing #700, we ran into files that had non-ASCII characters in column names that broke our grouping/filtering because the Javascript conversion was causing those columns to no longer match the database. As a blanket fix, I added renaming logic to remove all non-ASCII characters from column names during the data source ingestion process. This is now causing issues for users who include units like `µm³` in their metadata field names. 

Resolves #780 

## Changes
Made the logic for renaming columns with non-ASCII characters more conservative and less of a sledgehammer. Instead of always removing those characters, this checks whether Javascript actually trims them (or leaves them, as is the case with `µm³`), and then only renames columns if the Javascript version no longer matches what's in the DuckDB database.

Potential to do:
There are probably ways to make this smarter? e.g., maybe we don't ever want to remove them, or should just convert them to their characters codes?

## Testing
Tested manually on three cases:
1. Nucmorph dataset: this is the file that has a column named `ÔªøPrefix` that causes filtering and aggregate sources to fail. This is a case where the column should be renamed
2. Saurabh's dataset that uses `µm³` etc. These don't get renamed
3. A dataset where none of the columns have any non-ASCII characters