### PR TITLE
Feature/add prov to aics fms

### DIFF
--- a/packages/core/components/NetworkGraph/Edges/DefaultEdge.tsx
+++ b/packages/core/components/NetworkGraph/Edges/DefaultEdge.tsx
@@ -61,10 +61,13 @@ const DefaultEdge: FC<EdgeProps<Edge<AnnotationEdge>>> = ({
                         provOriginId: undefined,
                     });
                 } else {
+                    const filters = [data.child, data.parent]
+                        .filter((value) => !!value && typeof value === "string")
+                        .map((value) => new IncludeFilter(value as string));
                     newUrl = SearchParams.encode({
                         ...currentQuery,
                         hierarchy: [],
-                        filters: [new IncludeFilter(data.parent), new IncludeFilter(data.child)],
+                        filters: filters,
                         provOriginId: undefined,
                     });
                 }

--- a/packages/core/components/NetworkGraph/index.tsx
+++ b/packages/core/components/NetworkGraph/index.tsx
@@ -7,8 +7,8 @@ import {
     useEdgesState,
     Controls,
     useReactFlow,
-    useNodesInitialized,
     ReactFlowProvider,
+    FitViewOptions,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import classNames from "classnames";
@@ -55,8 +55,7 @@ function NetworkGraph(props: NetworkGraphProps) {
     const provenanceSource = useSelector(selection.selectors.getSelectedSourceProvenance);
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<AnnotationEdge>>([]);
     const [nodes, setNodes, onNodesChange] = useNodesState<FileNodeType | MetadataNodeType>([]);
-    const { fitView, setCenter, getZoom } = useReactFlow();
-    const nodesInitialized = useNodesInitialized();
+    const { fitView, getZoom } = useReactFlow();
 
     // Unfortunately we have to have some notion of state at a high level for control from the components
     // and at the dagre level for when the user does a drag action causing this duplication of efforts
@@ -65,22 +64,14 @@ function NetworkGraph(props: NetworkGraphProps) {
         setNodes(graph.nodes);
     }, [graph, setEdges, setNodes, refreshKey]);
 
-    // Once the graph has finished building, pan so the origin (selected) node
-    // is centered in the viewport. The origin is the sole node flagged as
-    // selected (see Graph.originate -> createFileNode(origin, true)).
-    const lastCenteredRefreshKeyRef = React.useRef<string | undefined>(undefined);
-    React.useEffect(() => {
-        if (isLoading || !nodesInitialized) return;
-        if (lastCenteredRefreshKeyRef.current === refreshKey) return;
-
-        const originNode = nodes.find((node) => node.data.isSelected);
-        if (!originNode) return;
-
-        lastCenteredRefreshKeyRef.current = refreshKey;
-        const centerX = originNode.position.x + (originNode.width ?? 0) / 2;
-        const centerY = originNode.position.y + (originNode.height ?? 0) / 2;
-        setCenter(centerX, centerY, { zoom: getZoom(), duration: 800 });
-    }, [isLoading, nodesInitialized, nodes, refreshKey, setCenter, getZoom]);
+    const originNodeId = React.useMemo(() => nodes.find((node) => node.data.isSelected)?.id, [
+        nodes,
+    ]);
+    const fitViewOptions: FitViewOptions<FileNodeType | MetadataNodeType> = React.useMemo(() => {
+        if (!originNodeId) return {};
+        // Center the origin node in the viewport and set the zoom level to fit the graph
+        return { nodes: [{ id: originNodeId }], duration: 800, maxZoom: getZoom() };
+    }, [originNodeId, getZoom]);
 
     // The option to open this graph shouldn't even appear when a
     // source isn't available so this shouldn't ever happen
@@ -98,7 +89,7 @@ function NetworkGraph(props: NetworkGraphProps) {
 
     const onClickReset = () => {
         graph.resetLayout(); // return to default layout if any
-        fitView(); // reset zoom
+        fitView(fitViewOptions); // reset zoom and center on origin
         dispatch(interaction.actions.refreshGraph());
     };
 
@@ -112,6 +103,8 @@ function NetworkGraph(props: NetworkGraphProps) {
                 onClick={onClickReset}
             />
             <ReactFlow
+                fitView
+                fitViewOptions={fitViewOptions}
                 onlyRenderVisibleElements
                 className={styles.graph}
                 edgesFocusable={false}

--- a/packages/core/components/NetworkGraph/index.tsx
+++ b/packages/core/components/NetworkGraph/index.tsx
@@ -66,16 +66,19 @@ function NetworkGraph(props: NetworkGraphProps) {
     // Once the graph has finished building, pan so the origin (selected) node
     // is centered in the viewport. The origin is the sole node flagged as
     // selected (see Graph.originate -> createFileNode(origin, true)).
+    const lastCenteredRefreshKeyRef = React.useRef<number | undefined>(undefined);
     React.useEffect(() => {
         if (isLoading) return;
+        if (lastCenteredRefreshKeyRef.current === refreshKey) return;
 
         const originNode = nodes.find((node) => node.data.isSelected);
         if (!originNode) return;
 
+        lastCenteredRefreshKeyRef.current = refreshKey;
         const centerX = originNode.position.x + (originNode.width ?? 0) / 2;
         const centerY = originNode.position.y + (originNode.height ?? 0) / 2;
         setCenter(centerX, centerY, { zoom: getZoom(), duration: 800 });
-    }, [isLoading, nodes, setCenter, getZoom]);
+    }, [isLoading, nodes, refreshKey, setCenter, getZoom]);
 
     // The option to open this graph shouldn't even appear when a
     // source isn't available so this shouldn't ever happen

--- a/packages/core/components/NetworkGraph/index.tsx
+++ b/packages/core/components/NetworkGraph/index.tsx
@@ -54,7 +54,7 @@ function NetworkGraph(props: NetworkGraphProps) {
     const provenanceSource = useSelector(selection.selectors.getSelectedSourceProvenance);
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<AnnotationEdge>>([]);
     const [nodes, setNodes, onNodesChange] = useNodesState<FileNodeType | MetadataNodeType>([]);
-    const { fitView } = useReactFlow();
+    const { fitView, setCenter, getZoom } = useReactFlow();
 
     // Unfortunately we have to have some notion of state at a high level for control from the components
     // and at the dagre level for when the user does a drag action causing this duplication of efforts
@@ -62,6 +62,20 @@ function NetworkGraph(props: NetworkGraphProps) {
         setEdges(graph.edges);
         setNodes(graph.nodes);
     }, [graph, setEdges, setNodes, refreshKey]);
+
+    // Once the graph has finished building, pan so the origin (selected) node
+    // is centered in the viewport. The origin is the sole node flagged as
+    // selected (see Graph.originate -> createFileNode(origin, true)).
+    React.useEffect(() => {
+        if (isLoading) return;
+
+        const originNode = nodes.find((node) => node.data.isSelected);
+        if (!originNode) return;
+
+        const centerX = originNode.position.x + (originNode.width ?? 0) / 2;
+        const centerY = originNode.position.y + (originNode.height ?? 0) / 2;
+        setCenter(centerX, centerY, { zoom: getZoom(), duration: 800 });
+    }, [isLoading, nodes, setCenter, getZoom]);
 
     // The option to open this graph shouldn't even appear when a
     // source isn't available so this shouldn't ever happen

--- a/packages/core/components/NetworkGraph/index.tsx
+++ b/packages/core/components/NetworkGraph/index.tsx
@@ -66,7 +66,7 @@ function NetworkGraph(props: NetworkGraphProps) {
     // Once the graph has finished building, pan so the origin (selected) node
     // is centered in the viewport. The origin is the sole node flagged as
     // selected (see Graph.originate -> createFileNode(origin, true)).
-    const lastCenteredRefreshKeyRef = React.useRef<number | undefined>(undefined);
+    const lastCenteredRefreshKeyRef = React.useRef<string | undefined>(undefined);
     React.useEffect(() => {
         if (isLoading) return;
         if (lastCenteredRefreshKeyRef.current === refreshKey) return;

--- a/packages/core/components/NetworkGraph/index.tsx
+++ b/packages/core/components/NetworkGraph/index.tsx
@@ -7,6 +7,7 @@ import {
     useEdgesState,
     Controls,
     useReactFlow,
+    useNodesInitialized,
     ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -55,6 +56,7 @@ function NetworkGraph(props: NetworkGraphProps) {
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<AnnotationEdge>>([]);
     const [nodes, setNodes, onNodesChange] = useNodesState<FileNodeType | MetadataNodeType>([]);
     const { fitView, setCenter, getZoom } = useReactFlow();
+    const nodesInitialized = useNodesInitialized();
 
     // Unfortunately we have to have some notion of state at a high level for control from the components
     // and at the dagre level for when the user does a drag action causing this duplication of efforts
@@ -68,7 +70,7 @@ function NetworkGraph(props: NetworkGraphProps) {
     // selected (see Graph.originate -> createFileNode(origin, true)).
     const lastCenteredRefreshKeyRef = React.useRef<string | undefined>(undefined);
     React.useEffect(() => {
-        if (isLoading) return;
+        if (isLoading || !nodesInitialized) return;
         if (lastCenteredRefreshKeyRef.current === refreshKey) return;
 
         const originNode = nodes.find((node) => node.data.isSelected);
@@ -78,7 +80,7 @@ function NetworkGraph(props: NetworkGraphProps) {
         const centerX = originNode.position.x + (originNode.width ?? 0) / 2;
         const centerY = originNode.position.y + (originNode.height ?? 0) / 2;
         setCenter(centerX, centerY, { zoom: getZoom(), duration: 800 });
-    }, [isLoading, nodes, refreshKey, setCenter, getZoom]);
+    }, [isLoading, nodesInitialized, nodes, refreshKey, setCenter, getZoom]);
 
     // The option to open this graph shouldn't even appear when a
     // source isn't available so this shouldn't ever happen
@@ -110,7 +112,6 @@ function NetworkGraph(props: NetworkGraphProps) {
                 onClick={onClickReset}
             />
             <ReactFlow
-                fitView
                 onlyRenderVisibleElements
                 className={styles.graph}
                 edgesFocusable={false}

--- a/packages/core/entity/Graph/index.ts
+++ b/packages/core/entity/Graph/index.ts
@@ -465,6 +465,22 @@ export default class Graph {
                     // add an edge
                     parentNodes.forEach((parentNode) => {
                         childNodes.forEach((childNode) => {
+                            // Ensure both endpoints exist in the graph with their
+                            // real labels before connecting them. Recursive
+                            // expansion above may have skipped adding a node once
+                            // the node affordance limit was reached (especially
+                            // under the concurrent edge-definition traversal). If
+                            // we called setEdge for a missing endpoint, graphlib
+                            // would auto-create a labelless placeholder node, which
+                            // later breaks the `nodes` getter. Adding the node
+                            // objects we already hold here keeps the graph
+                            // connected without introducing phantom nodes.
+                            if (!this.graph.hasNode(parentNode.id)) {
+                                this.graph.setNode(parentNode.id, parentNode);
+                            }
+                            if (!this.graph.hasNode(childNode.id)) {
+                                this.graph.setNode(childNode.id, childNode);
+                            }
                             this.graph.setEdge(parentNode.id, childNode.id, annotationEdge);
                         });
                     });
@@ -511,13 +527,13 @@ export default class Graph {
                 const node = this.graph.node(value); // the value should be a file path
                 if (node) return node;
                 try {
-                    const file = await this.getFileBy("File Path", [value]);
+                    const file = await this.getFileByProvenanceId(value);
                     if (file) {
                         return createFileNode(file);
                     }
                 } catch {
                     // Backup while moving between provenance versions: Try looking by "File ID", this should be removed in the future
-                    const fileById = await this.getFileBy("File ID", [value]);
+                    const fileById = await this.getFileByProvenanceId(value);
                     if (fileById) return createFileNode(fileById);
                 }
                 throw new Error(`Unable to find file with value ${value}`);
@@ -577,11 +593,10 @@ export default class Graph {
     }
 
     /**
-     * Get a single file that matches a column/value pair
+     * Get a single file that matches a provenance ID
      */
-    private async getFileBy(
-        column: string,
-        value: (string | number | boolean)[]
+    private async getFileByProvenanceId(
+        value: string | number | boolean
     ): Promise<FileDetail | undefined> {
         let files;
         try {
@@ -590,20 +605,20 @@ export default class Graph {
                 limit: 2, // We only want one result, so if there are >=2 it's not a unique identifier
                 fileSet: new FileSet({
                     fileService: this.fileService,
-                    filters: [new FileFilter(column, value)],
+                    filters: [new FileFilter(this.fileService.provenanceIdColumn, [value])],
                 }),
             });
         } catch (err) {
             console.error(
-                `Failed to find file with value ${column} for annotation ${value}. Error: ${
-                    (err as Error).message
-                }`
+                `Failed to find file at column ${
+                    this.fileService.provenanceIdColumn
+                } with value ${value}. Error: ${(err as Error).message}`
             );
             return undefined;
         }
         if (files.length !== 1) {
             throw new Error(
-                `Failed to fetch 1 file with value ${column} for annotation ${value}. Found ${files.length} instead.`
+                `Failed to fetch 1 file at column ${this.fileService.provenanceIdColumn} with value ${value}. Found ${files.length} instead.`
             );
         }
         return files[0];

--- a/packages/core/entity/Graph/index.ts
+++ b/packages/core/entity/Graph/index.ts
@@ -526,16 +526,8 @@ export default class Graph {
                 // Avoid re-requesting the file when possible
                 const node = this.graph.node(value); // the value should be a file path
                 if (node) return node;
-                try {
-                    const file = await this.getFileByProvenanceId(value);
-                    if (file) {
-                        return createFileNode(file);
-                    }
-                } catch {
-                    // Backup while moving between provenance versions: Try looking by "File ID", this should be removed in the future
-                    const fileById = await this.getFileByProvenanceId(value);
-                    if (fileById) return createFileNode(fileById);
-                }
+                const file = await this.getFileByProvenanceId(value);
+                if (file) return createFileNode(file);
                 throw new Error(`Unable to find file with value ${value}`);
             })
         );

--- a/packages/core/entity/Graph/index.ts
+++ b/packages/core/entity/Graph/index.ts
@@ -590,30 +590,30 @@ export default class Graph {
     private async getFileByProvenanceId(
         value: string | number | boolean
     ): Promise<FileDetail | undefined> {
-        let files;
-        try {
-            files = await this.fileService.getFiles({
-                from: 0,
-                limit: 2, // We only want one result, so if there are >=2 it's not a unique identifier
-                fileSet: new FileSet({
-                    fileService: this.fileService,
-                    filters: [new FileFilter(this.fileService.provenanceIdColumn, [value])],
-                }),
-            });
-        } catch (err) {
-            console.error(
-                `Failed to find file at column ${
-                    this.fileService.provenanceIdColumn
-                } with value ${value}. Error: ${(err as Error).message}`
-            );
-            return undefined;
+        let files: FileDetail[] = [];
+        for (const column of this.fileService.provenanceIdColumns) {
+            try {
+                files = await this.fileService.getFiles({
+                    from: 0,
+                    limit: 2, // We only want one result, so if there are >=2 it's not a unique identifier
+                    fileSet: new FileSet({
+                        fileService: this.fileService,
+                        filters: [new FileFilter(column, [value])],
+                    }),
+                });
+                if (files.length === 1) return files[0];
+            } catch (err) {
+                console.debug(
+                    `Error in getFileByProvenanceId(${value}) for ${column}. Details: ${
+                        (err as Error).message
+                    }`
+                );
+            }
         }
-        if (files.length !== 1) {
-            throw new Error(
-                `Failed to fetch 1 file at column ${this.fileService.provenanceIdColumn} with value ${value}. Found ${files.length} instead.`
-            );
-        }
-        return files[0];
+        console.error(
+            `Failed to match file by value ${value} on any of the columns ${this.fileService.provenanceIdColumns}.`
+        );
+        return undefined;
     }
 
     /**

--- a/packages/core/entity/Graph/index.ts
+++ b/packages/core/entity/Graph/index.ts
@@ -611,7 +611,7 @@ export default class Graph {
             }
         }
         console.error(
-            `Failed to match file by value ${value} on any of the columns ${this.fileService.provenanceIdColumns}.`
+            `Failed to match file by value ${value} on any of the usual referential columns ${this.fileService.provenanceIdColumns}.`
         );
         return undefined;
     }

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -77,6 +77,12 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     openFolders: [],
     sources: [{ name: AICS_FMS_DATA_SOURCE_NAME }],
     filters: [PAST_YEAR_FILTER],
+    provenanceSource: {
+        name: "Provenance",
+        type: "csv",
+        uri:
+            "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv",
+    },
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -80,8 +80,7 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     provenanceSource: {
         name: "AICS",
         type: "csv",
-        uri:
-            "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv",
+        uri: "https://biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv",
     },
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -78,7 +78,7 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     sources: [{ name: AICS_FMS_DATA_SOURCE_NAME }],
     filters: [PAST_YEAR_FILTER],
     provenanceSource: {
-        name: "Provenance",
+        name: "AICS",
         type: "csv",
         uri:
             "https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv",

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -143,6 +143,7 @@ export default class DatabaseFileService implements FileService {
     private readonly databaseService: DatabaseService;
     private readonly downloadService: FileDownloadService;
     private readonly dataSourceNames: string[];
+    public readonly provenanceIdColumn = "File Path";
 
     private static convertDatabaseRowToFileDetail(row: FileRow, env: Environment): FileDetail {
         const uniqueId = row[HIDDEN_UID_ANNOTATION];

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -143,7 +143,7 @@ export default class DatabaseFileService implements FileService {
     private readonly databaseService: DatabaseService;
     private readonly downloadService: FileDownloadService;
     private readonly dataSourceNames: string[];
-    public readonly provenanceIdColumn = "File Path";
+    public readonly provenanceIdColumns = ["File Path", "File ID"];
 
     private static convertDatabaseRowToFileDetail(row: FileRow, env: Environment): FileDetail {
         const uniqueId = row[HIDDEN_UID_ANNOTATION];

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -289,7 +289,7 @@ export default class DatabaseFileService implements FileService {
                 grouped.set(head, { isArray: headIsArray, subPaths: [] });
             }
             if (tailSegments.length > 0) {
-                grouped.get(head)!.subPaths.push({ segments: tailSegments, isArray: tailIsArray });
+                grouped.get(head)?.subPaths.push({ segments: tailSegments, isArray: tailIsArray });
             }
         }
 

--- a/packages/core/services/FileService/FileServiceNoop.ts
+++ b/packages/core/services/FileService/FileServiceNoop.ts
@@ -3,6 +3,7 @@ import { DownloadResolution, DownloadResult } from "../FileDownloadService";
 import FileDetail from "../../entity/FileDetail";
 
 export default class FileServiceNoop implements FileService {
+    provenanceIdColumn = "";
     public getCountOfMatchingFiles(): Promise<number> {
         return Promise.resolve(0);
     }

--- a/packages/core/services/FileService/FileServiceNoop.ts
+++ b/packages/core/services/FileService/FileServiceNoop.ts
@@ -3,7 +3,7 @@ import { DownloadResolution, DownloadResult } from "../FileDownloadService";
 import FileDetail from "../../entity/FileDetail";
 
 export default class FileServiceNoop implements FileService {
-    public readonly provenanceIdColumn = "";
+    public readonly provenanceIdColumns = [];
     public getCountOfMatchingFiles(): Promise<number> {
         return Promise.resolve(0);
     }

--- a/packages/core/services/FileService/FileServiceNoop.ts
+++ b/packages/core/services/FileService/FileServiceNoop.ts
@@ -3,7 +3,7 @@ import { DownloadResolution, DownloadResult } from "../FileDownloadService";
 import FileDetail from "../../entity/FileDetail";
 
 export default class FileServiceNoop implements FileService {
-    provenanceIdColumn = "";
+    public readonly provenanceIdColumn = "";
     public getCountOfMatchingFiles(): Promise<number> {
         return Promise.resolve(0);
     }

--- a/packages/core/services/FileService/FileServiceNoop.ts
+++ b/packages/core/services/FileService/FileServiceNoop.ts
@@ -3,7 +3,7 @@ import { DownloadResolution, DownloadResult } from "../FileDownloadService";
 import FileDetail from "../../entity/FileDetail";
 
 export default class FileServiceNoop implements FileService {
-    public readonly provenanceIdColumns = [];
+    public readonly provenanceIdColumns = [""];
     public getCountOfMatchingFiles(): Promise<number> {
         return Promise.resolve(0);
     }

--- a/packages/core/services/FileService/HttpFileService/index.ts
+++ b/packages/core/services/FileService/HttpFileService/index.ts
@@ -90,7 +90,7 @@ export default class HttpFileService extends HttpServiceBase implements FileServ
     private static readonly CSV_ENDPOINT_VERSION = "2.0";
     public static readonly BASE_CSV_DOWNLOAD_URL = `file-explorer-service/${HttpFileService.CSV_ENDPOINT_VERSION}/files/selection/manifest`;
     private readonly downloadService: FileDownloadService;
-    public readonly provenanceIdColumn = AnnotationName.FILE_ID;
+    public readonly provenanceIdColumns = [AnnotationName.FILE_ID];
 
     constructor(config: Config = { downloadService: new FileDownloadServiceNoop() }) {
         super(config);

--- a/packages/core/services/FileService/HttpFileService/index.ts
+++ b/packages/core/services/FileService/HttpFileService/index.ts
@@ -90,7 +90,7 @@ export default class HttpFileService extends HttpServiceBase implements FileServ
     private static readonly CSV_ENDPOINT_VERSION = "2.0";
     public static readonly BASE_CSV_DOWNLOAD_URL = `file-explorer-service/${HttpFileService.CSV_ENDPOINT_VERSION}/files/selection/manifest`;
     private readonly downloadService: FileDownloadService;
-    public readonly provenanceIdColumn = "file_id";
+    public readonly provenanceIdColumn = AnnotationName.FILE_ID;
 
     constructor(config: Config = { downloadService: new FileDownloadServiceNoop() }) {
         super(config);

--- a/packages/core/services/FileService/HttpFileService/index.ts
+++ b/packages/core/services/FileService/HttpFileService/index.ts
@@ -90,6 +90,7 @@ export default class HttpFileService extends HttpServiceBase implements FileServ
     private static readonly CSV_ENDPOINT_VERSION = "2.0";
     public static readonly BASE_CSV_DOWNLOAD_URL = `file-explorer-service/${HttpFileService.CSV_ENDPOINT_VERSION}/files/selection/manifest`;
     private readonly downloadService: FileDownloadService;
+    public readonly provenanceIdColumn = "file_id";
 
     constructor(config: Config = { downloadService: new FileDownloadServiceNoop() }) {
         super(config);

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -48,6 +48,7 @@ export interface AnnotationNameToValuesMap {
 }
 
 export default interface FileService {
+    provenanceIdColumn: string;
     fileExplorerServiceBaseUrl?: string;
     download(
         annotations: string[],

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -48,7 +48,9 @@ export interface AnnotationNameToValuesMap {
 }
 
 export default interface FileService {
-    provenanceIdColumn: string;
+    // Ordered list of column names that can be used to uniquely identify a file in the system
+    //  Used for provenance lookups.
+    provenanceIdColumns: string[];
     fileExplorerServiceBaseUrl?: string;
     download(
         annotations: string[],

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -49,7 +49,7 @@ export interface AnnotationNameToValuesMap {
 
 export default interface FileService {
     // Ordered list of column names that can be used to uniquely identify a file in the system
-    //  Used for provenance lookups.
+    // Used for provenance lookups.
     provenanceIdColumns: string[];
     fileExplorerServiceBaseUrl?: string;
     download(


### PR DESCRIPTION
## Context
Provenance is available for use in the application, however for internal users their query defaults to AICS FMS which won't include provenance at the moment.

## Changes
This adds a provenance source to the default AICS FMS query. While doing so I encountered 3 other things:
1) The origin would be out of sight after the graph loads for large graphs, so I added a zoom to `NetworkGraph/index.tsx`
2) "File Path" is not a good column to query AICS FMS by, so this changes the column to search to "File ID" when querying AICS FMS
3) Fixed a bug that happens on large graphs when the node searching ends early. If an edge exists without both nodes existing already the graph would generate a placeholder node that would cause the `graph.node(<node id>)` to bubble up an error (`Graph/index.ts`)

## Testing
[Tested using this provenance source file](https://staging-biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv)

## Example
<img width="931" height="391" alt="Screenshot 2026-07-08 at 10 21 43 AM" src="https://github.com/user-attachments/assets/688073a9-5afd-4cf2-aa7d-c1e9e86dd66e" />

