### PR TITLE
Render .zarr thumbnails in provenance graph

### DIFF
--- a/packages/core/components/NetworkGraph/Nodes/FileNode.tsx
+++ b/packages/core/components/NetworkGraph/Nodes/FileNode.tsx
@@ -9,7 +9,7 @@ import nodeMenuItems from "./nodeMenuItems";
 import { useButtonMenu } from "../../Buttons";
 import FileThumbnail from "../../FileThumbnail";
 import Tooltip from "../../Tooltip";
-import { FileNode as FileNodeType, MetadataNode as MetadataNodeType } from "../../../entity/Graph";
+import { FileNode as FileNodeType } from "../../../entity/Graph";
 import useOpenWithMenuItems from "../../../hooks/useOpenWithMenuItems";
 import useTruncatedString from "../../../hooks/useTruncatedString";
 import { interaction } from "../../../state";
@@ -20,10 +20,12 @@ import styles from "./FileNode.module.css";
  * Custom node element for displaying a File and providing interaction
  * options related to a file
  */
-export default function FileNode(props: NodeProps<FileNodeType | MetadataNodeType>) {
+export default function FileNode(props: NodeProps<FileNodeType>) {
     const file = props.data.file;
     const dispatch = useDispatch();
     const graph = useSelector(interaction.selectors.getGraph);
+
+    const [thumbnail, setThumbnail] = React.useState<string | undefined>(file.thumbnail);
 
     const openWithSubMenuItems = useOpenWithMenuItems(file);
     const buttonMenu = useButtonMenu({
@@ -53,10 +55,14 @@ export default function FileNode(props: NodeProps<FileNodeType | MetadataNodeTyp
         ],
     });
 
-    if (!file) {
-        console.error("This should never happen, a <FileNode /> was rendered without a file");
-        throw new Error(JSON.stringify(props));
-    }
+    // Attempt to get the path to the advanced thumbnail rendering for this file.
+    // Ex. if the file is a .zarr will attempt to create a thumbnail for that.
+    // If it is not available or does not work, will default to the basic thumbnail
+    React.useEffect(() => {
+        file.getPathToThumbnail().then((thumbnail) => {
+            setThumbnail(thumbnail);
+        });
+    }, [file]);
 
     return (
         <Tooltip content={file.name}>
@@ -73,7 +79,7 @@ export default function FileNode(props: NodeProps<FileNodeType | MetadataNodeTyp
                     position={Position.Top}
                 />
                 <div className={styles.contentContainer}>
-                    <FileThumbnail uri={file.thumbnail} height={100} width={100} />
+                    <FileThumbnail uri={thumbnail} height={100} width={100} />
                     <div className={styles.fileNodeLabel}>{useTruncatedString(file.name, 10)}</div>
                 </div>
                 <Handle

--- a/packages/core/components/NetworkGraph/Nodes/MetadataNode.tsx
+++ b/packages/core/components/NetworkGraph/Nodes/MetadataNode.tsx
@@ -7,11 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import nodeMenuItems from "./nodeMenuItems";
 import { useButtonMenu } from "../../Buttons";
 import Tooltip from "../../Tooltip";
-import {
-    FileNode as FileNodeType,
-    MetadataNode as MetadataNodeType,
-    getGridPosition,
-} from "../../../entity/Graph";
+import { MetadataNode as MetadataNodeType, getGridPosition } from "../../../entity/Graph";
 import { interaction } from "../../../state";
 
 import styles from "./MetadataNode.module.css";
@@ -25,7 +21,7 @@ const clipLabel = (label?: string) => {
 
 // This is a proof-of-concept example of a custom node
 // Note that we are able to apply styling to the node, and can include custom buttons as content
-export default function MetadataNode(props: NodeProps<FileNodeType | MetadataNodeType>) {
+export default function MetadataNode(props: NodeProps<MetadataNodeType>) {
     const dispatch = useDispatch();
     const graph = useSelector(interaction.selectors.getGraph);
     const origin = useSelector(interaction.selectors.getOriginForProvenance);


### PR DESCRIPTION
## Context
The provenance/relationship graph BFF can display currently just renders the simple `thumbnail` path rather than the complex one that `FileDetail.getPathToThumbnail` creates based on availalbe metadata and file type.

## Changes
Adds a `.useEffect` for trying to create a complex thumbnail path

Also, narrows the prop type (avoids unnecessary checks for presence of `.file` prop)

<img width="862" height="417" alt="Screenshot 2026-07-09 at 8 32 47 AM" src="https://github.com/user-attachments/assets/60799a61-8dbb-4ebd-a7d8-3409ef10b1c0" />
