### PR TITLE
Fix multi-file parquet row identity, and expose S3 URL parsing

### DIFF
--- a/packages/core/entity/SQLBuilder/index.ts
+++ b/packages/core/entity/SQLBuilder/index.ts
@@ -4,6 +4,18 @@ import { AnnotationType } from "../AnnotationFormatter";
 import { HIDDEN_UID_ANNOTATION } from "../../constants";
 
 /**
+ * Escape special characters for regex
+ */
+function toEscapedSqlString(str: string | number | boolean | null): string {
+    return (
+        `${str}`
+            .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+            // Escape single-quotes for SQL string literal (ex. O'Reilly -> O''Reilly)
+            .replaceAll("'", "''")
+    );
+}
+
+/**
  * A simple SQL query builder.
  */
 export default class SQLBuilder {
@@ -26,8 +38,7 @@ export default class SQLBuilder {
         expr: string,
         value: string | boolean | number | null
     ): string {
-        // Escape special characters for regex
-        const escapedValue = `${value}`.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+        const escapedValue = toEscapedSqlString(value);
         return `REGEXP_MATCHES(CAST(${expr} AS VARCHAR), '(,\\s*${escapedValue}\\s*,)|(^\\s*${escapedValue}\\s*,)|(,\\s*${escapedValue}\\s*$)|(^\\s*${escapedValue}\\s*$)') = true`;
     }
 
@@ -36,9 +47,7 @@ export default class SQLBuilder {
      * `REGEXP_MATCHES(CAST(expr AS VARCHAR), '(?i)pattern') = true`.
      */
     public static regexContains(expr: string, value: string | boolean | number | null): string {
-        const regexEscaped = `${value}`
-            .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
-            .replaceAll("'", "''");
+        const regexEscaped = toEscapedSqlString(value);
         return `REGEXP_MATCHES(CAST(${expr} AS VARCHAR), '(?i)${regexEscaped}') = true`;
     }
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -1027,15 +1027,24 @@ export default abstract class DatabaseService {
         if (fileNameSelectPart !== null) {
             selectParts.push(fileNameSelectPart);
         }
-        selectParts.push(`"file_row_number" AS "${HIDDEN_UID_ANNOTATION}"`);
+        // "file_row_number" restarts at 0 in every parquet file, so on its own it
+        // does not identify a row once the scan spans more than one file. Qualifying
+        // it with "filename" makes it unique. Kept VARCHAR even for a single file,
+        // both for consistency and because a 0-valued uid reads as falsy downstream.
+        selectParts.push(
+            `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`
+        );
         if (sourceNames.length > 1) {
             selectParts.push(`"filename" AS "${DATA_SOURCE_COLUMN}"`);
         }
         // 4. Create the view for this data source
         const quotedNames = sourceNames.map((name) => `'${fileHandleName(name)}'`).join(", ");
+        // filename/file_row_number are pseudo-columns parquet_scan only projects
+        // when asked for, and the hidden uid above depends on both.
         const createViewSql = `CREATE VIEW "${aggregateName}"
             AS SELECT ${selectParts.join(", ")}
-            FROM parquet_scan(ARRAY[${quotedNames}], union_by_name = true);`;
+            FROM parquet_scan(ARRAY[${quotedNames}], union_by_name = true,
+                filename = true, file_row_number = true);`;
         await this.execute(createViewSql);
         this.parquetDirectViewNames.add(aggregateName);
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -57,6 +57,12 @@ const PRE_DEFINED_COLUMNS = Object.values(PreDefinedColumn);
 
 const DATA_SOURCE_COLUMN = "Data source";
 
+// parquet_scan can inject the source file name as a column, but under its
+// default name it collides with any source parquet carrying its own column
+// called "filename" -- DuckDB then refuses to bind the scan at all. Ask for it
+// under a name a data file is not going to be using.
+const SOURCE_FILE_COLUMN = "bff_source_file";
+
 // Suffix appended to every DuckDB file-handle name so that a short name like
 // "foo" can never prefix-match a longer name like "foo2".
 // See https://github.com/duckdb/duckdb-wasm/issues/2227
@@ -1126,22 +1132,24 @@ export default abstract class DatabaseService {
         }
         // "file_row_number" restarts at 0 in every parquet file, so on its own it
         // does not identify a row once the scan spans more than one file. Qualifying
-        // it with "filename" makes it unique. Kept VARCHAR even for a single file,
-        // both for consistency and because a 0-valued uid reads as falsy downstream.
+        // it with the source file makes it unique. Kept VARCHAR even for a single
+        // file, both for consistency and because a 0-valued uid reads as falsy
+        // downstream.
         selectParts.push(
-            `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`
+            `("${SOURCE_FILE_COLUMN}" || '#' || CAST("file_row_number" AS VARCHAR)) ` +
+                `AS "${HIDDEN_UID_ANNOTATION}"`
         );
         if (sourceNames.length > 1) {
-            selectParts.push(`"filename" AS "${DATA_SOURCE_COLUMN}"`);
+            selectParts.push(`"${SOURCE_FILE_COLUMN}" AS "${DATA_SOURCE_COLUMN}"`);
         }
         // 4. Create the view for this data source
         const quotedNames = sourceNames.map((name) => `'${fileHandleName(name)}'`).join(", ");
-        // filename/file_row_number are pseudo-columns parquet_scan only projects
-        // when asked for, and the hidden uid above depends on both.
+        // Both are pseudo-columns parquet_scan only projects when asked for, and
+        // the hidden uid above depends on both.
         const createViewSql = `CREATE VIEW "${aggregateName}"
             AS SELECT ${selectParts.join(", ")}
             FROM parquet_scan(ARRAY[${quotedNames}], union_by_name = true,
-                filename = true, file_row_number = true);`;
+                filename = '${SOURCE_FILE_COLUMN}', file_row_number = true);`;
         await this.execute(createViewSql);
         this.parquetDirectViewNames.add(aggregateName);
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -57,10 +57,9 @@ const PRE_DEFINED_COLUMNS = Object.values(PreDefinedColumn);
 
 const DATA_SOURCE_COLUMN = "Data source";
 
-// parquet_scan can inject the source file name as a column, but under its
-// default name it collides with any source parquet carrying its own column
-// called "filename" -- DuckDB then refuses to bind the scan at all. Ask for it
-// under a name a data file is not going to be using.
+// Assign a column name that is unlikely to be used in a data source to
+// be used as the name of the column that `parquet_scan` can inject the source
+// file name into.
 const SOURCE_FILE_COLUMN = "bff_source_file";
 
 // Suffix appended to every DuckDB file-handle name so that a short name like
@@ -1130,11 +1129,9 @@ export default abstract class DatabaseService {
         if (fileNameSelectPart !== null) {
             selectParts.push(fileNameSelectPart);
         }
-        // "file_row_number" restarts at 0 in every parquet file, so on its own it
-        // does not identify a row once the scan spans more than one file. Qualifying
-        // it with the source file makes it unique. Kept VARCHAR even for a single
-        // file, both for consistency and because a 0-valued uid reads as falsy
-        // downstream.
+        // Have to qualify each row number by its source file to prevent collisions
+        // across files (especially relevant for sharded datasets).
+        // Ex. This would become: "my_dataset#1"
         selectParts.push(
             `("${SOURCE_FILE_COLUMN}" || '#' || CAST("file_row_number" AS VARCHAR)) ` +
                 `AS "${HIDDEN_UID_ANNOTATION}"`
@@ -1144,12 +1141,14 @@ export default abstract class DatabaseService {
         }
         // 4. Create the view for this data source
         const quotedNames = sourceNames.map((name) => `'${fileHandleName(name)}'`).join(", ");
-        // Both are pseudo-columns parquet_scan only projects when asked for, and
-        // the hidden uid above depends on both.
         const createViewSql = `CREATE VIEW "${aggregateName}"
             AS SELECT ${selectParts.join(", ")}
-            FROM parquet_scan(ARRAY[${quotedNames}], union_by_name = true,
-                filename = '${SOURCE_FILE_COLUMN}', file_row_number = true);`;
+            FROM parquet_scan(
+                ARRAY[${quotedNames}],
+                union_by_name = true,
+                filename = '${SOURCE_FILE_COLUMN}',
+                file_row_number = true
+            );`;
         await this.execute(createViewSql);
         this.parquetDirectViewNames.add(aggregateName);
     }

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -375,10 +375,6 @@ describe("DatabaseService", () => {
         });
 
         it("qualifies the hidden UID by filename so it stays unique across files", async () => {
-            // file_row_number restarts at 0 in every parquet file. Selecting it
-            // alone gives row 0 of file A and row 0 of file B the same id, which
-            // silently breaks `hidden_bff_uid IN (...)` selection and the ORDER BY
-            // that keeps pagination stable.
             const service = new MockAggregateParquetDatabaseService({
                 "a.parquet": ["File Path"],
                 "b.parquet": ["File Path"],
@@ -394,17 +390,9 @@ describe("DatabaseService", () => {
                 `("bff_source_file" || '#' || CAST("file_row_number" AS VARCHAR)) ` +
                     `AS "${HIDDEN_UID_ANNOTATION}"`
             );
-            expect(
-                createViewSql,
-                "a bare file_row_number uid is not unique across files"
-            ).to.not.match(new RegExp(`"file_row_number" AS "${HIDDEN_UID_ANNOTATION}"`));
         });
 
         it("does not collide with a source column named filename", async () => {
-            // parquet_scan's injected filename column has a fixed default name.
-            // A source parquet carrying its own "filename" column collides with
-            // it and DuckDB refuses to bind the scan at all, so the injected one
-            // is requested under a namespaced name instead.
             const service = new MockAggregateParquetDatabaseService({
                 "a.parquet": ["File Path", "filename"],
                 "b.parquet": ["File Path", "filename"],
@@ -422,25 +410,6 @@ describe("DatabaseService", () => {
             // that is what the uid and "Data source" are built from.
             expect(createViewSql).to.include(`filename = 'bff_source_file'`);
             expect(createViewSql).to.include(`"bff_source_file" || '#'`);
-            expect(createViewSql).to.not.include(`("filename" || '#'`);
-        });
-
-        it("asks parquet_scan for the pseudo-columns the view selects", async () => {
-            // filename and file_row_number are only projected when requested, and
-            // both the hidden UID and the "Data source" column depend on them.
-            const service = new MockAggregateParquetDatabaseService({
-                "a.parquet": ["File Path"],
-                "b.parquet": ["File Path"],
-            });
-
-            await service.prepareDataSources([
-                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
-            ]);
-
-            const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
-            expect(createViewSql).to.include(`filename = 'bff_source_file'`);
-            expect(createViewSql).to.include("file_row_number = true");
         });
 
         it("creates aggregate parquet view using union_by_name and data source projection", async () => {

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -370,8 +370,9 @@ describe("DatabaseService", () => {
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
             expect(createViewSql).to.not.be.undefined;
-            expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo-bff-filehandle'.*]/);
-            expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo2-bff-filehandle'.*]/);
+            expect(createViewSql).to.match(/parquet_scan\(\s*ARRAY\[/);
+            expect(createViewSql).to.include("'foo-bff-filehandle'");
+            expect(createViewSql).to.include("'foo2-bff-filehandle'");
         });
 
         it("qualifies the hidden UID by filename so it stays unique across files", async () => {
@@ -425,7 +426,7 @@ describe("DatabaseService", () => {
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
             expect(createViewSql).to.not.be.undefined;
-            expect(createViewSql).to.include("parquet_scan(ARRAY[");
+            expect(createViewSql).to.match(/parquet_scan\(\s*ARRAY\[/);
             expect(createViewSql).to.include("union_by_name = true");
             expect(createViewSql).to.include(`"bff_source_file" AS "Data source"`);
         });

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import sinon from "sinon";
 
 import DatabaseServiceNoop from "../DatabaseServiceNoop";
+import { HIDDEN_UID_ANNOTATION } from "../../../constants";
 import Annotation from "../../../entity/Annotation";
 import { AnnotationType } from "../../../entity/AnnotationFormatter";
 import AnnotationName from "../../../entity/Annotation/AnnotationName";
@@ -371,6 +372,49 @@ describe("DatabaseService", () => {
             expect(createViewSql).to.not.be.undefined;
             expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo-bff-filehandle'.*]/);
             expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo2-bff-filehandle'.*]/);
+        });
+
+        it("qualifies the hidden UID by filename so it stays unique across files", async () => {
+            // file_row_number restarts at 0 in every parquet file. Selecting it
+            // alone gives row 0 of file A and row 0 of file B the same id, which
+            // silently breaks `hidden_bff_uid IN (...)` selection and the ORDER BY
+            // that keeps pagination stable.
+            const service = new MockAggregateParquetDatabaseService({
+                "a.parquet": ["File Path"],
+                "b.parquet": ["File Path"],
+            });
+
+            await service.prepareDataSources([
+                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+            ]);
+
+            const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
+            expect(createViewSql).to.include(
+                `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`
+            );
+            expect(
+                createViewSql,
+                "a bare file_row_number uid is not unique across files"
+            ).to.not.match(new RegExp(`"file_row_number" AS "${HIDDEN_UID_ANNOTATION}"`));
+        });
+
+        it("asks parquet_scan for the pseudo-columns the view selects", async () => {
+            // filename and file_row_number are only projected when requested, and
+            // both the hidden UID and the "Data source" column depend on them.
+            const service = new MockAggregateParquetDatabaseService({
+                "a.parquet": ["File Path"],
+                "b.parquet": ["File Path"],
+            });
+
+            await service.prepareDataSources([
+                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+            ]);
+
+            const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
+            expect(createViewSql).to.include("filename = true");
+            expect(createViewSql).to.include("file_row_number = true");
         });
 
         it("creates aggregate parquet view using union_by_name and data source projection", async () => {

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -391,12 +391,38 @@ describe("DatabaseService", () => {
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
             expect(createViewSql).to.include(
-                `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`
+                `("bff_source_file" || '#' || CAST("file_row_number" AS VARCHAR)) ` +
+                    `AS "${HIDDEN_UID_ANNOTATION}"`
             );
             expect(
                 createViewSql,
                 "a bare file_row_number uid is not unique across files"
             ).to.not.match(new RegExp(`"file_row_number" AS "${HIDDEN_UID_ANNOTATION}"`));
+        });
+
+        it("does not collide with a source column named filename", async () => {
+            // parquet_scan's injected filename column has a fixed default name.
+            // A source parquet carrying its own "filename" column collides with
+            // it and DuckDB refuses to bind the scan at all, so the injected one
+            // is requested under a namespaced name instead.
+            const service = new MockAggregateParquetDatabaseService({
+                "a.parquet": ["File Path", "filename"],
+                "b.parquet": ["File Path", "filename"],
+            });
+
+            await service.prepareDataSources([
+                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+            ]);
+
+            const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
+            // The user's own column is still projected untouched...
+            expect(createViewSql).to.include(`"filename"`);
+            // ...while the injected one is asked for under a name of ours, and
+            // that is what the uid and "Data source" are built from.
+            expect(createViewSql).to.include(`filename = 'bff_source_file'`);
+            expect(createViewSql).to.include(`"bff_source_file" || '#'`);
+            expect(createViewSql).to.not.include(`("filename" || '#'`);
         });
 
         it("asks parquet_scan for the pseudo-columns the view selects", async () => {
@@ -413,7 +439,7 @@ describe("DatabaseService", () => {
             ]);
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
-            expect(createViewSql).to.include("filename = true");
+            expect(createViewSql).to.include(`filename = 'bff_source_file'`);
             expect(createViewSql).to.include("file_row_number = true");
         });
 
@@ -432,7 +458,7 @@ describe("DatabaseService", () => {
             expect(createViewSql).to.not.be.undefined;
             expect(createViewSql).to.include("parquet_scan(ARRAY[");
             expect(createViewSql).to.include("union_by_name = true");
-            expect(createViewSql).to.include(`"filename" AS "Data source"`);
+            expect(createViewSql).to.include(`"bff_source_file" AS "Data source"`);
         });
     });
 

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -146,12 +146,15 @@ export default class DatabaseFileService implements FileService {
     public readonly provenanceIdColumns = ["File Path", "File ID"];
 
     private static convertDatabaseRowToFileDetail(row: FileRow, env: Environment): FileDetail {
-        const uniqueId = row[HIDDEN_UID_ANNOTATION];
+        const rawUniqueId = row[HIDDEN_UID_ANNOTATION];
         // isNil rather than a truthiness check: 0 is a legitimate uid for the
-        // first row of a table.
-        if (isNil(uniqueId)) {
+        // first row of a table. It has to be stringified before it reaches
+        // FileDetail, whose uid getter is `this.uniqueId || this.id` -- a numeric
+        // 0 would otherwise be discarded in favour of the file ID.
+        if (isNil(rawUniqueId)) {
             throw new Error("Missing auto-generated unique ID");
         }
+        const uniqueId = String(rawUniqueId);
 
         const annotations = Object.entries(row).flatMap(([name, values]): FmsFileAnnotation[] => {
             // Filter out UID annotation used for selection logic

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -147,7 +147,9 @@ export default class DatabaseFileService implements FileService {
 
     private static convertDatabaseRowToFileDetail(row: FileRow, env: Environment): FileDetail {
         const uniqueId = row[HIDDEN_UID_ANNOTATION];
-        if (!uniqueId) {
+        // isNil rather than a truthiness check: 0 is a legitimate uid for the
+        // first row of a table.
+        if (isNil(uniqueId)) {
             throw new Error("Missing auto-generated unique ID");
         }
 

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -31,7 +31,8 @@ type UnwrappedMetadataValue =
     | null
     | undefined;
 type FileRow = {
-    [HIDDEN_UID_ANNOTATION]?: string;
+    // This is a string for parquet and a number for CSV/JSON
+    [HIDDEN_UID_ANNOTATION]?: string | number;
     [key: string]: UnwrappedMetadataValue;
 };
 
@@ -147,10 +148,6 @@ export default class DatabaseFileService implements FileService {
 
     private static convertDatabaseRowToFileDetail(row: FileRow, env: Environment): FileDetail {
         const rawUniqueId = row[HIDDEN_UID_ANNOTATION];
-        // isNil rather than a truthiness check: 0 is a legitimate uid for the
-        // first row of a table. It has to be stringified before it reaches
-        // FileDetail, whose uid getter is `this.uniqueId || this.id` -- a numeric
-        // 0 would otherwise be discarded in favour of the file ID.
         if (isNil(rawUniqueId)) {
             throw new Error("Missing auto-generated unique ID");
         }

--- a/packages/core/services/S3StorageService/index.ts
+++ b/packages/core/services/S3StorageService/index.ts
@@ -9,7 +9,7 @@ import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
 export const isMultiObjectFile = (url: string) =>
     [".zarr", ".zarr/", ".sldy", ".sldy/"].some((ext) => url.endsWith(ext));
 
-interface ParsedUrl {
+export interface ParsedUrl {
     hostname: string;
     bucket: string;
     key: string;
@@ -194,7 +194,7 @@ export default class S3StorageService extends HttpServiceBase {
     /**
      * Parse URL into hostname, bucket, key from a url
      */
-    private parseUrl(url: string): Promise<ParsedUrl | undefined> {
+    public parseUrl(url: string): Promise<ParsedUrl | undefined> {
         return S3StorageService.isSimpleS3Url(url)
             ? Promise.resolve(S3StorageService.parseSimpleUrl(url))
             : // TODO: what about virtualized objects not directories???


### PR DESCRIPTION
Precursor work to supporting `deltalake` / sharded parquets

### 1. Fix `hidden_bff_uid` collisions across multi-file parquet scans

`hidden_bff_uid` was selected as parquet_scan's `file_row_number`, which restarts
at 0 in every file. Any view spanning more than one parquet gave row 0 of file A and row 0 of
file B the same id.

Also fixes `convertDatabaseRowToFileDetail` rejected a falsy
uid, so row 0 raised "Missing auto-generated unique ID".

### 2. Expose S3 URL parsing on `S3StorageService`

Makes `parseUrl` and `ParsedUrl` public so callers outside the class can turn an
s3: URL into an addressable https one. No behavior change, this will be used in a follow-up.

