### PR TITLE
Use SHA for actions in release and deployment workflows

### DIFF
--- a/.github/workflows/aws-deployment.yml
+++ b/.github/workflows/aws-deployment.yml
@@ -33,9 +33,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
 
@@ -46,7 +46,7 @@ jobs:
         run: npm run --prefix packages/web build
 
       - name: Upload build files
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: aws-deploy-files
           path: ./packages/web/dist
@@ -65,7 +65,7 @@ jobs:
         run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
 
       - name: Configure AWS credentials with OIDC
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_biofile_finder
           role-session-name: github_biofile_finder-${{ env.SHORT_SHA }}
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Download build artifacts
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: aws-deploy-files
           path: ./packages/web/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.client_payload.ref }}
 
       - name: Install Node.js
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Build/release Electron app
-        uses: AllenCell/action-electron-builder@v2.0.0
+        uses: AllenCell/action-electron-builder@4a8da00f5301a1f70ad0d2224b23bf5dc8a6c671
         env:
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
         with:


### PR DESCRIPTION
## Context
When upgrading Node in #830, I missed updating the action versions for the AWS deployment workflow. Infra's preference for this one is that we use the SHA for the latest version release, per [this thread](https://allencellscience.slack.com/archives/C04DNM9G43S/p1781632964108009). I also switched to using the SHA for `action-electron-builder` in release.yml.

Relatedly, for release we had been using `@main` for `checkout` and and `setup-node`, but it's slightly more reliable to point to a release that matches our node version. 

## Testing
Was able to successfully [run the aws-deployment workflow](https://github.com/AllenInstitute/biofile-finder/actions/runs/27642174214) to deploy this branch to staging, and GitHub's node deprecation warnings are no longer present. May not be able to verify that release works until after this branch is merged