### PR TITLE
Center align text; make icon heavier

### DIFF
--- a/packages/core/components/QueryPart/QueryPartRow.module.css
+++ b/packages/core/components/QueryPart/QueryPartRow.module.css
@@ -14,6 +14,7 @@
     align-items: center;
     display: flex;
     font-size: smaller;
+    font-weight: 600;
     padding-right: 8px;
 }
 
@@ -61,16 +62,15 @@
     color: var(--highlight-text-color);
 }
 
-.row-title > i {
-    font-weight: 600;
-}
-
-.row-title > div {
+.row-tooltip {
+    align-items: center;
+    display: flex;
     flex: 1 1 0;
     min-width: 0;
+    padding-bottom: 1px;
 }
 
-.row-title > p, .row-title > div > p {
+.title-line {
     font-size: var(--s-paragraph-size);
     margin: 0;
     display: flex;
@@ -113,7 +113,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    height: 100%;
 }
 
 /* Nested leaf last-resort truncation happens from the START ("…umn"), never the end. */

--- a/packages/core/components/QueryPart/QueryPartRow.tsx
+++ b/packages/core/components/QueryPart/QueryPartRow.tsx
@@ -58,7 +58,10 @@ export default function QueryGroupRow(props: Props) {
                 [styles.grabbable]: !props.item.disabled,
                 [styles.interactive]: isInteractive,
             })}
-            style={{ marginLeft, maxWidth: `calc(100% - ${marginLeft + 8}px)` }}
+            style={{
+                marginLeft,
+                maxWidth: marginLeft ? `calc(100% - ${marginLeft + 8}px)` : undefined,
+            }}
         >
             <div
                 ref={rowTitleRef}
@@ -73,7 +76,7 @@ export default function QueryGroupRow(props: Props) {
                         <Icon className={styles.icon} iconName={props.item.titleIconName} />
                     </span>
                 )}
-                <Tooltip content={tooltip}>
+                <Tooltip content={tooltip} hostClassName={styles.rowTooltip}>
                     <p className={styles.titleLine}>
                         {hasPrefix && prefix !== null && (
                             <span className={styles.titlePrefix}>{prefix}</span>


### PR DESCRIPTION
While fixing some of the styling in the tooltip and the overflow I didn't notice I caused the text to be slightly off center and reduced the icon weight. This should fix that - I used the specific classes to avoid the brittle CSS selector route from before to help try to avoid this happening again.

### What is on production
<img width="692" height="404" alt="Screenshot 2026-06-30 at 10 51 15 AM" src="https://github.com/user-attachments/assets/82cb3739-9493-4cd8-8612-439393550257" />

### What is on staging
<img width="601" height="362" alt="Screenshot 2026-06-30 at 10 51 12 AM" src="https://github.com/user-attachments/assets/36720913-c49f-4225-8e71-5d8f117e8146" />

### What this changeset would cause (the ideal)
<img width="669" height="445" alt="Screenshot 2026-06-30 at 10 52 10 AM" src="https://github.com/user-attachments/assets/f0383a32-c2a9-4c9f-8870-2b1cfd943302" />
