### PR TITLE
Allow toggling between list picker and search box for string annotations

### DIFF
--- a/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
+++ b/packages/core/components/AnnotationFilterForm/AnnotationFilterForm.module.css
@@ -1,4 +1,4 @@
-.loading-container, .picker {
+.loading-container, .picker, .picker-toggle {
     background-color: var(--primary-background-color);
     color: var(--primary-text-color);
     padding: 0 30px 16px;
@@ -17,6 +17,15 @@
 
 .choice-group {
     margin-bottom: 6px;
+}
+
+.picker-toggle:hover {
+    background-color: var(--primary-background-color);
+    color: var(--highlight-text-color) !important;
+}
+
+.picker-toggle:hover i {
+    color: var(--highlight-text-color) !important;
 }
 
 .footer {

--- a/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/SearchBoxForm/index.tsx
@@ -35,7 +35,10 @@ export default function SearchBoxForm(props: SearchBoxFormProps) {
     }
 
     return (
-        <div className={classNames(props.className, styles.container)}>
+        <div
+            className={classNames(props.className, styles.container)}
+            data-testid="search-box-form"
+        >
             <h3 className={styles.title}>{props.title}</h3>
             <Checkbox
                 className={classNames(styles.checkbox, {

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -1,4 +1,4 @@
-import { IChoiceGroupOption } from "@fluentui/react";
+import { ActionButton, IChoiceGroupOption } from "@fluentui/react";
 import classNames from "classnames";
 import { isNil } from "lodash";
 import * as React from "react";
@@ -23,6 +23,10 @@ import styles from "./AnnotationFilterForm.module.css";
 interface AnnotationFilterFormProps {
     annotation: Annotation;
 }
+
+// Above this many distinct values, string annotations default to the search box
+// rather than the list picker; users can still toggle between the two.
+const MAX_VALUES_FOR_DEFAULT_LIST_PICKER = 100;
 
 /**
  * A form that provides a user the ability to select particular annotation values with which
@@ -58,6 +62,10 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     );
 
     const [filterType, setFilterType] = React.useState<FilterType>(defaultFilterType);
+
+    // User override for which picker to use for string annotations;
+    // undefined means no explicit choice has been made and the default applies
+    const [showListPicker, setShowListPicker] = React.useState<boolean | undefined>(undefined);
 
     // Propagate regular file filter values from state into UI
     const items = React.useMemo<ListItem[]>(() => {
@@ -194,23 +202,47 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                         units={props.annotation.units}
                     />
                 );
-            case AnnotationType.STRING:
-                // Use list picker when there are a manageable number of values; fall back to search otherwise
-                if (items.length > 0 && items.length <= 100) {
-                    return listPickerComponent;
-                }
+            case AnnotationType.STRING: {
+                // Use list picker by default when there are a manageable number of values;
+                // default to search otherwise. Users can toggle between the two,
+                // but without values to list only the search box is usable.
+                const useListPicker =
+                    items.length > 0 &&
+                    (showListPicker ?? items.length <= MAX_VALUES_FOR_DEFAULT_LIST_PICKER);
+                const toggleLabel = useListPicker
+                    ? "Switch to search box"
+                    : "Switch to list pick mode";
+
                 return (
-                    <SearchBoxForm
-                        className={styles.picker}
-                        onSelectAll={onSelectAll}
-                        onDeselectAll={onDeselectAll}
-                        onSearch={onSearch}
-                        fuzzySearchEnabled={fuzzySearchEnabled}
-                        fieldName={props.annotation.displayName}
-                        defaultValue={filtersForAnnotation?.[0]}
-                        hideFuzzyToggle={!canFuzzySearch}
-                    />
+                    <>
+                        {useListPicker ? (
+                            listPickerComponent
+                        ) : (
+                            <SearchBoxForm
+                                className={styles.picker}
+                                onSelectAll={onSelectAll}
+                                onDeselectAll={onDeselectAll}
+                                onSearch={onSearch}
+                                fuzzySearchEnabled={fuzzySearchEnabled}
+                                fieldName={props.annotation.displayName}
+                                defaultValue={filtersForAnnotation?.[0]}
+                                hideFuzzyToggle={!canFuzzySearch}
+                            />
+                        )}
+                        {items.length > 0 && (
+                            <ActionButton
+                                ariaLabel={toggleLabel}
+                                className={styles.pickerToggle}
+                                data-testid="picker-toggle"
+                                iconProps={{ iconName: useListPicker ? "Search" : "BulletedList" }}
+                                onClick={() => setShowListPicker(!useListPicker)}
+                            >
+                                {toggleLabel}
+                            </ActionButton>
+                        )}
+                    </>
                 );
+            }
             case AnnotationType.DURATION:
             // prettier-ignore
             default: // FALL-THROUGH

--- a/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
@@ -123,6 +123,93 @@ describe("<AnnotationFilterForm />", () => {
             expect(selection.selectors.getFileFilters(store.getState())).to.be.lengthOf(1);
         });
 
+        it("defaults to search box over 100 values and can toggle to the list picker", async () => {
+            // arrange
+            const manyValues = Array.from({ length: 150 }, (_, index) => `value-${index}`);
+            const responseStub = {
+                when: `${FESBaseUrl.TEST}/file-explorer-service/1.0/annotations/${fooAnnotation.name}/values`,
+                respondWith: {
+                    data: { data: manyValues },
+                },
+            };
+            const mockHttpClient = createMockHttpClient(responseStub);
+            const annotationService = new HttpAnnotationService({
+                fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
+                httpClient: mockHttpClient,
+            });
+            sandbox.stub(interaction.selectors, "getAnnotationService").returns(annotationService);
+
+            const { store } = configureMockStore({
+                state: initialState,
+                responseStubs: responseStub,
+            });
+
+            // act
+            const { findByTestId, getByTestId, queryByTestId } = render(
+                <Provider store={store}>
+                    <AnnotationFilterForm annotation={fooAnnotation} />
+                </Provider>
+            );
+
+            // assert: search box renders by default, not the list picker
+            const toggle = await findByTestId("picker-toggle");
+            expect(getByTestId("search-box-form")).to.exist;
+            expect(queryByTestId("list-picker")).to.equal(null);
+
+            // act: switch to the list picker
+            fireEvent.click(toggle);
+
+            // assert
+            expect(getByTestId("list-picker")).to.exist;
+            expect(queryByTestId("search-box-form")).to.equal(null);
+
+            // act: switch back to the search box
+            fireEvent.click(getByTestId("picker-toggle"));
+
+            // assert
+            expect(getByTestId("search-box-form")).to.exist;
+            expect(queryByTestId("list-picker")).to.equal(null);
+        });
+
+        it("defaults to list picker under 100 values and can toggle to the search box", async () => {
+            // arrange
+            const responseStub = {
+                when: `${FESBaseUrl.TEST}/file-explorer-service/1.0/annotations/${fooAnnotation.name}/values`,
+                respondWith: {
+                    data: { data: ["a", "b", "c", "d"] },
+                },
+            };
+            const mockHttpClient = createMockHttpClient(responseStub);
+            const annotationService = new HttpAnnotationService({
+                fileExplorerServiceBaseUrl: FESBaseUrl.TEST,
+                httpClient: mockHttpClient,
+            });
+            sandbox.stub(interaction.selectors, "getAnnotationService").returns(annotationService);
+
+            const { store } = configureMockStore({
+                state: initialState,
+                responseStubs: responseStub,
+            });
+
+            // act
+            const { findByTestId, getByTestId, queryByTestId } = render(
+                <Provider store={store}>
+                    <AnnotationFilterForm annotation={fooAnnotation} />
+                </Provider>
+            );
+
+            // assert: list picker renders by default, not the search box
+            expect(await findByTestId("list-picker")).to.exist;
+            expect(queryByTestId("search-box-form")).to.equal(null);
+
+            // act: switch to the search box
+            fireEvent.click(getByTestId("picker-toggle"));
+
+            // assert
+            expect(getByTestId("search-box-form")).to.exist;
+            expect(queryByTestId("list-picker")).to.equal(null);
+        });
+
         it("naturally sorts values", async () => {
             // arrange
             const responseStub = {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fms-file-explorer-desktop",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "An application designed to simplify access and exploration of data produced by the Allen Institute for Cell Science, provide an intuitive mechanism for organizing data and provide simple hooks to incorporating that data into both programmatic and non-programmatic workflows.",
   "main": "dist/main/index.js",
   "repository": {


### PR DESCRIPTION
## Context
Addresses #726. String annotations with more than 100 distinct values only rendered the exact-match search box, so users could not multi-select values (e.g. selecting several plate barcodes at once).

## Changes
- Added a toggle button (rendered below the picker) for string annotations that lets users switch between the `ListPicker` and the `SearchBoxForm` in both directions. Defaults are unchanged: list picker for 1–100 distinct values, search box otherwise.

- Note: rendering the full list for >100 values is cheap — `useAnnotationValues` already fetches all distinct values regardless, and `ListPicker` virtualizes rows past 100 items.

## Testing
- Two new unit tests: 150 values defaults to the search box and toggles to the list picker and back; 4 values defaults to the list picker and toggles to the search box. Each state asserts both the presence of the expected picker and the absence of the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)