### PR TITLE
New browser instance per benchmark task

### DIFF
--- a/packages/web/benchmark/src/index.ts
+++ b/packages/web/benchmark/src/index.ts
@@ -1,9 +1,7 @@
 import { BENCHMARK_TASKS, createServices } from "./tasks";
 import { BenchmarkConfig, BenchmarkResults, QueryResult, SourceResult } from "./types";
+import { DEFAULT_ITERATIONS, DEFAULT_WARMUP_ROUNDS, buildQueryResult } from "./stats";
 import DatabaseServiceWebWorker from "../../src/services/DatabaseServiceWeb/duckdb-worker.worker";
-
-const DEFAULT_ITERATIONS = 5;
-const DEFAULT_WARMUP_ROUNDS = 1;
 
 // Updates the #status element in the benchmark HTML page and mirrors to console.
 // The page can run headlessly in CI (Playwright), so the console log is the
@@ -12,14 +10,6 @@ function setStatus(msg: string) {
     const el = document.getElementById("status");
     if (el) el.textContent = msg;
     console.log("[benchmark]", msg);
-}
-
-// Nearest-rank percentile over a pre-sorted array. Used to report p50 and p95
-// across timed iterations — p95 surfaces occasional slow outliers (GC pauses,
-// DuckDB cache misses) that the median would hide.
-function percentile(sorted: number[], p: number): number {
-    const idx = Math.ceil((p / 100) * sorted.length) - 1;
-    return sorted[Math.max(0, idx)];
 }
 
 // Fisher-Yates shuffle — randomizes task order each timed iteration so that a
@@ -95,16 +85,7 @@ async function benchmarkSource(
         }
     }
 
