### PR TITLE
Restrict scroll to just the modal body

### DIFF
--- a/packages/core/components/Modal/BaseModal/BaseModal.module.css
+++ b/packages/core/components/Modal/BaseModal/BaseModal.module.css
@@ -21,6 +21,10 @@
     max-height: 100vh;
 }
 
+.body-wrapper {
+    position: relative;
+}
+
 .scrollable-body {
     overflow-y: auto;
     max-height: 80vh;
@@ -60,4 +64,16 @@
 
 .overlay {
     background-color: rgba(0, 0, 0, 0.7);
+}
+
+.vertical-gradient {
+    background-image: linear-gradient(to bottom, transparent, var(--secondary-background-color));
+    position: absolute;
+    height: 60px;
+    width: 100%;
+    pointer-events: none;
+    opacity: 1;
+    /* Should cover the body but not the header or footer (1000)*/
+    z-index: 100;
+    bottom: 0;
 }

--- a/packages/core/components/Modal/BaseModal/BaseModal.module.css
+++ b/packages/core/components/Modal/BaseModal/BaseModal.module.css
@@ -14,8 +14,16 @@
     flex-direction: column;
 }
 
+/* Prevent scrolling for the overall modal;
+ restrict to just the body content */
 .scrollable-container {
     overflow: hidden;
+    max-height: 100vh;
+}
+
+.scrollable-body {
+    overflow-y: auto;
+    max-height: 80vh;
 }
 
 .header {

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -21,6 +21,31 @@ interface BaseModalProps {
  */
 export default function BaseModal(props: BaseModalProps) {
     const { body, className, footer, title, onDismiss } = props;
+    const bodyContainerRef = React.useRef<HTMLDivElement>(null);
+    const [hasScroll, setHasScroll] = React.useState(false);
+
+    React.useEffect(() => {
+        const el = bodyContainerRef.current;
+        if (!el) return;
+
+        const checkScroll = () => {
+            const isOverflowing = el.scrollHeight > el.clientHeight;
+            // we've reached the end of the content if the distance scrolled
+            // from the top (rounded up to account for sub-pixel differences)
+            // is equal to the total content height
+            const isAtBottom = Math.ceil(el.scrollTop) + el.clientHeight >= el.scrollHeight;
+            setHasScroll(isOverflowing && !isAtBottom);
+        };
+        checkScroll();
+
+        const observer = new ResizeObserver(checkScroll);
+        observer.observe(el);
+        el.addEventListener("scroll", checkScroll);
+        return () => {
+            observer.disconnect();
+            el.removeEventListener("scroll", checkScroll);
+        };
+    }, [body]);
 
     const titleId = "base-modal-title";
     return (
@@ -40,7 +65,12 @@ export default function BaseModal(props: BaseModalProps) {
                 ) : null}
                 <TertiaryButton iconName="Cancel" onClick={onDismiss} title="" />
             </div>
-            <div className={styles.scrollableBody}>{body}</div>
+            <div className={styles.bodyWrapper}>
+                <div className={styles.scrollableBody} ref={bodyContainerRef}>
+                    {body}
+                </div>
+                {hasScroll && <div className={styles.verticalGradient} />}
+            </div>
             <div className={styles.footer}>{footer}</div>
         </Modal>
     );

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -29,12 +29,13 @@ export default function BaseModal(props: BaseModalProps) {
         if (!el) return;
 
         const checkScroll = () => {
-            const isOverflowing = el.scrollHeight > el.clientHeight;
+            const hasOverflowingContent = el.scrollHeight > el.clientHeight;
             // we've reached the end of the content if the distance scrolled
             // from the top (rounded up to account for sub-pixel differences)
             // is equal to the total content height
-            const isAtBottom = Math.ceil(el.scrollTop) + el.clientHeight >= el.scrollHeight;
-            setHasScroll(isOverflowing && !isAtBottom);
+            const isAtBottomOfContent =
+                Math.ceil(el.scrollTop) + el.clientHeight >= el.scrollHeight;
+            setHasScroll(hasOverflowingContent && !isAtBottomOfContent);
         };
         checkScroll();
 

--- a/packages/core/components/Modal/BaseModal/index.tsx
+++ b/packages/core/components/Modal/BaseModal/index.tsx
@@ -30,6 +30,7 @@ export default function BaseModal(props: BaseModalProps) {
             containerClassName={classNames(styles.container, className)}
             titleAriaId={titleId}
             overlay={{ className: styles.overlay }}
+            scrollableContentClassName={styles.scrollableContainer}
         >
             <div className={styles.header}>
                 {title ? (
@@ -39,7 +40,7 @@ export default function BaseModal(props: BaseModalProps) {
                 ) : null}
                 <TertiaryButton iconName="Cancel" onClick={onDismiss} title="" />
             </div>
-            <div className={styles.scrollableContent}>{body}</div>
+            <div className={styles.scrollableBody}>{body}</div>
             <div className={styles.footer}>{footer}</div>
         </Modal>
     );


### PR DESCRIPTION
## Context
Resolves #815. 
For the base modal class, the entire modal had scrolling applied because of FluentUI internal styling. A side effect of this was that the "body" content of the modal often overlapped with the header and/or footer.

## Changes
Restricts scroll styling to just the body and applies a gradient to the bottom of the container when there's still scrollable content.

## Testing
Manually tested each of our modal types

## Screenshots
### Before
<img width="502" alt="image" src="https://github.com/user-attachments/assets/76bfbb1f-8906-43cc-93eb-482651695a3b" />

### After
<img width="502" alt="image" src="https://github.com/user-attachments/assets/776b1bdb-7a4b-48cf-a683-80cee0bc7339" />

