### PR TITLE
Fast benchmark mode

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: "1"
+      skip_large:
+        description: "Skip 10m+10m, 20m test cases and the large sort task"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -61,8 +66,10 @@ jobs:
           curl -fL "$BASE/synthetic-100k.parquet" -o packages/web/fixtures/synthetic-100k.parquet
           curl -fL "$BASE/synthetic-1m.parquet"   -o packages/web/fixtures/synthetic-1m.parquet
           curl -fL "$BASE/synthetic-10m.parquet"  -o packages/web/fixtures/synthetic-10m.parquet
-          curl -fL "$BASE/synthetic-10m-copy.parquet"  -o packages/web/fixtures/synthetic-10m-copy.parquet
-          curl -fL "$BASE/synthetic-20m.parquet"  -o packages/web/fixtures/synthetic-20m.parquet
+          if [ "${{ github.event.inputs.skip_large }}" != "true" ]; then
+            curl -fL "$BASE/synthetic-10m-copy.parquet"  -o packages/web/fixtures/synthetic-10m-copy.parquet
+            curl -fL "$BASE/synthetic-20m.parquet"  -o packages/web/fixtures/synthetic-20m.parquet
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -77,7 +84,7 @@ jobs:
         working-directory: packages/web
 
       - name: Run benchmark (${{ github.event.inputs.compare_branch }})
-        run: npm run benchmark:regression -- --iterations ${{ github.event.inputs.iterations }} --warmup ${{ github.event.inputs.warmup }}
+        run: npm run benchmark:regression -- --iterations ${{ github.event.inputs.iterations }} --warmup ${{ github.event.inputs.warmup }} ${{ github.event.inputs.skip_large == 'true' && '--skip-large' || '' }}
         working-directory: packages/web
         env:
           BENCHMARK_BRANCH: ${{ github.event.inputs.compare_branch }}
@@ -94,7 +101,7 @@ jobs:
         run: npm ci
 
       - name: Run benchmark (${{ github.event.inputs.base_branch }})
-        run: npm run benchmark:regression -- --skip-build --iterations ${{ github.event.inputs.iterations }} --warmup ${{ github.event.inputs.warmup }}
+        run: npm run benchmark:regression -- --skip-build --iterations ${{ github.event.inputs.iterations }} --warmup ${{ github.event.inputs.warmup }} ${{ github.event.inputs.skip_large == 'true' && '--skip-large' || '' }}
         working-directory: packages/web
         env:
           BENCHMARK_BRANCH: ${{ github.event.inputs.base_branch }}

