### PR TITLE
Fall back to cloud path when local VAST path is missing for compute pipeline

### DIFF
--- a/packages/core/components/Modal/ComputePipelineModal/index.tsx
+++ b/packages/core/components/Modal/ComputePipelineModal/index.tsx
@@ -250,8 +250,13 @@ export default function ComputePipelineModal({ onDismiss }: ModalProps) {
         try {
             const details = await fileSelection.fetchAllDetails();
             const filePaths = details
-                .map((d) => d.getFirstAnnotationValue(AnnotationName.LOCAL_FILE_PATH))
-                .filter((p): p is string => typeof p === "string");
+                .map((d) => {
+                    // Prefer the local VAST path when present; otherwise fall back to the
+                    // cloud path so the file gets downloaded and processed.
+                    const localPath = d.getFirstAnnotationValue(AnnotationName.LOCAL_FILE_PATH);
+                    return typeof localPath === "string" && localPath !== "" ? localPath : d.path;
+                })
+                .filter((p): p is string => typeof p === "string" && p !== "");
 
             const result = await pipelineService.submitComputeTask({
                 pipeline: selectedPipeline.id,


### PR DESCRIPTION
### Summary

The All Cells Mask compute pipeline submission (`ComputePipelineModal`) built the `file_paths` parameter solely from the `File Path (Local VAST)` (`LOCAL_FILE_PATH`) annotation. Any selected file lacking a local VAST path returned `undefined` and was silently dropped by the `.filter(...)`, so cloud-only files were excluded from the submitted job.

This change falls back to the file's cloud path (`FileDetail.path`) when no local path is present, so those files get downloaded and processed. Empty-string annotation values are also treated as "no local path" so they don't suppress the fallback.

### Testing

Manually verified the All Cells Mask submission for a file without a local path.

Resolves #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)