### PR TITLE
Add Delta Lake file handling

### DIFF
--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -19,7 +19,7 @@ export enum FileView {
     LARGE_THUMBNAIL = "3",
 }
 
-export const ACCEPTED_SOURCE_TYPES = ["csv", "json", "parquet"] as const;
+export const ACCEPTED_SOURCE_TYPES = ["csv", "json", "parquet", "delta"] as const;
 
 export interface Source {
     name: string;

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -68,8 +68,7 @@ function isParquetBacked(type?: SourceType): boolean {
 }
 
 // A Delta Lake source is backed by many parquet files, so it registers one handle
-// per data file. The index is zero-padded to a fixed width so that no handle can
-// ever be a prefix of another (see FILE_HANDLE_SUFFIX above).
+// per data file
 function deltaFileHandleName(name: string, index: number): string {
     return `${fileHandleName(name)}-${String(index).padStart(8, "0")}.parquet`;
 }
@@ -324,8 +323,7 @@ export default abstract class DatabaseService {
     }
 
     /**
-     * Release DuckDB file handles. Overridable alongside registerFileURLs so tests
-     * can exercise the surrounding logic without a database.
+     * Release DuckDB file handles
      */
     protected async dropFileHandles(handles: string[]): Promise<void> {
         if (!this.database) return;
@@ -1126,9 +1124,8 @@ export default abstract class DatabaseService {
             selectParts.push(fileNameSelectPart);
         }
         // "file_row_number" restarts at 0 in every parquet file, so on its own it
-        // does not identify a row once the scan spans more than one file -- which
-        // is every Delta Lake table and every multi-source aggregate. Qualifying it
-        // with "filename" makes it unique. Kept VARCHAR even for a single file,
+        // does not identify a row once the scan spans more than one file. Qualifying
+        // it with "filename" makes it unique. Kept VARCHAR even for a single file,
         // both for consistency and because a 0-valued uid reads as falsy downstream.
         selectParts.push(
             `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -1674,8 +1674,9 @@ const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
     // Similar to getColumnsOnDataSource below, but suitable for use during the
     // data source preparation step.
     private async getRawParquetColumns(handles: string[]): Promise<string[]> {
-        const sql = `DESCRIBE SELECT * FROM parquet_scan(
-            ${handleArrayLiteral(handles)}
+const sql = `DESCRIBE SELECT * FROM parquet_scan(
+            ${handleArrayLiteral(handles)},
+            union_by_name = true
         )`;
         const rows = await this.query(sql).promise;
         return rows.map((row) => row["column_name"] as string);

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -366,7 +366,7 @@ export default abstract class DatabaseService {
         if (uri instanceof File) {
             throw new Error(
                 `Delta Lake tables cannot be uploaded from your computer because they are ` +
-                    `directories rather than single files. Provide a URL to the table instead.`
+                    `directories rather than single files. Upload your file to a remote source.`
             );
         }
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -363,11 +363,10 @@ export default abstract class DatabaseService {
             );
         }
 
-        const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
+const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
         const handles = dataFileUrls.map((_, index) => deltaFileHandleName(name, index));
-        await this.registerFileURLs(handles, dataFileUrls);
-
         this.sourceToHandles.set(name, handles);
+        await this.registerFileURLs(handles, dataFileUrls);
         await this.createParquetDirectView(name);
     }
 

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -2,11 +2,12 @@ import * as duckdb from "@duckdb/duckdb-wasm";
 import axios from "axios";
 import { isEmpty, isNil, mapKeys, mapValues, uniq } from "lodash";
 
+import DeltaLakeService from "../DeltaLakeService";
 import { AICS_FMS_DATA_SOURCE_NAME, HIDDEN_UID_ANNOTATION } from "../../constants";
 import Annotation from "../../entity/Annotation";
 import { AnnotationType } from "../../entity/AnnotationFormatter";
 import { EdgeDefinition, EdgeNodeType, RelationshipType } from "../../entity/Graph";
-import { Source } from "../../entity/SearchParams";
+import { ACCEPTED_SOURCE_TYPES, Source } from "../../entity/SearchParams";
 import SQLBuilder from "../../entity/SQLBuilder";
 import DataSourcePreparationError from "../../errors/DataSourcePreparationError";
 
@@ -58,6 +59,24 @@ const DATA_SOURCE_COLUMN = "Data source";
 const FILE_HANDLE_SUFFIX = "-bff-filehandle";
 function fileHandleName(name: string): string {
     return name + FILE_HANDLE_SUFFIX;
+}
+
+export type SourceType = typeof ACCEPTED_SOURCE_TYPES[number];
+// Return true if type is parquet or parquet-like
+function isParquetBacked(type?: SourceType): boolean {
+    return type === "parquet" || type === "delta";
+}
+
+// A Delta Lake source is backed by many parquet files, so it registers one handle
+// per data file. The index is zero-padded to a fixed width so that no handle can
+// ever be a prefix of another (see FILE_HANDLE_SUFFIX above).
+function deltaFileHandleName(name: string, index: number): string {
+    return `${fileHandleName(name)}-${String(index).padStart(8, "0")}.parquet`;
+}
+
+// Render file handles as a DuckDB list literal, e.g. ARRAY['a', 'b'].
+function handleArrayLiteral(handles: string[]): string {
+    return `ARRAY[${handles.map((handle) => `'${handle}'`).join(", ")}]`;
 }
 
 // Check if a value is a non-empty string. Returns true for any string with at least one non-whitespace character.
@@ -159,16 +178,21 @@ export default abstract class DatabaseService {
     protected sourceMetadataName?: string;
     public sourceProvenanceName?: string;
     private currentAggregateSource?: string;
+    protected deltaLakeService: DeltaLakeService;
     // Initialize with AICS FMS data source name to pretend it always exists
     protected readonly existingDataSources = new Set([AICS_FMS_DATA_SOURCE_NAME]);
     protected readonly dataSourceToAnnotationsMap: Map<string, Annotation[]> = new Map();
     private readonly dataSourceToProvenanceMap: Map<string, EdgeDefinition[]> = new Map();
     // Data source names that are views (parquet), so we DROP VIEW on delete
     private readonly parquetDirectViewNames = new Set<string>();
+    // Data sources backed by more than one parquet file (i.e. Delta Lake tables)
+    // map to the full list of DuckDB file handles registered for them.
+    private readonly sourceToHandles = new Map<string, string[]>();
 
     protected database: duckdb.AsyncDuckDB | undefined;
 
-    constructor() {
+    constructor(deltaLakeService?: DeltaLakeService) {
+        this.deltaLakeService = deltaLakeService ?? new DeltaLakeService();
         this.addDataSource = this.addDataSource.bind(this);
         this.execute = this.execute.bind(this);
         this.query = this.query.bind(this);
@@ -246,9 +270,13 @@ export default abstract class DatabaseService {
 
     protected async addDataSource(
         name: string,
-        type: "csv" | "json" | "parquet",
+        type: SourceType,
         uri: string | File
     ): Promise<void> {
+        if (type === "delta") {
+            return this.addDeltaDataSource(name, uri);
+        }
+
         if (!this.database) {
             throw new Error("Database failed to initialize");
         }
@@ -293,6 +321,68 @@ export default abstract class DatabaseService {
                 );
             }
         }
+    }
+
+    /**
+     * Release DuckDB file handles. Overridable alongside registerFileURLs so tests
+     * can exercise the surrounding logic without a database.
+     */
+    protected async dropFileHandles(handles: string[]): Promise<void> {
+        if (!this.database) return;
+        try {
+            await Promise.all(handles.map((handle) => this.database?.dropFile(handle)));
+        } catch (error) {
+            console.error(`Failed to drop file handles ${handles}: ${(error as Error).message}`);
+        }
+    }
+
+    /**
+     * Register every parquet data file of a Delta Lake table as its own DuckDB
+     * file handle, then expose them all as a single view.
+     */
+    private async addDeltaDataSource(name: string, uri: string | File): Promise<void> {
+        if (uri instanceof File) {
+            throw new Error(
+                `Delta Lake tables cannot be uploaded from your computer because they are ` +
+                    `directories rather than single files. Provide a URL to the table instead.`
+            );
+        }
+
+        const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
+        const handles = dataFileUrls.map((_, index) => deltaFileHandleName(name, index));
+        await this.registerFileURLs(handles, dataFileUrls);
+
+        this.sourceToHandles.set(name, handles);
+        await this.createParquetDirectView(name);
+    }
+
+    /**
+     * Register a batch of remote files with DuckDB, one handle per URL.
+     * Overridable so tests can exercise the surrounding logic without a database.
+     */
+    protected async registerFileURLs(handles: string[], urls: string[]): Promise<void> {
+        if (!this.database) {
+            throw new Error("Database failed to initialize");
+        }
+
+        await Promise.all(
+            urls.map((url, index) =>
+                this.database?.registerFileURL(
+                    handles[index],
+                    url,
+                    duckdb.DuckDBDataProtocol.HTTP,
+                    false
+                )
+            )
+        );
+    }
+
+    /**
+     * The DuckDB file handles backing a data source. All sources but Delta Lake
+     * tables are a single file, and so a single handle.
+     */
+    private handlesFor(name: string): string[] {
+        return this.sourceToHandles.get(name) ?? [fileHandleName(name)];
     }
 
     public async execute(sql: string): Promise<void> {
@@ -587,7 +677,7 @@ export default abstract class DatabaseService {
             let formattedError = (err as Error).message;
             // DuckDB does not provide informative server errors, so send a
             // separate 'get' call to retrieve error messages for URL data sources
-            if (!(uri instanceof File)) {
+            if (!(uri instanceof File) && dataSource.type !== "delta") {
                 await axios.get(uri).catch((error) => {
                     // Error responses can be formatted differently
                     // Get progressively less specific in where we look for the message
@@ -637,7 +727,7 @@ export default abstract class DatabaseService {
                 name
             );
         }
-        // Add the data source as a table on the database
+
         await this.addDataSource(name, type, uri);
 
         // Add data source name to in-memory set
@@ -647,7 +737,7 @@ export default abstract class DatabaseService {
         // Unless skipped, this will ensure the table is prepared
         // for querying with the expected columns & uniqueness constraints
         if (!skipNormalization) {
-            if (type !== "parquet") {
+            if (!isParquetBacked(type)) {
                 await this.normalizeDataSourceColumnNames(name);
                 await this.renameNonprintableCharColumns(name);
             }
@@ -657,7 +747,7 @@ export default abstract class DatabaseService {
                 throw new DataSourcePreparationError(error, name);
             }
 
-            if (type !== "parquet") {
+            if (!isParquetBacked(type)) {
                 await this.addRequiredColumns(name);
             }
         }
@@ -726,6 +816,11 @@ export default abstract class DatabaseService {
     protected async deleteDataSource(dataSource: string): Promise<void> {
         this.existingDataSources.delete(dataSource);
         this.dataSourceToAnnotationsMap.delete(dataSource);
+        const handles = this.sourceToHandles.get(dataSource);
+        this.sourceToHandles.delete(dataSource);
+        if (handles) {
+            await this.dropFileHandles(handles);
+        }
         if (this.parquetDirectViewNames.has(dataSource)) {
             this.parquetDirectViewNames.delete(dataSource);
             await this.execute(`DROP VIEW IF EXISTS "${dataSource}"`);
@@ -1011,7 +1106,10 @@ export default abstract class DatabaseService {
         // Note: we don't use this.getColumnsOnDataSource, since that expects a
         // fully built data source, and this function is used for creating a
         // data source.
-        const rawColumnQueries = sourceNames.map((name) => this.getRawParquetColumns(name));
+        const handles = sourceNames.flatMap((name) => this.handlesFor(name));
+        const rawColumnQueries = sourceNames.map((name) =>
+            this.getRawParquetColumns(this.handlesFor(name))
+        );
         const rawColumns = uniq((await Promise.all(rawColumnQueries)).flat());
         // 2. Determine which columns need to be renamed, if any
         const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
@@ -1028,8 +1126,9 @@ export default abstract class DatabaseService {
             selectParts.push(fileNameSelectPart);
         }
         // "file_row_number" restarts at 0 in every parquet file, so on its own it
-        // does not identify a row once the scan spans more than one file. Qualifying
-        // it with "filename" makes it unique. Kept VARCHAR even for a single file,
+        // does not identify a row once the scan spans more than one file -- which
+        // is every Delta Lake table and every multi-source aggregate. Qualifying it
+        // with "filename" makes it unique. Kept VARCHAR even for a single file,
         // both for consistency and because a 0-valued uid reads as falsy downstream.
         selectParts.push(
             `("filename" || '#' || CAST("file_row_number" AS VARCHAR)) AS "${HIDDEN_UID_ANNOTATION}"`
@@ -1037,14 +1136,17 @@ export default abstract class DatabaseService {
         if (sourceNames.length > 1) {
             selectParts.push(`"filename" AS "${DATA_SOURCE_COLUMN}"`);
         }
-        // 4. Create the view for this data source
-        const quotedNames = sourceNames.map((name) => `'${fileHandleName(name)}'`).join(", ");
+        // 4. Create the view for this data source.
         // filename/file_row_number are pseudo-columns parquet_scan only projects
         // when asked for, and the hidden uid above depends on both.
         const createViewSql = `CREATE VIEW "${aggregateName}"
             AS SELECT ${selectParts.join(", ")}
-            FROM parquet_scan(ARRAY[${quotedNames}], union_by_name = true,
-                filename = true, file_row_number = true);`;
+            FROM parquet_scan(
+                ${handleArrayLiteral(handles)},
+                union_by_name = true,
+                filename = true,
+                file_row_number = true
+            );`;
         await this.execute(createViewSql);
         this.parquetDirectViewNames.add(aggregateName);
     }
@@ -1055,7 +1157,7 @@ export default abstract class DatabaseService {
         name: string,
         logicalColumn: string
     ): Promise<string | null> {
-        const rawColumns = await this.getRawParquetColumns(name);
+        const rawColumns = await this.getRawParquetColumns(this.handlesFor(name));
         const actualToPreDefined = getActualToPreDefinedColumnMap(rawColumns);
         for (const [actual, predefined] of actualToPreDefined) {
             if (predefined === logicalColumn) {
@@ -1118,7 +1220,7 @@ export default abstract class DatabaseService {
          */
         const nullGroupCountSql = `
             SELECT COUNT(*) AS null_group_count,
-            FROM parquet_metadata('${fileHandleName(filename)}')
+            FROM parquet_metadata(${handleArrayLiteral(this.handlesFor(filename))})
             WHERE path_in_schema = '${column}'
             AND stats_null_count > 0`;
         const nullGroupCount = (await this.query(nullGroupCountSql).promise)[0].null_group_count;
@@ -1128,7 +1230,7 @@ export default abstract class DatabaseService {
 
         const validationSql = `
             SELECT COUNT(*) AS no_data_count,
-            FROM parquet_metadata('${fileHandleName(filename)}')
+            FROM parquet_metadata(${handleArrayLiteral(this.handlesFor(filename))})
             WHERE path_in_schema = '${column}'
             AND (
                 stats_null_count IS NULL
@@ -1147,7 +1249,7 @@ export default abstract class DatabaseService {
         // whitespace and/or non-printable control characters.
         const lowMinCountSql = `
             SELECT COUNT(*) as low_min_count,
-            FROM parquet_metadata('${fileHandleName(filename)}')
+            FROM parquet_metadata(${handleArrayLiteral(this.handlesFor(filename))})
             WHERE path_in_schema = '${column}'
             AND stats_min_value < '!'`;
         const lowMinCount = (await this.query(lowMinCountSql).promise)[0].low_min_count;
@@ -1190,9 +1292,9 @@ export default abstract class DatabaseService {
             await this.deleteDataSource(this.currentAggregateSource);
         }
 
-        const isParquet = dataSources.some((source) => source.type === "parquet");
+        const isParquet = dataSources.some((source) => isParquetBacked(source.type));
         if (isParquet) {
-            if (!dataSources.every((source) => source.type === "parquet")) {
+            if (!dataSources.every((source) => isParquetBacked(source.type))) {
                 throw new DataSourcePreparationError(
                     "Parquet tables cannot be aggregated with non-parquet tables.",
                     viewName
@@ -1476,8 +1578,10 @@ export default abstract class DatabaseService {
 
     // Similar to getColumnsOnDataSource below, but suitable for use during the
     // data source preparation step.
-    private async getRawParquetColumns(name: string): Promise<string[]> {
-        const sql = `DESCRIBE SELECT * FROM parquet_scan("${fileHandleName(name)}")`;
+    private async getRawParquetColumns(handles: string[]): Promise<string[]> {
+        const sql = `DESCRIBE SELECT * FROM parquet_scan(
+            ${handleArrayLiteral(handles)}
+        )`;
         const rows = await this.query(sql).promise;
         return rows.map((row) => row["column_name"] as string);
     }

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -93,6 +93,13 @@ function handleArrayLiteral(handles: string[]): string {
     return `ARRAY[${handles.map((handle) => `'${handle}'`).join(", ")}]`;
 }
 
+/**
+ * Recover the logical data source name from a DuckDB file handle.
+ */
+function sourceNameFromHandleExpression(handleColumn: string): string {
+    return `REGEXP_REPLACE(${handleColumn}, '${FILE_HANDLE_SUFFIX}.*$', '')`;
+}
+
 // Check if a value is a non-empty string. Returns true for any string with at least one non-whitespace character.
 function isValidString(value: unknown): value is string {
     return typeof value === "string" && !isEmpty(value.trim());
@@ -363,7 +370,7 @@ export default abstract class DatabaseService {
             );
         }
 
-const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
+        const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
         const handles = dataFileUrls.map((_, index) => deltaFileHandleName(name, index));
         this.sourceToHandles.set(name, handles);
         await this.registerFileURLs(handles, dataFileUrls);
@@ -1231,9 +1238,13 @@ const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
                 `AS "${HIDDEN_UID_ANNOTATION}"`
         );
         if (sourceNames.length > 1) {
-            selectParts.push(`"${SOURCE_FILE_COLUMN}" AS "${DATA_SOURCE_COLUMN}"`);
+            selectParts.push(
+                `${sourceNameFromHandleExpression(
+                    `"${SOURCE_FILE_COLUMN}"`
+                )} AS "${DATA_SOURCE_COLUMN}"`
+            );
         }
-        // 4. Create the view for this data source.
+        // 4. Create the view for this data source
         const createViewSql = `CREATE VIEW "${aggregateName}"
             AS SELECT ${selectParts.join(", ")}
             FROM parquet_scan(
@@ -1674,7 +1685,7 @@ const dataFileUrls = await this.deltaLakeService.listDataFiles(uri);
     // Similar to getColumnsOnDataSource below, but suitable for use during the
     // data source preparation step.
     private async getRawParquetColumns(handles: string[]): Promise<string[]> {
-const sql = `DESCRIBE SELECT * FROM parquet_scan(
+        const sql = `DESCRIBE SELECT * FROM parquet_scan(
             ${handleArrayLiteral(handles)},
             union_by_name = true
         )`;

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -445,8 +445,6 @@ describe("DatabaseService", () => {
 
             class MockDeltaDatabaseService extends DatabaseService {
                 public executedSQL: string[] = [];
-                public deltaProbeCount = 0;
-                public isDelta = true;
 
                 constructor(
                     private readonly parquetColumnsBySource: Record<string, string[]>,
@@ -455,8 +453,7 @@ describe("DatabaseService", () => {
                     const deltaLakeService = {
                         listDataFiles: () => Promise.resolve(dataFiles),
                         isDeltaTable: () => {
-                            this.deltaProbeCount += 1;
-                            return Promise.resolve(this.isDelta);
+                            return Promise.resolve(true);
                         },
                     } as any;
                     super(deltaLakeService);

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -436,7 +436,9 @@ describe("DatabaseService", () => {
             expect(createViewSql).to.not.be.undefined;
             expect(createViewSql).to.match(/parquet_scan\(\s*ARRAY\[/);
             expect(createViewSql).to.include("union_by_name = true");
-            expect(createViewSql).to.include(`"bff_source_file" AS "Data source"`);
+            expect(createViewSql).to.include(
+                `REGEXP_REPLACE("bff_source_file", '-bff-filehandle.*$', '') AS "Data source"`
+            );
         });
         describe("delta lake sources", () => {
             const DELTA_SOURCE = "table";
@@ -551,6 +553,32 @@ describe("DatabaseService", () => {
                 expect(createViewSql).to.include(`'table-bff-filehandle-00000000.parquet'`);
                 expect(createViewSql).to.include(`'table-bff-filehandle-00000001.parquet'`);
                 expect(createViewSql).to.include("union_by_name = true");
+            });
+
+            it('shows one "Data source" per logical source, not per data file', async () => {
+                const service = new MockDeltaDatabaseService(
+                    { table: ["File Path"], "a.parquet": ["File Path"] },
+                    DATA_FILES
+                );
+
+                await service.prepareDataSources(
+                    [
+                        { name: "table", type: "delta", uri: "s3://bucket/table" },
+                        {
+                            name: "a.parquet",
+                            type: "parquet",
+                            uri: "https://example.com/a.parquet",
+                        },
+                    ],
+                    true
+                );
+
+                const createViewSql = service.executedSQL.find((sql) =>
+                    sql.includes(`CREATE VIEW "a.parquet, table"`)
+                );
+                expect(createViewSql).to.include(
+                    `REGEXP_REPLACE("bff_source_file", '-bff-filehandle.*$', '') AS "Data source"`
+                );
             });
 
             it("aggregates with plain parquet sources rather than rejecting them", async () => {

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -304,13 +304,21 @@ describe("DatabaseService", () => {
 
             public query(sql: string): { promise: Promise<any> } {
                 const parquetDescribeMatch = sql.match(
-                    /DESCRIBE SELECT \* FROM parquet_scan\("(.+)-bff-filehandle"\)/
+                    /DESCRIBE SELECT \* FROM parquet_scan\(\s*ARRAY\[([\s\S]*?)\]/
                 );
                 if (parquetDescribeMatch) {
-                    const sourceName = parquetDescribeMatch[1];
-                    const columns = this.parquetColumnsBySource[sourceName] || [];
+                    // Recover the source name from each handle
+                    const columns = new Set<string>();
+                    for (const match of parquetDescribeMatch[1].matchAll(/'([^']+)'/g)) {
+                        const sourceName = match[1].split("-bff-filehandle")[0];
+                        (this.parquetColumnsBySource[sourceName] || []).forEach((column) =>
+                            columns.add(column)
+                        );
+                    }
                     return {
-                        promise: Promise.resolve(columns.map((column_name) => ({ column_name }))),
+                        promise: Promise.resolve(
+                            [...columns].map((column_name) => ({ column_name }))
+                        ),
                     };
                 }
                 return { promise: Promise.resolve([]) };
@@ -485,7 +493,7 @@ describe("DatabaseService", () => {
 
                 public query(sql: string): { promise: Promise<any> } {
                     const parquetDescribeMatch = sql.match(
-                        /DESCRIBE SELECT \* FROM parquet_scan\(ARRAY\[(.+?)\]/
+                        /DESCRIBE SELECT \* FROM parquet_scan\(\s*ARRAY\[([\s\S]*?)\]/
                     );
                     if (parquetDescribeMatch) {
                         // Recover the source name from each file handle. A Delta source

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -370,8 +370,9 @@ describe("DatabaseService", () => {
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
             expect(createViewSql).to.not.be.undefined;
-            expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo-bff-filehandle'.*]/);
-            expect(createViewSql).to.match(/parquet_scan\(ARRAY\[.*'foo2-bff-filehandle'.*]/);
+            expect(createViewSql).to.match(/parquet_scan\(\s*ARRAY\[/);
+            expect(createViewSql).to.include("'foo-bff-filehandle'");
+            expect(createViewSql).to.include("'foo2-bff-filehandle'");
         });
 
         it("qualifies the hidden UID by filename so it stays unique across files", async () => {
@@ -430,9 +431,147 @@ describe("DatabaseService", () => {
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
             expect(createViewSql).to.not.be.undefined;
-            expect(createViewSql).to.include("parquet_scan(ARRAY[");
+            expect(createViewSql).to.match(/parquet_scan\(\s*ARRAY\[/);
             expect(createViewSql).to.include("union_by_name = true");
             expect(createViewSql).to.include(`"filename" AS "Data source"`);
+        });
+        describe("delta lake sources", () => {
+            const DELTA_SOURCE = "table";
+
+            class MockDeltaDatabaseService extends DatabaseService {
+                public executedSQL: string[] = [];
+                public deltaProbeCount = 0;
+                public isDelta = true;
+
+                constructor(
+                    private readonly parquetColumnsBySource: Record<string, string[]>,
+                    dataFiles: string[]
+                ) {
+                    const deltaLakeService = {
+                        listDataFiles: () => Promise.resolve(dataFiles),
+                        isDeltaTable: () => {
+                            this.deltaProbeCount += 1;
+                            return Promise.resolve(this.isDelta);
+                        },
+                    } as any;
+                    super(deltaLakeService);
+                    // The delta source must go through addDataSource for its data
+                    // files to be registered, so leave it out of the pre-registered set.
+                    Object.keys(parquetColumnsBySource)
+                        .filter((sourceName) => sourceName !== DELTA_SOURCE)
+                        .forEach((sourceName) => this.existingDataSources.add(sourceName));
+                }
+
+                public execute(sql: string): Promise<void> {
+                    this.executedSQL.push(sql);
+                    return Promise.resolve();
+                }
+
+                // Delta sources go through the real addDataSource, so stub out the
+                // pieces that need the network and a live database.
+                public registeredURLs: { handle: string; url: string }[] = [];
+
+                protected addDataSource(
+                    name: string,
+                    type: string,
+                    uri: string | File
+                ): Promise<void> {
+                    if (type === "delta") {
+                        return super.addDataSource(name, type as any, uri);
+                    }
+                    return Promise.resolve();
+                }
+
+                protected async registerFileURLs(handles: string[], urls: string[]): Promise<void> {
+                    handles.forEach((handle, index) =>
+                        this.registeredURLs.push({ handle, url: urls[index] })
+                    );
+                }
+
+                public query(sql: string): { promise: Promise<any> } {
+                    const parquetDescribeMatch = sql.match(
+                        /DESCRIBE SELECT \* FROM parquet_scan\(ARRAY\[(.+?)\]/
+                    );
+                    if (parquetDescribeMatch) {
+                        // Recover the source name from each file handle. A Delta source
+                        // registers many handles, all prefixed with its source name.
+                        const columns = new Set<string>();
+                        for (const match of parquetDescribeMatch[1].matchAll(/'([^']+)'/g)) {
+                            const sourceName = match[1].split("-bff-filehandle")[0];
+                            (this.parquetColumnsBySource[sourceName] || []).forEach((column) =>
+                                columns.add(column)
+                            );
+                        }
+                        return {
+                            promise: Promise.resolve(
+                                [...columns].map((column_name) => ({ column_name }))
+                            ),
+                        };
+                    }
+                    return { promise: Promise.resolve([]) };
+                }
+            }
+
+            const DATA_FILES = [
+                "https://example.com/table/part-00000.snappy.parquet",
+                "https://example.com/table/part-00001.snappy.parquet",
+            ];
+
+            it("registers one file handle per parquet data file", async () => {
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+
+                // Skip normalization: these assert on registration and SQL shape,
+                // not on data source validation.
+                await service.prepareDataSources(
+                    [{ name: "table", type: "delta", uri: "s3://bucket/table" }],
+                    true
+                );
+
+                expect(service.registeredURLs).to.deep.equal([
+                    { handle: "table-bff-filehandle-00000000.parquet", url: DATA_FILES[0] },
+                    { handle: "table-bff-filehandle-00000001.parquet", url: DATA_FILES[1] },
+                ]);
+            });
+
+            it("scans every data file from a single view", async () => {
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+
+                await service.prepareDataSources(
+                    [{ name: "table", type: "delta", uri: "s3://bucket/table" }],
+                    true
+                );
+
+                const createViewSql = service.executedSQL.find((sql) =>
+                    sql.includes("CREATE VIEW")
+                );
+                expect(createViewSql).to.include(`CREATE VIEW "table"`);
+                expect(createViewSql).to.include(`'table-bff-filehandle-00000000.parquet'`);
+                expect(createViewSql).to.include(`'table-bff-filehandle-00000001.parquet'`);
+                expect(createViewSql).to.include("union_by_name = true");
+            });
+
+            it("aggregates with plain parquet sources rather than rejecting them", async () => {
+                // A Delta table is parquet underneath, so it must not trip the
+                // "parquet cannot be aggregated with non-parquet" guard.
+                const service = new MockDeltaDatabaseService(
+                    { table: ["File Path"], "a.parquet": ["File Path"] },
+                    DATA_FILES
+                );
+
+                await service.prepareDataSources(
+                    [
+                        { name: "table", type: "delta", uri: "s3://bucket/table" },
+                        {
+                            name: "a.parquet",
+                            type: "parquet",
+                            uri: "https://example.com/a.parquet",
+                        },
+                    ],
+                    true
+                );
+
+                expect(service.hasAggregateSource(["table", "a.parquet"])).to.be.true;
+            });
         });
     });
 

--- a/packages/core/services/DeltaLakeService/index.ts
+++ b/packages/core/services/DeltaLakeService/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Treats a Delta Lake table as a collection of parquet files
+ * by traversing the transaction log and grabbing relevant .parquet
+ * files.
+ * 
+ * This is a stopgap until DuckDB-wasm supports Delta Lake natively.
+ */
+export default class DeltaLakeService {
+
+    /**
+     * True if the URL points at the root of a Delta Lake table.
+     *
+     * Checks for presense of conventional log and checkpoint files,
+     * but does not guarantee the table is readable beyond that.
+     */
+    public async isDeltaTable(_url: string): Promise<boolean> {
+        return false;
+    }
+
+    /**
+     * The parquet data files making up the table's current snapshot, as URLs.
+     */
+    public async listDataFiles(_url: string): Promise<string[]> {
+        return [];
+    }
+}

--- a/packages/core/services/DeltaLakeService/index.ts
+++ b/packages/core/services/DeltaLakeService/index.ts
@@ -10,7 +10,7 @@ export default class DeltaLakeService {
     /**
      * True if the URL points at the root of a Delta Lake table.
      *
-     * Checks for presense of conventional log and checkpoint files,
+     * Checks for presence of conventional log and checkpoint files,
      * but does not guarantee the table is readable beyond that.
      */
     public async isDeltaTable(_url: string): Promise<boolean> {

--- a/packages/web/src/services/DatabaseServiceWeb/types.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/types.ts
@@ -59,7 +59,9 @@ export type WorkerReqPayload<T extends WorkerMsgType> = {
     };
     [WorkerMsgType.SAVE]: {
         destination: string;
-        format: typeof ACCEPTED_SOURCE_TYPES[number];
+        // Narrower than a source type: a query cannot be saved as a Delta Lake
+        // table, which is a directory rather than a file.
+        format: "csv" | "json" | "parquet";
         id: string;
         sql: string;
     };


### PR DESCRIPTION
## Context
`duckdb-wasm` does not yet support Delta Lake so we have to have some customized code here. The behavior here is intended to mirror how the Node `duckdb` works.

## Changes
Teaches DatabaseService to load a Delta Lake formatted Parquet file.
A Delta table is many parquet files rather than one, so this generalises the existing single-handle assumption: each source now maps to a list of DuckDB file handles, and the parquet view, DESCRIBE and parquet_metadata queries all scan that list.

`DeltaLakeService` is a no-op dummy for now - this branch will not be merged into `main` until downstream branches of this are approved and the integration is tested fully.
