### PR TITLE
bugfix/pipeline-card-info

### DIFF
--- a/packages/core/services/PipelineService/mockPipelineData.ts
+++ b/packages/core/services/PipelineService/mockPipelineData.ts
@@ -10,7 +10,7 @@ export const MOCK_PIPELINES: Pipeline[] = [
         name: "All Cells Mask Segmentation",
         description:
             "The All Cells Mask workflow generates segmentation masks for the selected files.",
-        restrictions: "Works only for Zarr and CZI files under 100gb",
+        restrictions: "Works only for Zarr and CZI files under 100 GB",
         clusters: ["slurm-prod"],
         acceptedExtensions: ["czi", "zarr"],
         maxFileSizeBytes: 107374182400,

--- a/packages/core/services/PipelineService/mockPipelineData.ts
+++ b/packages/core/services/PipelineService/mockPipelineData.ts
@@ -10,9 +10,9 @@ export const MOCK_PIPELINES: Pipeline[] = [
         name: "All Cells Mask Segmentation",
         description:
             "The All Cells Mask workflow generates segmentation masks for the selected files.",
-        restrictions: "Works only for Tiff and CZI files under 100gb",
+        restrictions: "Works only for Zarr and CZI files under 100gb",
         clusters: ["slurm-prod"],
-        acceptedExtensions: ["czi", "tiff", "tif"],
+        acceptedExtensions: ["czi", "zarr"],
         maxFileSizeBytes: 107374182400,
     },
 ];


### PR DESCRIPTION
## Description
Got mixed up about supported files here for the acm pipeline when making the placeholder data. supports zarr not tiff.