-    return tasks.map(({ name }) => {
-        const timings = [...(timingsMap.get(name) ?? [])].sort((a, b) => a - b);
-        return {
-            name,
-            timings,
-            p50: percentile(timings, 50),
-            p95: percentile(timings, 95),
-            p99: percentile(timings, 99),
-        };
-    });
+    return tasks.map(({ name }) => buildQueryResult(name, timingsMap.get(name) ?? []));
 }
 
 async function main() {

--- a/packages/web/benchmark/src/index.ts
+++ b/packages/web/benchmark/src/index.ts
@@ -53,7 +53,8 @@ async function benchmarkSource(
     service: DatabaseServiceWebWorker,
     sourceNames: string[],
     iterations: number,
-    warmupRounds: number
+    warmupRounds: number,
+    tasks: typeof BENCHMARK_TASKS
 ): Promise<QueryResult[]> {
     const { annotationSvc, fileSvc } = createServices(service, sourceNames);
 
@@ -64,17 +65,17 @@ async function benchmarkSource(
     // of every task reflect cold-start overhead rather than steady-state cost.
     setStatus(`Warming up ${sourceNames.join(", ")} (${warmupRounds} rounds)...`);
     for (let w = 0; w < warmupRounds; w++) {
-        for (const task of BENCHMARK_TASKS) {
+        for (const task of tasks) {
             service.clearTimings();
             await task.run(annotationSvc, fileSvc);
         }
     }
 
-    const timingsMap = new Map<string, number[]>(BENCHMARK_TASKS.map(({ name }) => [name, []]));
+    const timingsMap = new Map<string, number[]>(tasks.map(({ name }) => [name, []]));
 
     for (let i = 0; i < iterations; i++) {
         setStatus(`Timing ${sourceNames.join(", ")} — iteration ${i + 1}/${iterations}...`);
-        for (const task of shuffle(BENCHMARK_TASKS)) {
+        for (const task of shuffle(tasks)) {
             if (task.resetAnnotationCache) {
                 for (const sourceName of sourceNames) {
                     service.clearAnnotationCache(sourceName);
@@ -94,7 +95,7 @@ async function benchmarkSource(
         }
     }
 
-    return BENCHMARK_TASKS.map(({ name }) => {
+    return tasks.map(({ name }) => {
         const timings = [...(timingsMap.get(name) ?? [])].sort((a, b) => a - b);
         return {
             name,
@@ -113,6 +114,16 @@ async function main() {
     }
     const iterations = config.iterations ?? DEFAULT_ITERATIONS;
     const warmupRounds = config.warmupRounds ?? DEFAULT_WARMUP_ROUNDS;
+    const taskFilter = config.taskFilter;
+
+    // When a taskFilter is provided, only run the requested tasks.
+    if (taskFilter) {
+        const validNames = new Set(BENCHMARK_TASKS.map((t) => t.name));
+        const invalid = taskFilter.filter((n) => !validNames.has(n));
+        if (invalid.length) {
+            throw new Error(`Unknown task(s) in taskFilter: ${invalid.join(", ")}`);
+        }
+    }
 
     setStatus("Initializing DuckDB-WASM...");
     const initStart = performance.now();
@@ -149,6 +160,10 @@ async function main() {
         await service.execute('DROP VIEW IF EXISTS "__bff_warmup__"');
     }
 
+    const activeTasks = taskFilter
+        ? BENCHMARK_TASKS.filter((t) => taskFilter.includes(t.name))
+        : BENCHMARK_TASKS;
+
     const sourceResults: SourceResult[] = [];
 
     for (const sources of config.testCases) {
@@ -171,7 +186,13 @@ async function main() {
         const registrationMs = performance.now() - regStart;
 
         const labels = sources.map((source) => source.label);
-        const queries = await benchmarkSource(service, labels, iterations, warmupRounds);
+        const queries = await benchmarkSource(
+            service,
+            labels,
+            iterations,
+            warmupRounds,
+            activeTasks
+        );
         sourceResults.push({ labels, registrationMs, queries });
 
         for (const source of sources) {

--- a/packages/web/benchmark/src/stats.ts
+++ b/packages/web/benchmark/src/stats.ts
@@ -3,19 +3,11 @@ import { QueryResult } from "./types";
 export const DEFAULT_ITERATIONS = 5;
 export const DEFAULT_WARMUP_ROUNDS = 1;
 
-// Nearest-rank percentile over a pre-sorted array. Used to report p50 and p95
-// across timed iterations — p95 surfaces occasional slow outliers (GC pauses,
-// DuckDB cache misses) that the median would hide.
 export function percentile(sorted: number[], p: number): number {
     const idx = Math.ceil((p / 100) * sorted.length) - 1;
     return sorted[Math.max(0, idx)];
 }
 
-/**
- * Build a QueryResult from raw timing samples: sorts them and computes
- * p50/p95/p99. Used by both the in-browser benchmark engine and the
- * Playwright runner's cold-start aggregation path.
- */
 export function buildQueryResult(name: string, rawTimings: number[]): QueryResult {
     const timings = [...rawTimings].sort((a, b) => a - b);
     return {

--- a/packages/web/benchmark/src/stats.ts
+++ b/packages/web/benchmark/src/stats.ts
@@ -1,0 +1,28 @@
+import { QueryResult } from "./types";
+
+export const DEFAULT_ITERATIONS = 5;
+export const DEFAULT_WARMUP_ROUNDS = 1;
+
+// Nearest-rank percentile over a pre-sorted array. Used to report p50 and p95
+// across timed iterations — p95 surfaces occasional slow outliers (GC pauses,
+// DuckDB cache misses) that the median would hide.
+export function percentile(sorted: number[], p: number): number {
+    const idx = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+}
+
+/**
+ * Build a QueryResult from raw timing samples: sorts them and computes
+ * p50/p95/p99. Used by both the in-browser benchmark engine and the
+ * Playwright runner's cold-start aggregation path.
+ */
+export function buildQueryResult(name: string, rawTimings: number[]): QueryResult {
+    const timings = [...rawTimings].sort((a, b) => a - b);
+    return {
+        name,
+        timings,
+        p50: percentile(timings, 50),
+        p95: percentile(timings, 95),
+        p99: percentile(timings, 99),
+    };
+}

--- a/packages/web/benchmark/src/types.ts
+++ b/packages/web/benchmark/src/types.ts
@@ -15,6 +15,8 @@ export interface BenchmarkConfig {
     testCases: TestCase[];
     iterations?: number;
     warmupRounds?: number;
+    /** When set, only tasks whose name appears in this list will run. */
+    taskFilter?: string[];
 }
 
 export interface QueryResult {

--- a/packages/web/benchmark/src/types.ts
+++ b/packages/web/benchmark/src/types.ts
@@ -15,7 +15,6 @@ export interface BenchmarkConfig {
     testCases: TestCase[];
     iterations?: number;
     warmupRounds?: number;
-    /** When set, only tasks whose name appears in this list will run. */
     taskFilter?: string[];
 }
 

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -233,7 +233,9 @@ async function runColdStartBenchmarks({
 
                 const timing = runResult.queries[0]?.timings[0];
                 if (timing !== undefined) {
-                    timingsMap.get(taskName)!.push(timing);
+                    const timings = timingsMap.get(taskName);
+                    if (!timings) throw Error(`${taskName} not in timingsMap!`);
+                    timings.push(timing);
                 }
             }
         }

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -338,7 +338,7 @@ async function runInBrowser({
 async function injectFixtures(page: Page, testCases: TestCase[]) {
     const loaded = new Set<string>();
     for (const source of testCases.flat()) {
-        if (loaded.has(source.label)) continue;
+        if (loaded.has(source.label)) continue; // Don't add duplicate sources
         const localMatch = source.url.match(new RegExp(`^http://localhost:${PORT}/fixtures/(.+)$`));
         if (!localMatch) continue;
         const fixturePath = path.join(FIXTURES_DIR, localMatch[1]);

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -22,13 +22,15 @@ declare global {
 }
 
 import { chromium } from "playwright";
+import type { Page } from "playwright";
 import http from "http";
 import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
-import { BenchmarkResults, QueryResult, SourceResult, TestCase } from "../../benchmark/src/types";
+import { BenchmarkResults, SourceResult, TestCase } from "../../benchmark/src/types";
 import { BENCHMARK_TASKS } from "../../benchmark/src/tasks";
 import { DEFAULT_ITERATIONS, buildQueryResult } from "../../benchmark/src/stats";
+
 const DIST_DIR = path.join(__dirname, "..", "..", "benchmark", "dist");
 const FIXTURES_DIR = path.join(__dirname, "..", "..", "fixtures");
 const PORT = 18765;
@@ -170,107 +172,106 @@ export async function runBenchmarkPage({
     const server = await startServer();
 
     try {
-        const allTaskNames = BENCHMARK_TASKS.map((task) => task.name);
-        const iterationCount = iterations ?? DEFAULT_ITERATIONS;
-
-        let initTimeMs = 0;
-        const sourceResults: SourceResult[] = [];
-
-        for (const testCase of testCases) {
-            let registrationMs = 0;
-            let queries: QueryResult[];
-
-            if (warmupRounds === 0) {
-                // Each (task, iteration) pair gets a fresh browser so every
-                // measurement is a cold start.
-                console.log(
-                    `[playwright] warmupRounds=0: running ${allTaskNames.length} task(s) × ` +
-                        `${iterationCount} iteration(s) in separate browser instances`
-                );
-
-                const timingsMap = new Map<string, number[]>(
-                    allTaskNames.map((name) => [name, []])
-                );
-
-                for (const taskName of allTaskNames) {
-                    for (let i = 0; i < iterationCount; i++) {
-                        console.log(
-                            `[playwright] Launching browser for "${taskName}" ` +
-                                `iteration ${i + 1}/${iterationCount} ` +
-                                `(${testCase.map((source) => source.label).join(", ")})`
-                        );
-                        const run = await runSingleBenchmark({
-                            testCase,
-                            iterations: 1,
-                            warmupRounds: 0,
-                            channel,
-                            taskFilter: [taskName],
-                        });
-
-                        if (initTimeMs === 0) initTimeMs = run.initTimeMs;
-                        if (registrationMs === 0) registrationMs = run.registrationMs;
-
-                        const timing = run.queries[0]?.timings[0];
-                        if (timing !== undefined) {
-                            timingsMap.get(taskName)!.push(timing);
-                        }
-                    }
-                }
-
-                queries = allTaskNames.map((name) =>
-                    buildQueryResult(name, timingsMap.get(name) ?? [])
-                );
-            } else {
-                // Warmups > 0: all tasks share a single browser instance.
-                console.log(
-                    `[playwright] Launching browser for task(s): ${allTaskNames.join(", ")} ` +
-                        `(${testCase.map((source) => source.label).join(", ")})`
-                );
-                const run = await runSingleBenchmark({
-                    testCase,
-                    iterations: iterationCount,
-                    warmupRounds,
-                    channel,
-                    taskFilter: allTaskNames,
-                });
-
-                initTimeMs = initTimeMs || run.initTimeMs;
-                registrationMs = run.registrationMs;
-                queries = run.queries;
-            }
-
-            sourceResults.push({
-                labels: testCase.map((source) => source.label),
-                registrationMs,
-                queries,
-            });
+        if (warmupRounds === 0) {
+            return await runColdStartBenchmarks({ testCases, iterations, channel });
+        } else {
+            // Warmups > 0: all test cases share a single browser instance.
+            return await runInBrowser({ testCases, iterations, warmupRounds, channel });
         }
-
-        return {
-            timestamp: new Date().toISOString(),
-            commit: "unknown",
-            branch: "unknown",
-            initTimeMs,
-            results: sourceResults,
-        } as BenchmarkResults;
     } finally {
         await new Promise((res) => server.close(res));
     }
 }
 
-async function runSingleBenchmark({
-    testCase,
+/**
+ * warmupRounds=0 path: each (testCase, task, iteration) triple gets a fresh
+ * browser so every measurement is a cold start.
+ */
+async function runColdStartBenchmarks({
+    testCases,
+    iterations,
+    channel,
+}: {
+    testCases: TestCase[];
+    iterations?: number;
+    channel?: string;
+}): Promise<BenchmarkResults> {
+    const allTaskNames = BENCHMARK_TASKS.map((task) => task.name);
+    const iterationCount = iterations ?? DEFAULT_ITERATIONS;
+
+    let initTimeMs = 0;
+    const sourceResults: SourceResult[] = [];
+
+    for (const testCase of testCases) {
+        let registrationMs = 0;
+
+        console.log(
+            `[playwright] warmupRounds=0: running ${allTaskNames.length} task(s) × ` +
+                `${iterationCount} iteration(s) in separate browser instances`
+        );
+
+        const timingsMap = new Map<string, number[]>(allTaskNames.map((name) => [name, []]));
+
+        for (const taskName of allTaskNames) {
+            for (let i = 0; i < iterationCount; i++) {
+                console.log(
+                    `[playwright] Launching browser for "${taskName}" ` +
+                        `iteration ${i + 1}/${iterationCount} ` +
+                        `(${testCase.map((source) => source.label).join(", ")})`
+                );
+                const run = await runInBrowser({
+                    testCases: [testCase],
+                    iterations: 1,
+                    warmupRounds: 0,
+                    channel,
+                    taskFilter: [taskName],
+                });
+
+                if (initTimeMs === 0) initTimeMs = run.initTimeMs;
+                const runResult = run.results[0];
+                if (registrationMs === 0) registrationMs = runResult.registrationMs;
+
+                const timing = runResult.queries[0]?.timings[0];
+                if (timing !== undefined) {
+                    timingsMap.get(taskName)!.push(timing);
+                }
+            }
+        }
+
+        sourceResults.push({
+            labels: testCase.map((source) => source.label),
+            registrationMs,
+            queries: allTaskNames.map((name) => buildQueryResult(name, timingsMap.get(name) ?? [])),
+        });
+    }
+
+    return {
+        timestamp: new Date().toISOString(),
+        commit: "unknown",
+        branch: "unknown",
+        initTimeMs,
+        results: sourceResults,
+    };
+}
+
+/**
+ * Launch a single browser, run the benchmark with the given config, and return
+ * the raw BenchmarkResults. Both the warmup>0 path (all test cases) and the
+ * warmup=0 path (one test case + task filter) funnel through here.
+ */
+async function runInBrowser({
+    testCases,
     iterations,
     warmupRounds,
     channel,
     taskFilter,
 }: {
-    testCase: TestCase;
-    iterations: number;
+    testCases: TestCase[];
+    iterations?: number;
     warmupRounds?: number;
     channel?: string;
-    taskFilter: string[];
-}): Promise<{ initTimeMs: number; registrationMs: number; queries: QueryResult[] }> {
+    taskFilter?: string[];
+}): Promise<BenchmarkResults> {
     const browser = await chromium.launch({
         channel,
         headless: true,
@@ -289,14 +290,14 @@ async function runSingleBenchmark({
         // synchronously on startup — no callback handshake needed.
         await page.addInitScript({
             content: `window.__benchmarkConfig = ${JSON.stringify({
-                testCases: [testCase],
+                testCases,
                 iterations,
                 warmupRounds,
                 taskFilter,
             })};`,
         });
 
-        console.log(`[playwright] Starting benchmark...`);
+        console.log(`[playwright] Starting benchmark (${testCases.length} test case(s))...`);
         await page.goto(`http://localhost:${PORT}/`, { waitUntil: "domcontentloaded" });
 
         // Wait for the benchmark to signal it's ready for file injection
@@ -308,38 +309,7 @@ async function runSingleBenchmark({
         // The browser reads the file lazily via FileReader (BROWSER_FILEREADER protocol),
         // which is identical to how the real app loads files via the file picker —
         // no HTTP range-request overhead, so DuckDB sort performance matches real-user timing.
-        const loaded = new Set();
-        for (const source of testCase) {
-            if (source.label in loaded) continue; // Don't add duplicate sources
-            const localMatch = source.url.match(
-                new RegExp(`^http://localhost:${PORT}/fixtures/(.+)$`)
-            );
-            if (!localMatch) continue;
-            const fixturePath = path.join(FIXTURES_DIR, localMatch[1]);
-            if (!fs.existsSync(fixturePath)) continue;
-
-            console.log(`[playwright] Injecting ${source.label} via setInputFiles...`);
-            const inputHandle = await page.evaluateHandle(() => {
-                const inp: HTMLInputElement = document.createElement("input");
-                inp.type = "file";
-                document.body.appendChild(inp);
-                return inp;
-            });
-            await inputHandle.setInputFiles(fixturePath);
-            await page.evaluate((label) => {
-                const inputs: NodeListOf<HTMLInputElement> = document.querySelectorAll(
-                    "input[type=file]"
-                );
-                const inp = inputs[inputs.length - 1];
-                window.__pendingLocalFiles = window.__pendingLocalFiles || {};
-                if (!inp.files) {
-                    throw new Error(`Injected file not found for ${label}.`);
-                }
-                window.__pendingLocalFiles[label] = inp.files[0];
-                inp.remove();
-            }, source.label);
-            loaded.add(source.label);
-        }
+        await injectFixtures(page, testCases);
 
         // Signal the benchmark to proceed with injected File objects
         await page.evaluate(() => {
@@ -359,17 +329,42 @@ async function runSingleBenchmark({
         const error = await page.evaluate(() => window.__benchmarkError ?? null);
         if (error) throw new Error(`Benchmark failed in browser: ${error}`);
 
-        const benchmarkResults: BenchmarkResults = await page.evaluate(
-            () => window.__benchmarkResults
-        );
-        const result = benchmarkResults.results[0];
-        return {
-            initTimeMs: benchmarkResults.initTimeMs,
-            registrationMs: result.registrationMs,
-            queries: result.queries,
-        };
+        return await page.evaluate(() => window.__benchmarkResults);
     } finally {
         await browser.close();
+    }
+}
+
+async function injectFixtures(page: Page, testCases: TestCase[]) {
+    const loaded = new Set<string>();
+    for (const source of testCases.flat()) {
+        if (loaded.has(source.label)) continue;
+        const localMatch = source.url.match(new RegExp(`^http://localhost:${PORT}/fixtures/(.+)$`));
+        if (!localMatch) continue;
+        const fixturePath = path.join(FIXTURES_DIR, localMatch[1]);
+        if (!fs.existsSync(fixturePath)) continue;
+
+        console.log(`[playwright] Injecting ${source.label} via setInputFiles...`);
+        const inputHandle = await page.evaluateHandle(() => {
+            const inp: HTMLInputElement = document.createElement("input");
+            inp.type = "file";
+            document.body.appendChild(inp);
+            return inp;
+        });
+        await inputHandle.setInputFiles(fixturePath);
+        await page.evaluate((label) => {
+            const inputs: NodeListOf<HTMLInputElement> = document.querySelectorAll(
+                "input[type=file]"
+            );
+            const inp = inputs[inputs.length - 1];
+            window.__pendingLocalFiles = window.__pendingLocalFiles || {};
+            if (!inp.files) {
+                throw new Error(`Injected file not found for ${label}.`);
+            }
+            window.__pendingLocalFiles[label] = inp.files[0];
+            inp.remove();
+        }, source.label);
+        loaded.add(source.label);
     }
 }
 

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -158,7 +158,7 @@ export async function runBenchmarkPage({
     iterations?: number;
     warmupRounds?: number;
     channel?: string;
-}) {
+}): Promise<BenchmarkResults> {
     if (!skipBuild) buildBenchmark();
 
     if (!fs.existsSync(path.join(DIST_DIR, "index.html"))) {

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -23,7 +23,8 @@ import http from "http";
 import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
-import { BenchmarkResults, TestCase } from "../../benchmark/src/types";
+import { BenchmarkResults, QueryResult, SourceResult, TestCase } from "../../benchmark/src/types";
+import { BENCHMARK_TASKS } from "../../benchmark/src/tasks";
 
 const DIST_DIR = path.join(__dirname, "..", "..", "benchmark", "dist");
 const FIXTURES_DIR = path.join(__dirname, "..", "..", "fixtures");
@@ -154,7 +155,7 @@ export async function runBenchmarkPage({
     iterations?: number;
     warmupRounds?: number;
     channel?: string;
-}): Promise<BenchmarkResults> {
+}) {
     if (!skipBuild) buildBenchmark();
 
     if (!fs.existsSync(path.join(DIST_DIR, "index.html"))) {
@@ -164,6 +165,77 @@ export async function runBenchmarkPage({
     }
 
     const server = await startServer();
+
+    try {
+        // When warmups=0, each task gets its own browser for cold-start isolation.
+        // Otherwise all tasks share a single browser instance.
+        const allTaskNames = BENCHMARK_TASKS.map((t) => t.name);
+        const taskBatches: string[][] =
+            warmupRounds === 0 ? allTaskNames.map((name) => [name]) : [allTaskNames];
+
+        if (warmupRounds === 0) {
+            console.log(
+                `[playwright] warmupRounds=0: running ${allTaskNames.length} task(s) in separate browser instances`
+            );
+        }
+
+        let initTimeMs = 0;
+        const sourceResults: SourceResult[] = [];
+
+        for (const testCase of testCases) {
+            const queries: QueryResult[] = [];
+            let registrationMs = 0;
+
+            for (const batch of taskBatches) {
+                console.log(
+                    `[playwright] Launching browser for task(s): ${batch.join(", ")} ` +
+                        `(${testCase.map((s) => s.label).join(", ")})`
+                );
+                const run = await runSingleBenchmark({
+                    testCase,
+                    iterations,
+                    warmupRounds,
+                    channel,
+                    taskFilter: batch,
+                });
+
+                if (initTimeMs === 0) initTimeMs = run.initTimeMs;
+                if (registrationMs === 0) registrationMs = run.registrationMs;
+                queries.push(...run.queries);
+            }
+
+            sourceResults.push({
+                labels: testCase.map((testCase) => testCase.label),
+                registrationMs,
+                queries,
+            });
+        }
+
+        return {
+            timestamp: new Date().toISOString(),
+            commit: "unknown",
+            branch: "unknown",
+            initTimeMs,
+            results: sourceResults,
+        } as BenchmarkResults;
+    } finally {
+        await new Promise((res) => server.close(res));
+    }
+}
+
+async function runSingleBenchmark({
+    testCase,
+    iterations,
+    warmupRounds,
+    channel,
+    taskFilter,
+}: {
+    testCase: TestCase;
+    iterations?: number;
+    warmupRounds?: number;
+    channel?: string;
+    taskFilter: string[];
+}): Promise<{ initTimeMs: number; registrationMs: number; queries: QueryResult[] }> {
     const browser = await chromium.launch({
         channel,
         headless: true,
@@ -182,13 +254,14 @@ export async function runBenchmarkPage({
         // synchronously on startup — no callback handshake needed.
         await page.addInitScript({
             content: `window.__benchmarkConfig = ${JSON.stringify({
-                testCases,
+                testCases: [testCase],
                 iterations,
                 warmupRounds,
+                taskFilter,
             })};`,
         });
 
-        console.log(`[playwright] Starting benchmark (${testCases.length} test case(s))...`);
+        console.log(`[playwright] Starting benchmark...`);
         await page.goto(`http://localhost:${PORT}/`, { waitUntil: "domcontentloaded" });
 
         // Wait for the benchmark to signal it's ready for file injection
@@ -201,7 +274,7 @@ export async function runBenchmarkPage({
         // which is identical to how the real app loads files via the file picker —
         // no HTTP range-request overhead, so DuckDB sort performance matches real-user timing.
         const loaded = new Set();
-        for (const source of testCases.flat()) {
+        for (const source of testCase) {
             if (source.label in loaded) continue; // Don't add duplicate sources
             const localMatch = source.url.match(
                 new RegExp(`^http://localhost:${PORT}/fixtures/(.+)$`)
@@ -251,10 +324,17 @@ export async function runBenchmarkPage({
         const error = await page.evaluate(() => window.__benchmarkError ?? null);
         if (error) throw new Error(`Benchmark failed in browser: ${error}`);
 
-        return await page.evaluate(() => window.__benchmarkResults);
+        const benchmarkResults: BenchmarkResults = await page.evaluate(
+            () => window.__benchmarkResults
+        );
+        const result = benchmarkResults.results[0];
+        return {
+            initTimeMs: benchmarkResults.initTimeMs,
+            registrationMs: result.registrationMs,
+            queries: result.queries,
+        };
     } finally {
         await browser.close();
-        await new Promise((res) => server.close(res));
     }
 }
 

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -25,7 +25,7 @@ import path from "path";
 import { execSync } from "child_process";
 import { BenchmarkResults, QueryResult, SourceResult, TestCase } from "../../benchmark/src/types";
 import { BENCHMARK_TASKS } from "../../benchmark/src/tasks";
-
+import { DEFAULT_ITERATIONS, buildQueryResult } from "../../benchmark/src/stats";
 const DIST_DIR = path.join(__dirname, "..", "..", "benchmark", "dist");
 const FIXTURES_DIR = path.join(__dirname, "..", "..", "fixtures");
 const PORT = 18765;
@@ -167,45 +167,77 @@ export async function runBenchmarkPage({
     const server = await startServer();
 
     try {
-        // When warmups=0, each task gets its own browser for cold-start isolation.
-        // Otherwise all tasks share a single browser instance.
-        const allTaskNames = BENCHMARK_TASKS.map((t) => t.name);
-        const taskBatches: string[][] =
-            warmupRounds === 0 ? allTaskNames.map((name) => [name]) : [allTaskNames];
-
-        if (warmupRounds === 0) {
-            console.log(
-                `[playwright] warmupRounds=0: running ${allTaskNames.length} task(s) in separate browser instances`
-            );
-        }
+        const allTaskNames = BENCHMARK_TASKS.map((task) => task.name);
+        const iterationCount = iterations ?? DEFAULT_ITERATIONS;
 
         let initTimeMs = 0;
         const sourceResults: SourceResult[] = [];
 
         for (const testCase of testCases) {
-            const queries: QueryResult[] = [];
             let registrationMs = 0;
+            let queries: QueryResult[];
 
-            for (const batch of taskBatches) {
+            if (warmupRounds === 0) {
+                // Each (task, iteration) pair gets a fresh browser so every
+                // measurement is a cold start.
                 console.log(
-                    `[playwright] Launching browser for task(s): ${batch.join(", ")} ` +
-                        `(${testCase.map((s) => s.label).join(", ")})`
+                    `[playwright] warmupRounds=0: running ${allTaskNames.length} task(s) × ` +
+                        `${iterationCount} iteration(s) in separate browser instances`
+                );
+
+                const timingsMap = new Map<string, number[]>(
+                    allTaskNames.map((name) => [name, []])
+                );
+
+                for (const taskName of allTaskNames) {
+                    for (let i = 0; i < iterationCount; i++) {
+                        console.log(
+                            `[playwright] Launching browser for "${taskName}" ` +
+                                `iteration ${i + 1}/${iterationCount} ` +
+                                `(${testCase.map((source) => source.label).join(", ")})`
+                        );
+                        const run = await runSingleBenchmark({
+                            testCase,
+                            iterations: 1,
+                            warmupRounds: 0,
+                            channel,
+                            taskFilter: [taskName],
+                        });
+
+                        if (initTimeMs === 0) initTimeMs = run.initTimeMs;
+                        if (registrationMs === 0) registrationMs = run.registrationMs;
+
+                        const timing = run.queries[0]?.timings[0];
+                        if (timing !== undefined) {
+                            timingsMap.get(taskName)!.push(timing);
+                        }
+                    }
+                }
+
+                queries = allTaskNames.map((name) =>
+                    buildQueryResult(name, timingsMap.get(name) ?? [])
+                );
+            } else {
+                // Warmups > 0: all tasks share a single browser instance.
+                console.log(
+                    `[playwright] Launching browser for task(s): ${allTaskNames.join(", ")} ` +
+                        `(${testCase.map((source) => source.label).join(", ")})`
                 );
                 const run = await runSingleBenchmark({
                     testCase,
-                    iterations,
+                    iterations: iterationCount,
                     warmupRounds,
                     channel,
-                    taskFilter: batch,
+                    taskFilter: allTaskNames,
                 });
 
-                if (initTimeMs === 0) initTimeMs = run.initTimeMs;
-                if (registrationMs === 0) registrationMs = run.registrationMs;
-                queries.push(...run.queries);
+                initTimeMs = initTimeMs || run.initTimeMs;
+                registrationMs = run.registrationMs;
+                queries = run.queries;
             }
 
             sourceResults.push({
-                labels: testCase.map((testCase) => testCase.label),
+                labels: testCase.map((source) => source.label),
                 registrationMs,
                 queries,
             });
@@ -231,7 +263,7 @@ async function runSingleBenchmark({
     taskFilter,
 }: {
     testCase: TestCase;
-    iterations?: number;
+    iterations: number;
     warmupRounds?: number;
     channel?: string;
     taskFilter: string[];


### PR DESCRIPTION
## Purpose

Enable benchmarking cold-start scenarios by using a new browser instance for every trial. This feature is enabled only when the user sets `warmups=0`.

Builds on #739, #806,

## Changes
* The benchmark page (`index.ts`) accepts an optional list of tasks to run, and runs all tasks by default.
* `run-benchmark-page.ts` now splits the logic into `runInBrowser` (for `warmups > 0`) and `runColdStartBenchmarks`, which makes use of `runInBrowser`.
* Fixed a bug where I used `in` instead of `has` for set membership.
* Extracted some logic to `stats.ts` (may need a better name) and `injectFixtures` for DRY and readability.

## Testing
Without this change, running tests with `warmups=0` shows a significant performance decrease for the first trial of each batch. The test below used 4 batches with 15 or 20 iterations each.

Before:
<img width="598" height="373" alt="Screenshot 2026-05-28 at 2 36 19 PM" src="https://github.com/user-attachments/assets/3341c4cf-1c4d-49dd-886b-1cafe20fa12b" />

After this change, with `warmups=0`, there are no obvious outliers.

[After](https://github.com/AllenInstitute/biofile-finder/actions/runs/26603676754) (2 batches, 5 iterations each):
<img width="598" height="373" alt="Screenshot 2026-05-29 at 10 53 40 AM" src="https://github.com/user-attachments/assets/a2109686-6783-4e56-b4dc-06aba37fb50a" />
