### PR TITLE
Bug: Consider links short always

### DIFF
--- a/packages/core/components/FileDetails/MetadataList/Value.tsx
+++ b/packages/core/components/FileDetails/MetadataList/Value.tsx
@@ -25,7 +25,10 @@ interface Props {
  */
 export default function Value(props: Props) {
     let content: React.ReactNode;
+    let { isLongValue } = props;
     if (props.annotation.isOpenFileLink) {
+        // Override long value truncation for open file links, since the link is rendered separately.
+        isLongValue = false;
         content = (
             <a className={styles.link} href={props.value} rel="noreferrer" target="_blank">
                 View link
@@ -35,7 +38,7 @@ export default function Value(props: Props) {
         content = (
             <MarkdownText
                 className={classNames({
-                    [styles.valueTruncated]: props.isCollapsed && props.isLongValue,
+                    [styles.valueTruncated]: props.isCollapsed && isLongValue,
                 })}
                 text={props.value}
             />
@@ -44,7 +47,7 @@ export default function Value(props: Props) {
         content = (
             <div
                 className={classNames({
-                    [styles.valueTruncated]: props.isCollapsed && props.isLongValue,
+                    [styles.valueTruncated]: props.isCollapsed && isLongValue,
                 })}
             >
                 {props.emphasize ? <i>{props.value}</i> : props.value}
@@ -55,7 +58,7 @@ export default function Value(props: Props) {
     return (
         <div className={styles.container} onContextMenu={props.onContextMenu}>
             {content}
-            {props.isLongValue && (
+            {isLongValue && (
                 <div className={styles.toggleContainer}>
                     <ContentLengthToggle
                         isCollapsed={props.isCollapsed}

--- a/packages/core/components/FileDetails/MetadataList/Value.tsx
+++ b/packages/core/components/FileDetails/MetadataList/Value.tsx
@@ -30,7 +30,7 @@ export default function Value(props: Props) {
         // Override long value truncation for open file links, since the link is rendered separately.
         isLongValue = false;
         content = (
-            <a className={styles.link} href={props.value} rel="noreferrer" target="_blank">
+            <a className={styles.link} href={props.value} rel="noopener noreferrer" target="_blank">
                 View link
             </a>
         );


### PR DESCRIPTION
In the right-hand side metadata list, long text values are given a content length toggle. However, links are always shown as a short "View link" text meaning we want to never render a link as a long text value with a toggle (which is what is currently happening).

Before
<img width="426" height="103" alt="Screenshot 2026-06-30 at 10 09 26 AM" src="https://github.com/user-attachments/assets/a24d6ba1-0d3e-4fe7-988d-695e337e766a" />

After
<img width="419" height="82" alt="Screenshot 2026-06-30 at 10 11 50 AM" src="https://github.com/user-attachments/assets/2cf15545-1af3-401e-99ca-d2f9604c903e" />
