### PR TITLE
Omit unexpected keys in FmsFile from detail

### DIFF
--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -90,6 +90,16 @@ export interface FmsFile {
     uploaded?: string;
     thumbnail?: string;
 }
+// Keys of fields that are expected to be present in the FMS file detail response. Any other keys will be ignored.
+const KEYS_IN_FMS_FILE = new Set([
+    "annotations",
+    "file_id",
+    "file_name",
+    "file_path",
+    "file_size",
+    "uploaded",
+    "thumbnail",
+]);
 
 /**
  * Facade for a FileDetailResponse.
@@ -149,7 +159,7 @@ export default class FileDetail {
             // to annotations-like structure so that we can treat all metadata as
             // annotations in the frontend and avoid having some weird special cases
             .flatMap(([key, value]) => {
-                if (isNil(value)) return [];
+                if (isNil(value) || !KEYS_IN_FMS_FILE.has(key)) return [];
                 if (key === "annotations") return value as FmsFileAnnotation[];
 
                 // Skip any fields that have unexpected types to avoid runtime errors.


### PR DESCRIPTION
## Context
The below error appears when loading the FMS data source. This is due to a duplicate, unnecessary key "uploadedBy" at the top level of the file document in the FMS MongoDB.
<img width="801" height="286" alt="Screenshot 2026-07-02 at 3 20 10 PM" src="https://github.com/user-attachments/assets/316630f9-b20d-4b61-8889-7020671e8e1f" />


## Changes
This adds a check to have any unexpected keys found on the object given to the `FileDetail` to get omitted.