--- a/packages/web/scripts/lib/run-benchmark-page.ts
+++ b/packages/web/scripts/lib/run-benchmark-page.ts
@@ -154,12 +154,14 @@ export async function runBenchmarkPage({
     iterations,
     warmupRounds,
     channel,
+    taskFilter,
 }: {
     testCases: TestCase[];
     skipBuild?: boolean;
     iterations?: number;
     warmupRounds?: number;
     channel?: string;
+    taskFilter?: string[];
 }): Promise<BenchmarkResults> {
     if (!skipBuild) buildBenchmark();
 
@@ -173,10 +175,10 @@ export async function runBenchmarkPage({
 
     try {
         if (warmupRounds === 0) {
-            return await runColdStartBenchmarks({ testCases, iterations, channel });
+            return await runColdStartBenchmarks({ testCases, iterations, channel, taskFilter });
         } else {
             // Warmups > 0: all test cases share a single browser instance.
-            return await runInBrowser({ testCases, iterations, warmupRounds, channel });
+            return await runInBrowser({ testCases, iterations, warmupRounds, channel, taskFilter });
         }
     } finally {
         await new Promise((res) => server.close(res));
@@ -191,12 +193,14 @@ async function runColdStartBenchmarks({
     testCases,
     iterations,
     channel,
+    taskFilter,
 }: {
     testCases: TestCase[];
     iterations?: number;
     channel?: string;
+    taskFilter?: string[];
 }): Promise<BenchmarkResults> {
-    const allTaskNames = BENCHMARK_TASKS.map((task) => task.name);
+    const allTaskNames = taskFilter ?? BENCHMARK_TASKS.map((task) => task.name);
     const iterationCount = iterations ?? DEFAULT_ITERATIONS;
 
     let initTimeMs = 0;

--- a/packages/web/scripts/run-regression.ts
+++ b/packages/web/scripts/run-regression.ts
@@ -15,6 +15,7 @@ function testCaseKey(sources: ParquetSource[]): string {
     return sources.map((s) => s.label).join("+");
 }
 
+// Task names from benchmark/src/tasks.ts that are too slow for the fast benchmark.
 const SKIP_LARGE_TASKS = new Set(["sort_file_list_large_page"]);
 
 const FIXTURES_DIR = path.join(__dirname, "..", "fixtures");

--- a/packages/web/scripts/run-regression.ts
+++ b/packages/web/scripts/run-regression.ts
@@ -2,11 +2,20 @@
 // benchmark-results-<branch>.json. Called once per branch by benchmark.yml.
 
 import { ParquetSource } from "../benchmark/src/types";
+import { BENCHMARK_TASKS } from "../benchmark/src/tasks";
 
 import path from "path";
 import fs from "fs";
 import { execSync } from "child_process";
 import { runBenchmarkPage } from "./lib/run-benchmark-page";
+
+const LARGE_TEST_CASE_LABELS = new Set(["10m+10m_2", "20m"]);
+
+function testCaseKey(sources: ParquetSource[]): string {
+    return sources.map((s) => s.label).join("+");
+}
+
+const SKIP_LARGE_TASKS = new Set(["sort_file_list_large_page"]);
 
 const FIXTURES_DIR = path.join(__dirname, "..", "fixtures");
 
@@ -47,19 +56,21 @@ const TEST_CASES: ParquetSource[][] = [
     ],
 ];
 
-const inputFiles = new Set(
-    TEST_CASES.flat().flatMap(({ url }) => url.replace("http://localhost:18765/fixtures/", ""))
-);
-
-const missing = Array.from(inputFiles).filter(
-    (fileName) => !fs.existsSync(path.join(FIXTURES_DIR, fileName))
-);
-if (missing.length > 0) {
-    console.error(
-        `Missing fixture files: ${missing.join(", ")}\n` +
-            `Download them to ${FIXTURES_DIR} before running this script.`
+function checkFixtures(testCases: ParquetSource[][]) {
+    const inputFiles = new Set(
+        testCases.flat().flatMap(({ url }) => url.replace("http://localhost:18765/fixtures/", ""))
     );
-    process.exit(1);
+
+    const missing = Array.from(inputFiles).filter(
+        (fileName) => !fs.existsSync(path.join(FIXTURES_DIR, fileName))
+    );
+    if (missing.length > 0) {
+        console.error(
+            `Missing fixture files: ${missing.join(", ")}\n` +
+                `Download them to ${FIXTURES_DIR} before running this script.`
+        );
+        process.exit(1);
+    }
 }
 
 function getCurrentBranch(): string {
@@ -82,18 +93,30 @@ function getArgValue(flag: string): number | undefined {
 
 async function main() {
     const skipBuild = process.argv.includes("--skip-build");
+    const skipLarge = process.argv.includes("--skip-large");
     const iterations = getArgValue("--iterations");
     const warmup = getArgValue("--warmup");
 
+    const testCases = skipLarge
+        ? TEST_CASES.filter((tc) => !LARGE_TEST_CASE_LABELS.has(testCaseKey(tc)))
+        : TEST_CASES;
+    const taskFilter = skipLarge
+        ? BENCHMARK_TASKS.map((t) => t.name).filter((n) => !SKIP_LARGE_TASKS.has(n))
+        : undefined;
+
+    checkFixtures(testCases);
+
     console.log(`[regression] Using local fixtures from ${FIXTURES_DIR}`);
+    if (skipLarge) console.log(`[regression] Skipping large test cases and sort task`);
     if (iterations) console.log(`[regression] Iterations: ${iterations}`);
     if (warmup !== undefined) console.log(`[regression] Warmup rounds: ${warmup}`);
 
     const rawResults = await runBenchmarkPage({
-        testCases: TEST_CASES,
+        testCases,
         skipBuild,
         iterations,
         warmupRounds: warmup,
+        taskFilter,
     });
 
     const branch = getCurrentBranch();


### PR DESCRIPTION
## Context
Closes #818 

## Changes
* Give run-regression a `--skip-large` flag to skip 10m+10m, 20m test cases and the large sort task
* Add an option to `benchmark.yml` to expose the flag to the user

## Testing
* See test run here with `iterations=1` and `warmups=0` (using the changes from #808, every task ran in a new browser instance) that skips the expected test cases and task: https://github.com/AllenInstitute/biofile-finder/actions/runs/26606173872