### PR TITLE
loadBalancer http->https

### DIFF
--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -79,8 +79,8 @@ export enum MMSBaseUrl {
 
 export enum LoadBalancerBaseUrl {
     LOCALHOST = "http://localhost:8080",
-    STAGING = "http://stg-aics.corp.alleninstitute.org",
-    PRODUCTION = "http://aics.corp.alleninstitute.org",
+    STAGING = "https://stg-aics.corp.alleninstitute.org",
+    PRODUCTION = "https://aics.corp.alleninstitute.org",
     TEST = "http://test-aics.corp.alleninstitute.org",
 }
 


### PR DESCRIPTION
## Description 

I ran into an issue with attempting to submit to our load balancer from https to http
```
https://bff.allencell.org/app?c=file_name%3A0.4%2CKind%3A0.2%2CType%3A0.25%2Cfile_size%3A0.15&filter=%7B%22name%22%3A%22file_name%22%2C%22value%22%3A%22czi%22%2C%22type%22%3A%22fuzzy%22%7D&source=%7B%22name%22%3A%22AICS+FMS%22%7D&sort=%7B%22annotationName%22%3A%22uploaded%22%2C%22order%22%3A%22DESC%22%7D' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://aics.corp.alleninstitute.org/fss2/v4.0/compute/all-cells-mask'. This request has been blocked; the content must be served over HTTPS.
```

I think this can be easily resolved by just making the load balancer URLs https. I am not sure how this will effect our stack.


## Testing

I tested this from http localhost to https loadBalancer. Im not sure how helpful this will be since our real condition is https to https. Going to deploy to staging to test out.