### PR TITLE
ACM REVIEW #1: Fix: use loadBalancerBaseUrl for compute endpoint

### DIFF
--- a/packages/core/services/FileService/HttpFileService/index.ts
+++ b/packages/core/services/FileService/HttpFileService/index.ts
@@ -229,8 +229,7 @@ export default class HttpFileService extends HttpServiceBase implements FileServ
         scene: number;
         channel: number;
     }): Promise<{ computeTaskId: string; dashboardUrl: string }> {
-        // This will become the service base when deployed
-        const requestUrl = `http://stg-aics.corp.alleninstitute.org/${HttpFileService.ALL_CELLS_MASK_URL}${this.pathSuffix}`;
+        const requestUrl = `${this.loadBalancerBaseUrl}/${HttpFileService.ALL_CELLS_MASK_URL}${this.pathSuffix}`;
 
         try {
             const result = await this.rawPost<{


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `stg-aics.corp.alleninstitute.org` URL in `submitAllCellsMaskJob` with `this.loadBalancerBaseUrl`, matching the pattern used by `cacheFiles` and other FSS2 endpoints
- This ensures the compute request targets the correct environment (prod: `aics.corp.alleninstitute.org`, staging: `stg-aics.corp.alleninstitute.org`) based on how the service is configured

## Test plan
- [x] Verify job submission hits the correct host in production and staging environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)