### PR TITLE
Auto detect webpage-like files as needing browser viewer

### DIFF
--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -265,12 +265,19 @@ function getSupportedApps(
             // If the content of the file linked appears to be a webpage
             // then offer Browser as the only option
             if (fileContentType === "webpage") {
-                const hostname = new URL(fileDetails.path).hostname;
+                let hostname: string | undefined;
+                try {
+                    hostname = new URL(fileDetails.path).hostname;
+                } catch (_e) {
+                    // Somehow, not a valid URL; skip formatting hostname
+                }
                 return [
                     {
                         ...apps.browser,
-                        text: `Browser (${hostname})`,
-                        title: `Open ${hostname} in the current browser in a new tab`,
+                        text: hostname ? `Browser (${hostname})` : "Browser",
+                        title: hostname
+                            ? `Open ${hostname} in the current browser in a new tab`
+                            : "Open in the current browser in a new tab",
                     },
                 ];
             }
@@ -532,7 +539,9 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
                     `Failed to get size or type of ${path}. Unable to determine most suitable viewer.`
                 );
             });
-    }, [path, size, s3StorageService, setFileContentType, setIsSmallFile]);
+        // We only want this to re-run when the path changes, not when the size changes
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [path, s3StorageService]);
 
     // Try to quickly check if user is on MacOS or not
     React.useEffect(() => {

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -527,7 +527,7 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
         // Trust the users size if it is defined, otherwise get the size from the cloud object info.
         // Also get the content type of the file, which may be used to determine the most suitable viewer.
         s3StorageService
-            .getCloudObjectInfo(path, true)
+            .getCloudObjectInfo(path)
             .then((info) => {
                 // Consider a "small" file to be <= 100Mb
                 if (size === undefined && info.size !== undefined)

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -213,6 +213,7 @@ type VolEMessage = {
 function getSupportedApps(
     apps: Apps,
     isSmallFile: boolean,
+    fileContentType: "webpage" | "image" | "multi-object" | "unknown",
     fileDetails?: FileDetail
 ): IContextualMenuItem[] {
     if (!fileDetails) {
@@ -259,6 +260,19 @@ function getSupportedApps(
                 }
             } catch (_e) {
                 // Not a valid URL; skip IDR check
+            }
+
+            // If the content of the file linked appears to be a webpage
+            // then offer Browser as the only option
+            if (fileContentType === "webpage") {
+                const hostname = new URL(fileDetails.path).hostname;
+                return [
+                    {
+                        ...apps.browser,
+                        text: `Browser (${hostname})`,
+                        title: `Open ${hostname} in the current browser in a new tab`,
+                    },
+                ];
             }
 
             return isLikelyLocalFile
@@ -359,6 +373,9 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     );
     const [isSmallFile, setIsSmallFile] = React.useState(false);
     const [isMacOS, setIsMacOS] = React.useState(false);
+    const [fileContentType, setFileContentType] = React.useState<
+        "webpage" | "image" | "multi-object" | "unknown"
+    >("unknown");
 
     const openInCfe = useOpenInCfe(fileSelection, annotationNames, fileService);
 
@@ -494,25 +511,28 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
 
     // Determine is the file is small or not asynchronously
     React.useEffect(() => {
-        async function determineFileSize() {
-            if (path) {
-                let fileSize = size;
-                if (!fileSize) {
-                    try {
-                        fileSize = await s3StorageService.getCloudObjectSize(path);
-                    } catch (_err) {
-                        console.debug(
-                            `Failed to get size of ${path}. Unable to determine if Vol-E is suitable viewer.`
-                        );
-                    }
-                }
+        if (!path) return;
 
+        // Consider a "small" file to be <= 100Mb
+        if (size !== undefined) setIsSmallFile(size <= 100 * ONE_MEGABYTE);
+
+        // Grab object info.
+        // Trust the users size if it is defined, otherwise get the size from the cloud object info.
+        // Also get the content type of the file, which may be used to determine the most suitable viewer.
+        s3StorageService
+            .getCloudObjectInfo(path, true)
+            .then((info) => {
                 // Consider a "small" file to be <= 100Mb
-                setIsSmallFile(!!fileSize && fileSize <= 100 * ONE_MEGABYTE);
-            }
-        }
-        determineFileSize();
-    }, [path, size, s3StorageService, setIsSmallFile]);
+                if (size === undefined && info.size !== undefined)
+                    setIsSmallFile(info.size <= 100 * ONE_MEGABYTE);
+                setFileContentType(info.type);
+            })
+            .catch((_err) => {
+                console.debug(
+                    `Failed to get size or type of ${path}. Unable to determine most suitable viewer.`
+                );
+            });
+    }, [path, size, s3StorageService, setFileContentType, setIsSmallFile]);
 
     // Try to quickly check if user is on MacOS or not
     React.useEffect(() => {
@@ -537,7 +557,10 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
         getIsMacOS().then(setIsMacOS);
     }, []);
 
-    const supportedApps = [...getSupportedApps(apps, isSmallFile, fileDetails), ...userApps]
+    const supportedApps = [
+        ...getSupportedApps(apps, isSmallFile, fileContentType, fileDetails),
+        ...userApps,
+    ]
         // TODO: This is a placeholder until FIJI finishes rolling out FIJI support across all
         // platforms
         .filter((app) => isMacOS || app.key !== AppKeys.FIJI);

--- a/packages/core/hooks/useOpenWithMenuItems/index.tsx
+++ b/packages/core/hooks/useOpenWithMenuItems/index.tsx
@@ -520,8 +520,10 @@ export default (fileDetails?: FileDetail, filters?: FileFilter[]): IContextualMe
     React.useEffect(() => {
         if (!path) return;
 
+        // Reset state between file changes
+        setFileContentType("unknown");
         // Consider a "small" file to be <= 100Mb
-        if (size !== undefined) setIsSmallFile(size <= 100 * ONE_MEGABYTE);
+        setIsSmallFile(size === undefined ? false : size <= 100 * ONE_MEGABYTE);
 
         // Grab object info.
         // Trust the users size if it is defined, otherwise get the size from the cloud object info.

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -288,7 +288,7 @@ export default class DatabaseFileService implements FileService {
                 grouped.set(head, { isArray: headIsArray, subPaths: [] });
             }
             if (tailSegments.length > 0) {
-                grouped.get(head)!.subPaths.push({ segments: tailSegments, isArray: tailIsArray });
+                grouped.get(head)?.subPaths.push({ segments: tailSegments, isArray: tailIsArray });
             }
         }
 

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -79,12 +79,19 @@ export default class S3StorageService extends HttpServiceBase {
      * Returns type = "image" if the URL points to an image (e.g. PNG, JPEG)
      * Returns type = "unknown" if the URL points to an unknown type of file
      * Returns size = undefined if unable to determine size
+     *
+     * Throws an error if BFF seemingly should be able to determine size or type but fails
+     * to do so.
      */
     public async getCloudObjectInfo(url: string, forceTypeDetection = false): Promise<HttpInfo> {
         if (isMultiObjectFile(url)) {
             const cloudDirInfo = await this.getCloudDirectoryInfo(url);
             const { size } = cloudDirInfo || {};
             return { type: "multi-object", size };
+        }
+        // Avoid trying to parse non-http URLs or non-simple S3 URLs
+        if (!url.startsWith("http") || !url.includes("amazonaws.com")) {
+            return { type: "unknown", size: undefined };
         }
 
         return this.getHttpObjectSize(url, forceTypeDetection);
@@ -183,9 +190,10 @@ export default class S3StorageService extends HttpServiceBase {
     }
 
     /**
-     * Attempt to retrieve file size from an http object using a HEAD request.
+     * Attempt to retrieve object content type and size from an http object using a HEAD request.
+     * Will fall back to a GET request if the HEAD request fails and forceTypeDetection is true.
      *
-     * Returns bytes (octet)
+     * Returns size in bytes (octet) and type as one of "webpage", "image", or "unknown"
      */
     private async getHttpObjectSize(url: string, forceTypeDetection: boolean): Promise<HttpInfo> {
         let response: AxiosResponse;

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -84,7 +84,7 @@ export default class S3StorageService extends HttpServiceBase {
      * Throws an error if BFF seemingly should be able to determine size or type but fails
      * to do so.
      */
-    public async getCloudObjectInfo(url: string, forceTypeDetection = false): Promise<HttpInfo> {
+    public async getCloudObjectInfo(url: string): Promise<HttpInfo> {
         if (isMultiObjectFile(url)) {
             const cloudDirInfo = await this.getCloudDirectoryInfo(url);
             const { size } = cloudDirInfo || {};
@@ -95,7 +95,7 @@ export default class S3StorageService extends HttpServiceBase {
             return { type: "unknown", size: undefined };
         }
 
-        return this.getHttpObjectSize(url, forceTypeDetection);
+        return this.getHttpObjectSize(url);
     }
 
     /**
@@ -192,39 +192,16 @@ export default class S3StorageService extends HttpServiceBase {
 
     /**
      * Attempt to retrieve object content type and size from an http object using a HEAD request.
-     * Will fall back to a GET request if the HEAD request fails and forceTypeDetection is true.
      *
      * Returns size in bytes (octet) and type as one of "webpage", "image", or "unknown"
      */
-    private async getHttpObjectSize(url: string, forceTypeDetection: boolean): Promise<HttpInfo> {
+    private async getHttpObjectSize(url: string): Promise<HttpInfo> {
         let response: AxiosResponse;
         try {
             response = await axios.head(url);
         } catch (err) {
-            console.warn(`Failed to get HEAD url. Will try via GET request.`);
-            if (!forceTypeDetection) {
-                console.error(
-                    `Failed to get HEAD url. Unable to get content length or type: ${err}`
-                );
-                throw err;
-            }
-
-            // Some servers (e.g. S3) do not support HEAD requests, so try a GET request instead
-            // Note: this can be slow for large files so only do this if forceTypeDetection is true
-            //       and the HEAD request already failed
-            try {
-                response = await axios.get(url, {
-                    responseType: "arraybuffer", // prevents parsing large HTML/images unnecessarily
-                    maxRedirects: 5,
-                    timeout: 3_000,
-                    validateStatus: () => true, // don’t throw on non-2xx
-                });
-            } catch (err) {
-                console.error(
-                    `Failed to get HEAD or GET url. Unable to get content length or type: ${err}`
-                );
-                throw err;
-            }
+            console.error(`Failed to get HEAD url. Unable to get content length or type: ${err}`);
+            throw err;
         }
 
         const contentLength = response.headers["content-length"];

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -1,5 +1,6 @@
 import { parseS3Url, isS3Url } from "amazon-s3-url";
 import axios, { AxiosResponse } from "axios";
+import { isNil } from "lodash";
 
 import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
 
@@ -72,7 +73,7 @@ export default class S3StorageService extends HttpServiceBase {
     }
 
     /**
-     * Return the interpretted type and size of the cloud object.
+     * Return the interpreted type and size of the cloud object.
      *
      * Returns type = "multi-object" if the URL points to a multi-object file like Zarr
      * Returns type = "webpage" if the URL points to a webpage (e.g. HTML)
@@ -226,7 +227,9 @@ export default class S3StorageService extends HttpServiceBase {
             }
         }
 
-        const size = parseInt(response.headers["content-length"] || "0", 10);
+        const contentLength = response.headers["content-length"];
+        const parsedLength = isNil(contentLength) ? undefined : parseInt(contentLength, 10);
+        const size = parsedLength && isNaN(parsedLength) ? undefined : parsedLength;
         const contentType = response.headers["content-type"]?.toLowerCase() ?? "";
         if (contentType.startsWith("image/")) return { type: "image", size };
         if (contentType.includes("text/html")) return { type: "webpage", size };

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -1,7 +1,12 @@
 import { parseS3Url, isS3Url } from "amazon-s3-url";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 
 import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
+
+interface HttpInfo {
+    type: "webpage" | "image" | "multi-object" | "unknown";
+    size?: number;
+}
 
 /**
  * Return true if the URL seems to point to a multi object file like Zarr
@@ -67,18 +72,22 @@ export default class S3StorageService extends HttpServiceBase {
     }
 
     /**
-     * Get file size for a file on the cloud
-     * Returns undefined if unable to determine size
+     * Return the interpretted type and size of the cloud object.
+     *
+     * Returns type = "multi-object" if the URL points to a multi-object file like Zarr
+     * Returns type = "webpage" if the URL points to a webpage (e.g. HTML)
+     * Returns type = "image" if the URL points to an image (e.g. PNG, JPEG)
+     * Returns type = "unknown" if the URL points to an unknown type of file
+     * Returns size = undefined if unable to determine size
      */
-    public async getCloudObjectSize(url: string): Promise<number | undefined> {
+    public async getCloudObjectInfo(url: string, forceTypeDetection = false): Promise<HttpInfo> {
         if (isMultiObjectFile(url)) {
             const cloudDirInfo = await this.getCloudDirectoryInfo(url);
-            if (!cloudDirInfo) return;
-            return cloudDirInfo.size;
-        } else if (url.includes("amazonaws.com")) {
-            // Handle individual S3 files if they are simple
-            return this.getHttpObjectSize(url);
+            const { size } = cloudDirInfo || {};
+            return { type: "multi-object", size };
         }
+
+        return this.getHttpObjectSize(url, forceTypeDetection);
     }
 
     /**
@@ -178,14 +187,42 @@ export default class S3StorageService extends HttpServiceBase {
      *
      * Returns bytes (octet)
      */
-    private async getHttpObjectSize(url: string): Promise<number> {
+    private async getHttpObjectSize(url: string, forceTypeDetection: boolean): Promise<HttpInfo> {
+        let response: AxiosResponse;
         try {
-            const response = await axios.head(url);
-            return parseInt(response.headers["content-length"] || "0", 10);
+            response = await axios.head(url);
         } catch (err) {
-            console.error(`Failed to get file size (content-length): ${err}`);
-            throw err;
+            console.warn(`Failed to get HEAD url. Will try via GET request.`);
+            if (!forceTypeDetection) {
+                console.error(
+                    `Failed to get HEAD url. Unable to get content length or type: ${err}`
+                );
+                throw err;
+            }
+
+            // Some servers (e.g. S3) do not support HEAD requests, so try a GET request instead
+            // Note: this can be slow for large files so only do this if forceTypeDetection is true
+            //       and the HEAD request already failed
+            try {
+                response = await axios.get(url, {
+                    responseType: "arraybuffer", // prevents parsing large HTML/images unnecessarily
+                    maxRedirects: 5,
+                    timeout: 3_000,
+                    validateStatus: () => true, // don’t throw on non-2xx
+                });
+            } catch (err) {
+                console.error(
+                    `Failed to get HEAD or GET url. Unable to get content length or type: ${err}`
+                );
+                throw err;
+            }
         }
+
+        const size = parseInt(response.headers["content-length"] || "0", 10);
+        const contentType = response.headers["content-type"]?.toLowerCase() ?? "";
+        if (contentType.startsWith("image/")) return { type: "image", size };
+        if (contentType.includes("text/html")) return { type: "webpage", size };
+        return { type: "unknown", size };
     }
 
     /**

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -312,7 +312,8 @@ const downloadFilesLogic = createLogic({
         await Promise.all(
             filesToDownload.map(async (file) => {
                 if (!file.size) {
-                    file.size = await s3StorageService.getCloudObjectSize(file.path);
+                    const { size } = await s3StorageService.getCloudObjectInfo(file.path);
+                    file.size = size;
                     if (file.size === undefined) someFilesHaveUnknownSize = true;
                 }
             })


### PR DESCRIPTION
## Context
Some users want to have their rows represent webpages or like for [IDR](https://bff.allencell.org/app?c=File+Name%3A9%2CAge%3A15%2CChannels%3A45%2CClinical+Information%3A19%2Cdata_source%3A11%2Cdescription%3A11&source=%7B%22uri%22%3A%22https%3A%2F%2Fidr.openmicroscopy.org%2Fsearchengine%2Fapi%2Fv1%2Fresources%2Fcontainer_data%2F%3Fcontainer_name%3Didr0026-weigelin-immunotherapy%2FexperimentA%26container_type%3Dproject%26file_type%3Dparquet%22%2C%22type%22%3A%22parquet%22%2C%22name%22%3A%22idr0026-weigelin-immunotherapy%2FexperimentA.parquet%22%7D) want to supply the file in the context of their own viewer. 

## Changes
The Column Descriptions feature (where you tell BFF which columns represent links) handles this more explicitly. However, it seems like a nice to have to have BFF auto-detect when a linked "File Path" is a webpage - when it is able to do so it will supply "Browser (<hostname>)" as the "Open with" option. For example, if we remove the IDR specialized handling it would render "Browser (idr.openmicroscopy.org)" as the option.

## Testing
This feature only works if BFF is able to reach out to the web page via a HEAD (ideal) or GET request which requires CORS to be enabled for BFF on the webpage.
