### PR TITLE
Derive data source type on the fly

### DIFF
--- a/packages/core/components/DataSourcePrompt/FilePrompt.tsx
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.tsx
@@ -8,7 +8,12 @@ import { useDispatch } from "react-redux";
 import MarkdownPreview from "./MarkdownPreview";
 import { SecondaryButton, TertiaryButton, TransparentIconButton } from "../Buttons";
 import Tooltip from "../Tooltip";
-import { Source, getNameAndTypeFromSourceUrl, isMarkdownType } from "../../entity/SearchParams";
+import {
+    Source,
+    getNameFromSourceUrl,
+    getResourceNameFromSourceUrl,
+    isMarkdownType,
+} from "../../entity/SearchParams";
 import { ParsedFrontmatter, processMarkdown } from "../../entity/MarkdownFrontMatter";
 import { interaction } from "../../state";
 
@@ -33,10 +38,10 @@ export default function FilePrompt(props: Props) {
     const [shouldHaveFrontmatter, setShouldHaveFrontmatter] = React.useState(false);
     const { onSelectFile } = props;
 
-    // Parse markdown files to provide a preview of the metadata we're able to find
+    // Parse markdown files to provide a preview of the metadata we're able to find.
     const handleMarkdownSource = React.useCallback(
-        (source: Source) => {
-            if (isMarkdownType(source.type)) {
+        (source: Source, extension?: string) => {
+            if (isMarkdownType(extension)) {
                 // Calls the standalone process instead of going through the DB service
                 // since we don't want to cache the result yet
                 processMarkdown(source, false) // skip source normalization since just previewing the data
@@ -63,13 +68,12 @@ export default function FilePrompt(props: Props) {
             const selectedFile = acceptedFiles?.[0];
             if (selectedFile) {
                 // Grab name minus extension
-                const nameAndExtension = selectedFile.name.split(".");
-                const name = nameAndExtension.slice(0, -1).join("");
+                const segments = selectedFile.name.split(".");
+                const name = segments.length > 1 ? segments.slice(0, -1).join(".") : segments[0];
                 // Extension validation is handled by the component itself
-                const extension = nameAndExtension.pop();
-                const source = { name, type: extension, uri: selectedFile };
+                const source = { name, uri: selectedFile };
                 onSelectFile(source);
-                handleMarkdownSource(source);
+                handleMarkdownSource(source, segments.length > 1 ? segments.pop() : undefined);
             }
         },
         [onSelectFile, handleMarkdownSource]
@@ -113,11 +117,14 @@ export default function FilePrompt(props: Props) {
             evt?.preventDefault();
             if (dataSourceURL) {
                 const source = {
-                    ...getNameAndTypeFromSourceUrl(dataSourceURL),
+                    name: getNameFromSourceUrl(dataSourceURL),
                     uri: dataSourceURL,
                 };
                 props.onSelectFile(source);
-                handleMarkdownSource(source);
+                handleMarkdownSource(
+                    source,
+                    getResourceNameFromSourceUrl(dataSourceURL).split(".").pop()
+                );
             }
         },
         10000,
@@ -131,7 +138,7 @@ export default function FilePrompt(props: Props) {
                     <Tooltip content={props.selectedFile.name}>
                         <p className={styles.selectedFile}>
                             {props?.fileLabel}
-                            {props.selectedFile.name}.{props.selectedFile.type}
+                            {props.selectedFile.name}
                         </p>
                     </Tooltip>
                     <TransparentIconButton

--- a/packages/core/components/Modal/QueryCodeSnippet/index.tsx
+++ b/packages/core/components/Modal/QueryCodeSnippet/index.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 
-import BaseModal from "../BaseModal";
-import { interaction } from "../../../state";
 import { ModalProps } from "..";
+import BaseModal from "../BaseModal";
 import CodeSnippet from "../../CodeSnippet";
+import { selection } from "../../../state";
 
 /**
  * Dialog meant to show the user a Code snippet of their active Query
  */
 export default function QueryCodeSnippet({ onDismiss }: ModalProps) {
-    const { code, setup } = useSelector(interaction.selectors.getPythonSnippet);
+    const { code, setup } = useSelector(selection.selectors.getPythonSnippet);
 
     return (
         <BaseModal

--- a/packages/core/components/QueryPart/QueryDataSource.tsx
+++ b/packages/core/components/QueryPart/QueryDataSource.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import QueryPart from ".";
 import { DataSourceType } from "../DataSourcePrompt";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
-import { isMarkdownType, Source } from "../../entity/SearchParams";
+import { isMarkdownSource, Source } from "../../entity/SearchParams";
 import { interaction, metadata, selection } from "../../state";
 
 interface Props {
@@ -35,7 +35,7 @@ export default function QueryDataSource(props: Props) {
                       [
                           ...props.dataSources.filter(
                               (source) =>
-                                  source.name !== mainSource?.name && !isMarkdownType(source.type)
+                                  source.name !== mainSource?.name && !isMarkdownSource(source)
                           ),
                           mainSource,
                       ]

--- a/packages/core/entity/MarkdownFrontMatter/index.ts
+++ b/packages/core/entity/MarkdownFrontMatter/index.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import yaml from "js-yaml";
 
-import { getNameAndTypeFromSourceUrl, Source } from "../SearchParams";
+import { getNameFromSourceUrl, Source } from "../SearchParams";
 import DataSourcePreparationError from "../../errors/DataSourcePreparationError";
 
 export interface DatasetSources {
@@ -64,7 +64,7 @@ export function parseFrontMatter(contents: string, parseSources = true): ParsedF
 }
 
 // Generate source names only when the markdown file is first processed
-// since getNameAndTypeFromSourceUrl uses a new Date every time it's called
+// since getNameFromSourceUrl uses a new Date every time it's called
 function deriveSourcesFromMetadata(metadata: RawDatasetMetadata): ParsedDatasetMetadata {
     let dataSource;
     let provenanceSource;
@@ -74,19 +74,19 @@ function deriveSourcesFromMetadata(metadata: RawDatasetMetadata): ParsedDatasetM
     const descriptionsUrl = metadata.descriptions_url;
     if (datasetUrl) {
         dataSource = {
-            ...getNameAndTypeFromSourceUrl(datasetUrl),
+            name: getNameFromSourceUrl(datasetUrl),
             uri: datasetUrl,
         };
     }
     if (provenanceUrl) {
         provenanceSource = {
-            ...getNameAndTypeFromSourceUrl(provenanceUrl),
+            name: getNameFromSourceUrl(provenanceUrl),
             uri: provenanceUrl,
         };
     }
     if (descriptionsUrl) {
         descriptionsSource = {
-            ...getNameAndTypeFromSourceUrl(descriptionsUrl),
+            name: getNameFromSourceUrl(descriptionsUrl),
             uri: descriptionsUrl,
         };
     }

--- a/packages/core/entity/MarkdownFrontMatter/test/MarkdownFrontMatter.test.ts
+++ b/packages/core/entity/MarkdownFrontMatter/test/MarkdownFrontMatter.test.ts
@@ -157,7 +157,7 @@ A description of the dataset`;
             // Arrange
             const tempFileName = `test-markdown.md`;
             const markdownUri = "https://fake-uri/file.md";
-            const testFile: Source = { name: tempFileName, type: "md", uri: markdownUri };
+            const testFile: Source = { name: tempFileName, uri: markdownUri };
 
             // Act
             const result = await processMarkdown(testFile);
@@ -173,7 +173,7 @@ A description of the dataset`;
             const tempFileName = `test-markdown.md`;
             // this path is just illustrative, does not impact the test
             const userPath = "/user/file/path/we/cannot/access/from/browser";
-            const testFile: Source = { name: tempFileName, type: "md", uri: userPath };
+            const testFile: Source = { name: tempFileName, uri: userPath };
 
             try {
                 // Act

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -5,6 +5,7 @@ import FileSort, { SortOrder } from "../FileSort";
 import type { DatasetSources } from "../MarkdownFrontMatter";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
 import { Column } from "../../state/selection/actions";
+import type { SourceType } from "../../services/DatabaseService";
 
 // Somewhat arbitrary default column width in pixels;
 // used as a fallback when calculating column widths based on content,
@@ -20,20 +21,26 @@ export enum FileView {
     LARGE_THUMBNAIL = "3",
 }
 
+// The formats a source can be read as
 export const MARKDOWN_SOURCE_TYPES = ["markdown", "md"] as const;
 export const TABULAR_SOURCE_TYPES = ["csv", "json", "parquet"] as const;
-export const ACCEPTED_SOURCE_TYPES = [
-    ...TABULAR_SOURCE_TYPES,
-    ...MARKDOWN_SOURCE_TYPES,
-    "delta",
-] as const;
 export function isMarkdownType(type?: string): boolean {
     return (MARKDOWN_SOURCE_TYPES as readonly any[]).includes(type);
 }
 
+/**
+ * Whether a source is a dataset description file.
+ */
+export function isMarkdownSource(source: Source): boolean {
+    // A source with nothing to fetch (e.g. AICS FMS) is never a description file.
+    if (!source.uri) return false;
+    const resource =
+        source.uri instanceof File ? source.uri.name : getResourceNameFromSourceUrl(source.uri);
+    return isMarkdownType(resource.split(".").pop());
+}
+
 export interface Source {
     name: string;
-    type?: typeof ACCEPTED_SOURCE_TYPES[number];
     uri?: string | File;
 }
 
@@ -90,24 +97,27 @@ export const DEFAULT_AICS_FMS_QUERY: SearchParamsComponents = {
     filters: [PAST_YEAR_FILTER],
     provenanceSource: {
         name: "AICS",
-        type: "csv",
         uri: "https://biofile-finder-datasets.s3.us-west-2.amazonaws.com/FMS.provenance.csv",
     },
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 
-export const getNameAndTypeFromSourceUrl = (dataSourceURL: string) => {
-    const uriResource = dataSourceURL.substring(dataSourceURL.lastIndexOf("/") + 1).split("?")[0];
-    const name = `${uriResource} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
-    // Returns undefined if can't find a match
-    let extensionGuess = ACCEPTED_SOURCE_TYPES.find(
-        (validSourcetype) => validSourcetype === uriResource.split(".").pop()
-    );
-    if (!extensionGuess) {
-        console.warn("Assuming the source is csv since no extension was recognized");
-        extensionGuess = "csv";
-    }
-    return { name, type: extensionGuess };
+/**
+ * The last meaningful path segment of a source URL, ignoring any query string
+ * and any trailing slashes (Delta Lake tables are directories, so their URLs
+ * commonly end in "/").
+ */
+export const getResourceNameFromSourceUrl = (dataSourceURL: string): string => {
+    const withoutQuery = dataSourceURL.split("?")[0].replace(/\/+$/, "");
+    return withoutQuery.substring(withoutQuery.lastIndexOf("/") + 1);
+};
+
+/**
+ * The derived name from getResourceNameFromSourceUrl() + a time-based suffix
+ */
+export const getNameFromSourceUrl = (url: string): string => {
+    const name = getResourceNameFromSourceUrl(url);
+    return `${name} (${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()})`;
 };
 
 // We want to eventually use shorthands and other tricks to
@@ -214,9 +224,7 @@ export default class SearchParams {
         let provenanceSourceAlreadyEncoded = false;
         // Check if one of sources is a markdown file. If so, parse it for urls.
         // check that those urls match, or else give preference to the overwritten provided sources
-        const datasetDescriptionSource = urlComponents.sources?.find((source) =>
-            isMarkdownType(source.type)
-        );
+        const datasetDescriptionSource = urlComponents.sources?.find(isMarkdownSource);
         if (datasetDescriptionSource) {
             // Only encode sources that aren't already in the markdown file
             const datasetUrl = cachedSourcesFromDescription?.dataSource?.uri;
@@ -312,7 +320,7 @@ export default class SearchParams {
             ...EMPTY_QUERY_COMPONENTS,
             sources: unparsedURLs.map((uri) => ({
                 uri,
-                ...getNameAndTypeFromSourceUrl(uri),
+                name: getNameFromSourceUrl(uri),
             })),
         };
     }
@@ -336,7 +344,7 @@ export default class SearchParams {
         const parsedSources = unparsedSources.map((unparsedSource) => JSON.parse(unparsedSource));
         const mayHaveProvSource =
             unparsedSourceProvenance ||
-            parsedSources.some((source) => isMarkdownType(source?.type));
+            parsedSources.some((source) => source && isMarkdownSource(source));
 
         const parsedSort = unparsedSort ? JSON.parse(unparsedSort) : undefined;
         if (
@@ -383,7 +391,11 @@ export default class SearchParams {
         };
     }
 
-    public static convertToPython(urlComponents: Partial<SearchParamsComponents>, userOS: string) {
+    public static convertToPython(
+        urlComponents: Partial<SearchParamsComponents>,
+        userOS: string,
+        sourceType?: SourceType
+    ) {
         if (
             (urlComponents?.sources?.length && urlComponents.sources.length > 1) ||
             urlComponents?.sources?.[0]?.name === AICS_FMS_DATA_SOURCE_NAME ||
@@ -391,7 +403,11 @@ export default class SearchParams {
         ) {
             return "# Coming soon";
         }
-        const sourceString = this.convertDataSourceToPython(urlComponents?.sources?.[0], userOS);
+        const sourceString = this.convertDataSourceToPython(
+            urlComponents?.sources?.[0],
+            userOS,
+            sourceType
+        );
         const groupByQueryString =
             urlComponents.hierarchy
                 ?.map((annotation) => this.convertGroupByToPython(annotation))
@@ -448,19 +464,46 @@ export default class SearchParams {
         return `\`${filter.name}\`=="${filter.value}"`;
     }
 
-    private static convertDataSourceToPython(source: Source | undefined, userOS: string) {
+    /**
+     * The Python that loads a data source into a dataframe.
+     */
+    private static convertDataSourceToPythonRead(
+        sourceType: SourceType | undefined,
+        location: string
+    ) {
+        // A Delta Lake table is a directory rather than a file, and pandas has no
+        // reader for it, so it needs the deltalake package.
+        if (sourceType === "delta") {
+            return {
+                imports: "from deltalake import DeltaTable # pip install deltalake\n",
+                code: `df = DeltaTable(${location}).to_pandas().astype('str')`,
+            };
+        }
+
+        // Fall back to CSV when the type was never settled, matching how an
+        // otherwise unidentifiable data source is loaded.
+        return {
+            imports: "",
+            code: `df = pd.read_${sourceType ?? "csv"}(${location}).astype('str')`,
+        };
+    }
+
+    private static convertDataSourceToPython(
+        source: Source | undefined,
+        userOS: string,
+        sourceType?: SourceType
+    ) {
         const isUsingWindowsOS = userOS === "Windows_NT" || userOS.includes("Windows NT");
         const rawFlagForWindows = isUsingWindowsOS ? "r" : "";
 
         if (typeof source?.uri === "string") {
             const comment = "#Convert current datasource file to a pandas dataframe";
+            const { imports, code } = SearchParams.convertDataSourceToPythonRead(
+                sourceType,
+                `${rawFlagForWindows}'${source.uri}'`
+            );
 
-            // Currently suggest setting all fields to strings; otherwise pandas assumes type conversions
-            // TO DO: Address different non-string type conversions
-            const code = `df = pd.read_${source.type}(${rawFlagForWindows}'${source.uri}').astype('str')`;
-            // This only works if we assume that the file types will only be csv, parquet or json
-
-            return `${comment}\n${code}\n\n`;
+            return `${imports}${comment}\n${code}\n\n`;
         } else if (source?.uri) {
             // Any other type, i.e., File. `instanceof` breaks testing library
             // Adding strings to avoid including unwanted white space
@@ -473,8 +516,11 @@ export default class SearchParams {
                 '\traise Exception("Must supply the data source location for the query")\n';
             const inputFileCode = 'input_file = ""' + inputFileLineComment + inputFileError;
 
-            const conversionCode = `df = pd.read_${source.type}(input_file).astype('str')`;
-            return `${inputFileCode}\n${conversionCode}\n\n`;
+            const { imports, code } = SearchParams.convertDataSourceToPythonRead(
+                sourceType,
+                "input_file"
+            );
+            return `${imports}${inputFileCode}\n${code}\n\n`;
         } else return ""; // Safeguard. Should not reach else
     }
 }

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -5,7 +5,6 @@ import FileSort, { SortOrder } from "../FileSort";
 import type { DatasetSources } from "../MarkdownFrontMatter";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
 import { Column } from "../../state/selection/actions";
-import type { SourceType } from "../../services/DatabaseService";
 
 // Somewhat arbitrary default column width in pixels;
 // used as a fallback when calculating column widths based on content,
@@ -39,9 +38,24 @@ export function isMarkdownSource(source: Source): boolean {
     return isMarkdownType(resource.split(".").pop());
 }
 
+// Every format a source can be read as. Kept off Source deliberately: a
+// source's type is derived from its uri when it loads, never persisted, so
+// nothing here is part of what a shareable URL carries.
+export const ACCEPTED_SOURCE_TYPES = [
+    ...TABULAR_SOURCE_TYPES,
+    ...MARKDOWN_SOURCE_TYPES,
+    "delta",
+] as const;
+export type SourceType = typeof ACCEPTED_SOURCE_TYPES[number];
+
 export interface Source {
     name: string;
     uri?: string | File;
+}
+
+// A source with its reader settled, as everything past type resolution sees it.
+export interface SourceWithType extends Source {
+    type: SourceType;
 }
 
 // Components of the application state this captures

--- a/packages/core/entity/SearchParams/index.ts
+++ b/packages/core/entity/SearchParams/index.ts
@@ -475,7 +475,7 @@ export default class SearchParams {
         // reader for it, so it needs the deltalake package.
         if (sourceType === "delta") {
             return {
-                imports: "from deltalake import DeltaTable # pip install deltalake\n",
+                imports: "from deltalake import DeltaTable\n",
                 code: `df = DeltaTable(${location}).to_pandas().astype('str')`,
             };
         }

--- a/packages/core/entity/SearchParams/test/searchparams.test.ts
+++ b/packages/core/entity/SearchParams/test/searchparams.test.ts
@@ -1,6 +1,13 @@
 import { expect } from "chai";
 
-import SearchParams, { SearchParamsComponents, FileView, Source, EMPTY_QUERY_COMPONENTS } from "..";
+import SearchParams, {
+    SearchParamsComponents,
+    FileView,
+    Source,
+    EMPTY_QUERY_COMPONENTS,
+    getNameFromSourceUrl,
+    getResourceNameFromSourceUrl,
+} from "..";
 import AnnotationName from "../../Annotation/AnnotationName";
 import FileFilter from "../../FileFilter";
 import ExcludeFilter from "../../FileFilter/ExcludeFilter";
@@ -12,7 +19,6 @@ import FileSort, { SortOrder } from "../../FileSort";
 describe("SearchParams", () => {
     const mockSource: Source = {
         name: "Fake Collection",
-        type: "csv",
     };
 
     const mockSourceUri = "fake-uri.test";
@@ -24,21 +30,18 @@ describe("SearchParams", () => {
     const provenanceSourceUri = "prov-url.csv";
     const mockProvenanceSource: Source = {
         name: "Provenance source",
-        type: "csv",
         uri: provenanceSourceUri,
     };
 
     const colDescrSourceUri = "metadata-url.csv";
     const mockColumnDescriptorSource: Source = {
         name: "Column description source",
-        type: "csv",
         uri: colDescrSourceUri,
     };
 
     const markdownSourceUri = "dataset-descriptions.md";
     const mockMarkdownSource: Source = {
         name: "Dataset description markdown",
-        type: "md",
         uri: markdownSourceUri,
     };
 
@@ -73,7 +76,7 @@ describe("SearchParams", () => {
 
             // Assert
             expect(result).to.be.equal(
-                "group=Cell+Line&group=Donor+Plasmid&group=Lifting%3F&filter=%7B%22name%22%3A%22Cas9%22%2C%22value%22%3A%22spCas9%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22Donor+Plasmid%22%2C%22value%22%3A%22ACTB-mEGFP%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22AICS-0%22%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%2Cfalse%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%2Ctrue%5D&source=%7B%22name%22%3A%22Fake+Collection%22%2C%22type%22%3A%22csv%22%7D&sort=%7B%22annotationName%22%3A%22file_size%22%2C%22order%22%3A%22DESC%22%7D"
+                "group=Cell+Line&group=Donor+Plasmid&group=Lifting%3F&filter=%7B%22name%22%3A%22Cas9%22%2C%22value%22%3A%22spCas9%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22Donor+Plasmid%22%2C%22value%22%3A%22ACTB-mEGFP%22%2C%22type%22%3A%22default%22%7D&openFolder=%5B%22AICS-0%22%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%2Cfalse%5D&openFolder=%5B%22AICS-0%22%2C%22ACTB-mEGFP%22%2Ctrue%5D&source=%7B%22name%22%3A%22Fake+Collection%22%7D&sort=%7B%22annotationName%22%3A%22file_size%22%2C%22order%22%3A%22DESC%22%7D"
             );
         });
 
@@ -118,7 +121,7 @@ describe("SearchParams", () => {
 
             // Assert
             expect(result).to.be.equal(
-                "group=Cell+Line&group=Well.Dose.Solution.Name&filter=%7B%22name%22%3A%22file_name%22%2C%22value%22%3A%22testname.csv%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22file_path%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22fuzzy%22%7D&filter=%7B%22name%22%3A%22Gene%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22exclude%22%7D&filter=%7B%22name%22%3A%22Cell+Line%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22include%22%7D&source=%7B%22name%22%3A%22Fake+Collection%22%2C%22type%22%3A%22csv%22%7D&sort=%7B%22annotationName%22%3A%22file_size%22%2C%22order%22%3A%22DESC%22%7D"
+                "group=Cell+Line&group=Well.Dose.Solution.Name&filter=%7B%22name%22%3A%22file_name%22%2C%22value%22%3A%22testname.csv%22%2C%22type%22%3A%22default%22%7D&filter=%7B%22name%22%3A%22file_path%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22fuzzy%22%7D&filter=%7B%22name%22%3A%22Gene%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22exclude%22%7D&filter=%7B%22name%22%3A%22Cell+Line%22%2C%22value%22%3A%22%22%2C%22type%22%3A%22include%22%7D&source=%7B%22name%22%3A%22Fake+Collection%22%7D&sort=%7B%22annotationName%22%3A%22file_size%22%2C%22order%22%3A%22DESC%22%7D"
             );
         });
 
@@ -151,7 +154,6 @@ describe("SearchParams", () => {
                 sources: [
                     {
                         name: "Fake Collection",
-                        type: "csv",
                         uri: "fake-uri.test",
                     },
                 ],
@@ -162,7 +164,7 @@ describe("SearchParams", () => {
 
             // Assert
             expect(result).to.be.equal(
-                "source=%7B%22name%22%3A%22Fake+Collection%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22fake-uri.test%22%7D"
+                "source=%7B%22name%22%3A%22Fake+Collection%22%2C%22uri%22%3A%22fake-uri.test%22%7D"
             );
         });
 
@@ -170,7 +172,6 @@ describe("SearchParams", () => {
             // Arrange
             const mockSourceWithoutUri: Source = {
                 name: "datasource-without-uri",
-                type: "csv",
             };
             const components: SearchParamsComponents = {
                 columns: [],
@@ -336,6 +337,61 @@ describe("SearchParams", () => {
             expect(result).to.not.contain("non-matching-uri");
             expect(result).to.contain(colDescrSourceUri);
         });
+        it("round-trips a directory-style source URL", () => {
+            // Arrange
+            const source: Source = {
+                name: "table",
+                uri: "s3://some-bucket/data/table",
+            };
+            const components: SearchParamsComponents = {
+                columns: [],
+                fileView: FileView.LIST,
+                hierarchy: [],
+                filters: [],
+                openFolders: [],
+                sources: [source],
+            };
+
+            // Act
+            const result = SearchParams.decode(SearchParams.encode(components));
+
+            // Assert
+            expect(result.sources).to.deep.equal([source]);
+        });
+    });
+
+    describe("getResourceNameFromSourceUrl", () => {
+        it("returns the last path segment", () => {
+            expect(getResourceNameFromSourceUrl("https://example.com/a/b.parquet")).to.equal(
+                "b.parquet"
+            );
+        });
+
+        it("ignores a query string", () => {
+            expect(
+                getResourceNameFromSourceUrl("https://example.com/a/b.json?versionId=7")
+            ).to.equal("b.json");
+        });
+
+        it("ignores trailing slashes", () => {
+            expect(getResourceNameFromSourceUrl("s3://some-bucket/data/table/")).to.equal("table");
+        });
+    });
+
+    describe("getNameFromSourceUrl", () => {
+        it("names a source after the last segment of its URL", () => {
+            expect(getNameFromSourceUrl("https://example.com/a/b.parquet")).to.contain("b.parquet");
+        });
+
+        it("adds a suffix so two sources sharing a filename do not collide", () => {
+            const name = getNameFromSourceUrl("https://a.example.com/proj1/manifest.csv");
+            expect(name).to.contain("manifest.csv");
+            expect(name).to.not.equal("manifest.csv");
+        });
+
+        it("names a directory URL after its last segment, ignoring trailing slashes", () => {
+            expect(getNameFromSourceUrl("s3://some-bucket/data/table/")).to.contain("table");
+        });
     });
 
     describe("decode", () => {
@@ -355,7 +411,6 @@ describe("SearchParams", () => {
                     {
                         // This grabs a date and isn't particularly important so just stub it out
                         name: result.sources[0].name,
-                        type: "csv",
                         uri: testUrl,
                     },
                 ],

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -231,8 +231,6 @@ export default abstract class DatabaseService {
     // Data sources backed by more than one parquet file (i.e. Delta Lake tables)
     // map to the full list of DuckDB file handles registered for them.
     private readonly sourceToHandles = new Map<string, string[]>();
-    // Distinguishes the DuckDB handle used for each checkpoint parquet read.
-    // Probing a URL for "_delta_log" costs a request, so remember the answer.
     private readonly resolvedTypeByUri = new Map<string, SourceType>();
 
     protected database: duckdb.AsyncDuckDB | undefined;

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -13,8 +13,9 @@ import {
     processMarkdown,
 } from "../../entity/MarkdownFrontMatter";
 import {
-    ACCEPTED_SOURCE_TYPES,
+    getResourceNameFromSourceUrl,
     isMarkdownType,
+    MARKDOWN_SOURCE_TYPES,
     Source,
     TABULAR_SOURCE_TYPES,
 } from "../../entity/SearchParams";
@@ -76,10 +77,29 @@ function fileHandleName(name: string): string {
     return name + FILE_HANDLE_SUFFIX;
 }
 
+export const ACCEPTED_SOURCE_TYPES = [
+    ...TABULAR_SOURCE_TYPES,
+    ...MARKDOWN_SOURCE_TYPES,
+    "delta",
+] as const;
 export type SourceType = typeof ACCEPTED_SOURCE_TYPES[number];
+
+export interface SourceWithType extends Source {
+    type: SourceType;
+}
+
 // Return true if type is parquet or parquet-like
 function isParquetBacked(type?: SourceType): boolean {
     return type === "parquet" || type === "delta";
+}
+
+/**
+ * The reader implied by a file name or URL's extension, or undefined when there
+ * is no recognized extension
+ */
+function sourceTypeFromExtension(nameOrUrl: string): SourceType | undefined {
+    const extension = getResourceNameFromSourceUrl(nameOrUrl).split(".").pop();
+    return ACCEPTED_SOURCE_TYPES.find((accepted) => accepted === extension);
 }
 
 // A Delta Lake source is backed by many parquet files, so it registers one handle
@@ -211,6 +231,9 @@ export default abstract class DatabaseService {
     // Data sources backed by more than one parquet file (i.e. Delta Lake tables)
     // map to the full list of DuckDB file handles registered for them.
     private readonly sourceToHandles = new Map<string, string[]>();
+    // Distinguishes the DuckDB handle used for each checkpoint parquet read.
+    // Probing a URL for "_delta_log" costs a request, so remember the answer.
+    private readonly resolvedTypeByUri = new Map<string, SourceType>();
 
     protected database: duckdb.AsyncDuckDB | undefined;
 
@@ -685,14 +708,20 @@ export default abstract class DatabaseService {
         dataSources: Source[],
         skipNormalization = false
     ): Promise<void> {
-        const markdownSources = dataSources.filter((source) => isMarkdownType(source.type));
+        const sourcesWithTypes = await Promise.all(
+            dataSources.map((dataSource) => this.withResolvedType(dataSource))
+        );
+
+        const markdownSources = sourcesWithTypes.filter((source) => isMarkdownType(source.type));
         const additionalSourcesToPrepare = await Promise.all(
-            markdownSources.map((markdownSource) => this.getDataSourcesFromMarkdown(markdownSource))
+            markdownSources.map(async (markdownSource) =>
+                this.withResolvedType(await this.getDataSourcesFromMarkdown(markdownSource))
+            )
         );
         // Account for the possibility of duplicate sources
         const sourcesToPrepare = uniqBy(
             [
-                ...dataSources.filter((source) => !isMarkdownType(source.type)),
+                ...sourcesWithTypes.filter((source) => !isMarkdownType(source.type)),
                 ...additionalSourcesToPrepare,
             ],
             "name"
@@ -712,13 +741,53 @@ export default abstract class DatabaseService {
         }
     }
 
+    /**
+     * Synchronous check for what the source's type is.
+     * Returns undefined if it cannot be determined without going to the network.
+     */
+    public getResolvedType(dataSource: Source): SourceType | undefined {
+        return dataSource.uri ? this.cachedTypeFor(dataSource.uri) : undefined;
+    }
+
+    /**
+     * Work out how to read a data source from where it lives.
+     */
+    private async resolveSourceType(uri: string | File): Promise<SourceType> {
+        const type = this.cachedTypeFor(uri);
+        if (type) return type;
+
+        if (uri instanceof File) return "csv";
+
+        // Default to CSV if unable to determine if source is a Delta Lake table
+        const deltaOrCsv = (await this.deltaLakeService.isDeltaTable(uri)) ? "delta" : "csv";
+        this.resolvedTypeByUri.set(uri, deltaOrCsv);
+        return deltaOrCsv;
+    }
+
+    /**
+     * The type of a source without going to the network: what its extension says,
+     * or what a previous probe concluded. Undefined when neither has an answer.
+     */
+    private cachedTypeFor(uri: string | File): SourceType | undefined {
+        return uri instanceof File
+            ? sourceTypeFromExtension(uri.name)
+            : sourceTypeFromExtension(uri) ?? this.resolvedTypeByUri.get(uri);
+    }
+
+    private async withResolvedType(dataSource: Source): Promise<SourceWithType> {
+        return {
+            ...dataSource,
+            type: dataSource.uri ? await this.resolveSourceType(dataSource.uri) : "csv",
+        };
+    }
+
     private async prepareDataSourceWrapper(
-        dataSource: Source,
+        dataSource: SourceWithType,
         skipNormalization: boolean
     ): Promise<void> {
-        const { name, type, uri } = dataSource;
+        const { name, uri } = dataSource;
 
-        if (!type || !uri) {
+        if (!uri) {
             throw new DataSourcePreparationError(
                 `Lost access to data source "${name}".\
                 </br> \
@@ -770,12 +839,12 @@ export default abstract class DatabaseService {
     }
 
     protected async prepareDataSource(
-        dataSource: Source,
+        dataSource: SourceWithType,
         skipNormalization: boolean
     ): Promise<void> {
-        const { name, type, uri } = dataSource;
+        const { name, uri, type } = dataSource;
 
-        if (!type || !uri) {
+        if (!uri) {
             throw new DataSourcePreparationError(
                 `Lost access to data source "${name}".\
                 </br> \
@@ -814,7 +883,7 @@ export default abstract class DatabaseService {
         }
     }
 
-    protected async getDataSourcesFromMarkdown(dataSource: Source): Promise<Source> {
+    protected async getDataSourcesFromMarkdown(dataSource: SourceWithType): Promise<Source> {
         if (!isMarkdownType(dataSource.type)) {
             // should not reach this, just a type guard
             throw new Error("Data source is not a markdown file");
@@ -869,7 +938,7 @@ export default abstract class DatabaseService {
             if (!this.hasDataSource(sourceMetadata.name)) {
                 await this.prepareDataSourceWrapper(
                     {
-                        ...sourceMetadata,
+                        ...(await this.withResolvedType(sourceMetadata)),
                         name: sourceMetadata.name,
                     },
                     true
@@ -892,7 +961,7 @@ export default abstract class DatabaseService {
             if (!this.hasDataSource(sourceProvenance.name)) {
                 await this.prepareDataSourceWrapper(
                     {
-                        ...sourceProvenance,
+                        ...(await this.withResolvedType(sourceProvenance)),
                         name: sourceProvenance.name,
                     },
                     true
@@ -1387,7 +1456,7 @@ export default abstract class DatabaseService {
             .join(", ");
     }
 
-    private async aggregateDataSources(dataSources: Source[]): Promise<void> {
+    private async aggregateDataSources(dataSources: SourceWithType[]): Promise<void> {
         const viewName = DatabaseService.combineSourceNames(dataSources);
 
         if (this.currentAggregateSource === viewName) {

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -13,10 +13,12 @@ import {
     processMarkdown,
 } from "../../entity/MarkdownFrontMatter";
 import {
+    ACCEPTED_SOURCE_TYPES,
     getResourceNameFromSourceUrl,
     isMarkdownType,
-    MARKDOWN_SOURCE_TYPES,
     Source,
+    SourceType,
+    SourceWithType,
     TABULAR_SOURCE_TYPES,
 } from "../../entity/SearchParams";
 import SQLBuilder from "../../entity/SQLBuilder";
@@ -75,17 +77,6 @@ const SOURCE_FILE_COLUMN = "bff_source_file";
 const FILE_HANDLE_SUFFIX = "-bff-filehandle";
 function fileHandleName(name: string): string {
     return name + FILE_HANDLE_SUFFIX;
-}
-
-export const ACCEPTED_SOURCE_TYPES = [
-    ...TABULAR_SOURCE_TYPES,
-    ...MARKDOWN_SOURCE_TYPES,
-    "delta",
-] as const;
-export type SourceType = typeof ACCEPTED_SOURCE_TYPES[number];
-
-export interface SourceWithType extends Source {
-    type: SourceType;
 }
 
 // Return true if type is parquet or parquet-like

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -436,6 +436,8 @@ describe("DatabaseService", () => {
             const DELTA_SOURCE = "table";
 
             class MockDeltaDatabaseService extends DatabaseService {
+                public isDelta = true;
+                public deltaProbeCount = 0;
                 public executedSQL: string[] = [];
 
                 constructor(
@@ -445,7 +447,8 @@ describe("DatabaseService", () => {
                     const deltaLakeService = {
                         listDataFiles: () => Promise.resolve(dataFiles),
                         isDeltaTable: () => {
-                            return Promise.resolve(true);
+                            this.deltaProbeCount++;
+                            return Promise.resolve(this.isDelta);
                         },
                     } as any;
                     super(deltaLakeService);

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -512,8 +512,6 @@ describe("DatabaseService", () => {
             ];
 
             it("identifies an untyped URL as delta by probing for _delta_log", async () => {
-                // getNameAndTypeFromSourceUrl leaves type undefined for a URL with
-                // no recognized extension; this is where that gets settled.
                 const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
 
                 await service.prepareDataSources(

--- a/packages/core/services/DatabaseService/test/DatabaseService.test.ts
+++ b/packages/core/services/DatabaseService/test/DatabaseService.test.ts
@@ -109,10 +109,7 @@ describe("DatabaseService", () => {
                 await fs.promises.writeFile(tempFile, "a,b,c\n1,2,3\n4,5,6\n");
                 // Act
                 // Skip normalization
-                await service.prepareDataSources(
-                    [{ name: tempFileName, type, uri: tempFile }],
-                    true
-                );
+                await service.prepareDataSources([{ name: tempFileName, uri: tempFile }], true);
                 // Assert
                 expect(service.hasDataSource(tempFileName)).to.be.true;
             });
@@ -128,9 +125,7 @@ describe("DatabaseService", () => {
 
             // Act
             try {
-                await service.prepareDataSources([
-                    { name: tempFileName, type: "csv", uri: tempFile },
-                ]);
+                await service.prepareDataSources([{ name: tempFileName, uri: tempFile }]);
             } catch (error) {
                 caughtError = error;
             }
@@ -161,9 +156,7 @@ describe("DatabaseService", () => {
 
             // Act
             try {
-                await service.prepareDataSources([
-                    { name: tempFileName, type: "csv", uri: tempFile },
-                ]);
+                await service.prepareDataSources([{ name: tempFileName, uri: tempFile }]);
             } catch (error) {
                 caughtError = error;
             }
@@ -193,9 +186,7 @@ describe("DatabaseService", () => {
 
             // Act
             try {
-                await service.prepareDataSources([
-                    { name: tempFileName, type: "csv", uri: tempFile },
-                ]);
+                await service.prepareDataSources([{ name: tempFileName, uri: tempFile }]);
             } catch (error) {
                 caughtError = error;
             }
@@ -237,7 +228,7 @@ describe("DatabaseService", () => {
                 let caughtError;
                 try {
                     await failingService.prepareDataSources([
-                        { name: "cors-test", type: "csv", uri: "https://example.com/data.csv" },
+                        { name: "cors-test", uri: "https://example.com/data.csv" },
                     ]);
                 } catch (error) {
                     caughtError = error;
@@ -266,7 +257,6 @@ describe("DatabaseService", () => {
                     await failingService.prepareDataSources([
                         {
                             name: "http-error-test",
-                            type: "csv",
                             uri: "https://example.com/data.csv",
                         },
                     ]);
@@ -307,7 +297,8 @@ describe("DatabaseService", () => {
                     /DESCRIBE SELECT \* FROM parquet_scan\(\s*ARRAY\[([\s\S]*?)\]/
                 );
                 if (parquetDescribeMatch) {
-                    // Recover the source name from each handle
+                    // Recover the source name from each file handle. A Delta source
+                    // registers many handles, all prefixed with its source name.
                     const columns = new Set<string>();
                     for (const match of parquetDescribeMatch[1].matchAll(/'([^']+)'/g)) {
                         const sourceName = match[1].split("-bff-filehandle")[0];
@@ -332,8 +323,8 @@ describe("DatabaseService", () => {
             });
 
             await service.prepareDataSources([
-                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+                { name: "a.parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", uri: "https://example.com/b.parquet" },
             ]);
 
             expect(service.hasAggregateSource(["a.parquet", "b.parquet"])).to.be.true;
@@ -348,8 +339,8 @@ describe("DatabaseService", () => {
             let caughtError;
             try {
                 await service.prepareDataSources([
-                    { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                    { name: "b.csv", type: "csv", uri: "https://example.com/b.csv" },
+                    { name: "a.parquet", uri: "https://example.com/a.parquet" },
+                    { name: "b.csv", uri: "https://example.com/b.csv" },
                 ]);
             } catch (error) {
                 caughtError = error;
@@ -372,8 +363,8 @@ describe("DatabaseService", () => {
             });
 
             await service.prepareDataSources([
-                { name: "foo", type: "parquet", uri: "https://example.com/foo.parquet" },
-                { name: "foo2", type: "parquet", uri: "https://example.com/foo2.parquet" },
+                { name: "foo", uri: "https://example.com/foo.parquet" },
+                { name: "foo2", uri: "https://example.com/foo2.parquet" },
             ]);
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
@@ -390,8 +381,8 @@ describe("DatabaseService", () => {
             });
 
             await service.prepareDataSources([
-                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+                { name: "a.parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", uri: "https://example.com/b.parquet" },
             ]);
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
@@ -408,8 +399,8 @@ describe("DatabaseService", () => {
             });
 
             await service.prepareDataSources([
-                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+                { name: "a.parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", uri: "https://example.com/b.parquet" },
             ]);
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
@@ -428,8 +419,8 @@ describe("DatabaseService", () => {
             });
 
             await service.prepareDataSources([
-                { name: "a.parquet", type: "parquet", uri: "https://example.com/a.parquet" },
-                { name: "b.parquet", type: "parquet", uri: "https://example.com/b.parquet" },
+                { name: "a.parquet", uri: "https://example.com/a.parquet" },
+                { name: "b.parquet", uri: "https://example.com/b.parquet" },
             ]);
 
             const createViewSql = service.executedSQL.find((sql) => sql.includes("CREATE VIEW"));
@@ -440,6 +431,7 @@ describe("DatabaseService", () => {
                 `REGEXP_REPLACE("bff_source_file", '-bff-filehandle.*$', '') AS "Data source"`
             );
         });
+
         describe("delta lake sources", () => {
             const DELTA_SOURCE = "table";
 
@@ -519,13 +511,69 @@ describe("DatabaseService", () => {
                 "https://example.com/table/part-00001.snappy.parquet",
             ];
 
+            it("identifies an untyped URL as delta by probing for _delta_log", async () => {
+                // getNameAndTypeFromSourceUrl leaves type undefined for a URL with
+                // no recognized extension; this is where that gets settled.
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+
+                await service.prepareDataSources(
+                    [{ name: "table", uri: "s3://bucket/table" }],
+                    true
+                );
+
+                expect(service.hasDataSource("table")).to.be.true;
+                expect(service.registeredURLs).to.have.lengthOf(2);
+            });
+
+            it("falls back to csv for an untyped URL that is not a delta table", async () => {
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+                service.isDelta = false;
+
+                await service.prepareDataSources(
+                    [{ name: "table", uri: "s3://bucket/table" }],
+                    true
+                );
+
+                expect(service.hasDataSource("table")).to.be.true;
+                expect(service.registeredURLs).to.be.empty;
+            });
+
+            it("does not probe a URL whose extension already identified it", async () => {
+                const service = new MockDeltaDatabaseService(
+                    { "a.parquet": ["File Path"] },
+                    DATA_FILES
+                );
+
+                await service.prepareDataSources(
+                    [{ name: "a.parquet", uri: "https://example.com/a.parquet" }],
+                    true
+                );
+
+                expect(service.deltaProbeCount).to.equal(0);
+            });
+
+            it("probes a given URL only once", async () => {
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+
+                await service.prepareDataSources(
+                    [{ name: "table", uri: "s3://bucket/table" }],
+                    true
+                );
+                await service.prepareDataSources(
+                    [{ name: "table", uri: "s3://bucket/table" }],
+                    true
+                );
+
+                expect(service.deltaProbeCount).to.equal(1);
+            });
+
             it("registers one file handle per parquet data file", async () => {
                 const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
 
                 // Skip normalization: these assert on registration and SQL shape,
                 // not on data source validation.
                 await service.prepareDataSources(
-                    [{ name: "table", type: "delta", uri: "s3://bucket/table" }],
+                    [{ name: "table", uri: "s3://bucket/table" }],
                     true
                 );
 
@@ -538,8 +586,10 @@ describe("DatabaseService", () => {
             it("scans every data file from a single view", async () => {
                 const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
 
+                // Skip normalization: these assert on registration and SQL shape,
+                // not on data source validation.
                 await service.prepareDataSources(
-                    [{ name: "table", type: "delta", uri: "s3://bucket/table" }],
+                    [{ name: "table", uri: "s3://bucket/table" }],
                     true
                 );
 
@@ -560,10 +610,9 @@ describe("DatabaseService", () => {
 
                 await service.prepareDataSources(
                     [
-                        { name: "table", type: "delta", uri: "s3://bucket/table" },
+                        { name: "table", uri: "s3://bucket/table" },
                         {
                             name: "a.parquet",
-                            type: "parquet",
                             uri: "https://example.com/a.parquet",
                         },
                     ],
@@ -579,8 +628,6 @@ describe("DatabaseService", () => {
             });
 
             it("aggregates with plain parquet sources rather than rejecting them", async () => {
-                // A Delta table is parquet underneath, so it must not trip the
-                // "parquet cannot be aggregated with non-parquet" guard.
                 const service = new MockDeltaDatabaseService(
                     { table: ["File Path"], "a.parquet": ["File Path"] },
                     DATA_FILES
@@ -588,10 +635,9 @@ describe("DatabaseService", () => {
 
                 await service.prepareDataSources(
                     [
-                        { name: "table", type: "delta", uri: "s3://bucket/table" },
+                        { name: "table", uri: "s3://bucket/table" },
                         {
                             name: "a.parquet",
-                            type: "parquet",
                             uri: "https://example.com/a.parquet",
                         },
                     ],
@@ -599,6 +645,21 @@ describe("DatabaseService", () => {
                 );
 
                 expect(service.hasAggregateSource(["table", "a.parquet"])).to.be.true;
+            });
+
+            it("never treats an uploaded local file as a Delta table", async () => {
+                // A Delta table is a directory, which the browser cannot hand us
+                // as a File, so there is nothing to probe.
+                const service = new MockDeltaDatabaseService({ table: ["File Path"] }, DATA_FILES);
+
+                await service.prepareDataSources(
+                    [{ name: "table", uri: new File([""], "table") }],
+                    true
+                );
+
+                expect(service.hasDataSource("table")).to.be.true;
+                expect(service.deltaProbeCount).to.equal(0);
+                expect(service.registeredURLs).to.be.empty;
             });
         });
     });

--- a/packages/core/state/interaction/selectors.ts
+++ b/packages/core/state/interaction/selectors.ts
@@ -18,16 +18,9 @@ import {
     getDataSources,
     getEdgeDefinitions,
 } from "../metadata/selectors";
-import {
-    getSelectedDataSources,
-    getPythonConversion,
-    getSelectedSourceMetadata,
-} from "../selection/selectors";
+import { getSelectedDataSources, getSelectedSourceMetadata } from "../selection/selectors";
 import { AnnotationService, FileService } from "../../services";
-import DatasetService, {
-    DataSource,
-    PythonicDataAccessSnippet,
-} from "../../services/DataSourceService";
+import DatasetService, { DataSource } from "../../services/DataSourceService";
 import DatabaseAnnotationService from "../../services/AnnotationService/DatabaseAnnotationService";
 import DatabaseFileService from "../../services/FileService/DatabaseFileService";
 import HttpAnnotationService from "../../services/AnnotationService/HttpAnnotationService";
@@ -151,16 +144,6 @@ export const getExtractMetadataPythonSnippet = (state: State) =>
     state.interaction.extractMetadataPythonSnippet;
 
 export const getConvertFilesSnippet = (state: State) => state.interaction.convertFilesSnippet;
-
-export const getPythonSnippet = createSelector(
-    [getPythonConversion],
-    (pythonQuery): PythonicDataAccessSnippet => {
-        const setup = `pip install \"pandas>=1.5\"`;
-        const code = `${pythonQuery}`;
-
-        return { setup, code };
-    }
-);
 
 export const getUserName = createSelector(
     [getPlatformDependentServices],

--- a/packages/core/state/interaction/selectors.ts
+++ b/packages/core/state/interaction/selectors.ts
@@ -35,7 +35,7 @@ import HttpFileService from "../../services/FileService/HttpFileService";
 import PipelineService from "../../services/PipelineService";
 import S3StorageService from "../../services/S3StorageService";
 import Graph from "../../entity/Graph";
-import { isMarkdownType } from "../../entity/SearchParams";
+import { isMarkdownSource } from "../../entity/SearchParams";
 
 // BASIC SELECTORS
 export const getEnvironment = (state: State) => state.interaction.environment;
@@ -261,7 +261,7 @@ export const getAnnotationService = createSelector(
                 databaseService: platformDependentServices.databaseService,
                 // Don't try to get annotations from markdown files
                 dataSourceNames: dataSources
-                    .filter((source) => !isMarkdownType(source.type))
+                    .filter((source) => !isMarkdownSource(source))
                     .map((source) => source.name),
                 metadataSource,
             });

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -303,7 +303,7 @@ const requestDatasetManifest = createLogic({
 
         try {
             const uri = `${datasetBucketUrl}/Dataset+Manifest.csv`;
-            await databaseService.prepareDataSources([{ name, type: "csv", uri }]);
+            await databaseService.prepareDataSources([{ name, uri }]);
             dispatch(receiveDatasetManifest(name, uri));
         } catch (err) {
             console.error("Failed to add dataset manifest", err);

--- a/packages/core/state/metadata/test/logics.test.ts
+++ b/packages/core/state/metadata/test/logics.test.ts
@@ -315,7 +315,6 @@ describe("Metadata logics", () => {
             {
                 id: "123414",
                 name: "Microscopy Set",
-                type: "csv",
                 version: 1,
                 uri: "",
             },

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -77,7 +77,12 @@ import FileFolder from "../../entity/FileFolder";
 import FileSelection from "../../entity/FileSelection";
 import FileSet from "../../entity/FileSet";
 import { DatasetSources } from "../../entity/MarkdownFrontMatter";
-import { DEFAULT_COLUMN_WIDTH, FileView, isMarkdownType, Source } from "../../entity/SearchParams";
+import {
+    DEFAULT_COLUMN_WIDTH,
+    FileView,
+    isMarkdownSource,
+    Source,
+} from "../../entity/SearchParams";
 import HttpAnnotationService from "../../services/AnnotationService/HttpAnnotationService";
 import { DataSource } from "../../services/DataSourceService";
 import DataSourcePreparationError from "../../errors/DataSourcePreparationError";
@@ -693,7 +698,7 @@ const changeDataSourceLogic = createLogic({
         // markdown files may be present when changeDataSource is called directly from an existing query
         const selectedDataSources = action.payload as Source[];
         const datasetDescriptionSource = selectedDataSources.find((source) =>
-            isMarkdownType(source.type)
+            isMarkdownSource(source)
         );
         if (!datasetDescriptionSource) {
             return next(action);
@@ -732,8 +737,7 @@ const changeDataSourceLogic = createLogic({
                 payload: [
                     // avoid duplicates and remove the markdown file
                     ...selectedDataSources.filter(
-                        (source) =>
-                            !isMarkdownType(source.type) && source.name !== mainDatasource.name
+                        (source) => !isMarkdownSource(source) && source.name !== mainDatasource.name
                     ),
                     mainDatasource,
                 ],
@@ -1021,7 +1025,7 @@ const changeQueryLogic = createLogic({
             let provenanceSource = parts.provenanceSource;
             let columnDescriptionSource = parts.sourceMetadata;
             const datasetDescriptionSource = parts.sources.find((source) => {
-                return isMarkdownType(source.type);
+                return isMarkdownSource(source);
             });
             if (datasetDescriptionSource) {
                 let parsedMetadata: DatasetSources | undefined;
@@ -1057,7 +1061,7 @@ const changeQueryLogic = createLogic({
                         mainSources = [
                             ...parts.sources.filter(
                                 (source) =>
-                                    source.name !== mainSource?.name && !isMarkdownType(source.type)
+                                    source.name !== mainSource?.name && !isMarkdownSource(source)
                             ),
                             mainSource,
                         ];

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -11,6 +11,7 @@ import {
     getAnnotationNameToAnnotationMap,
 } from "../metadata/selectors";
 import { AICS_FMS_DATA_SOURCE_NAME } from "../../constants";
+import { PythonicDataAccessSnippet } from "../../services/DataSourceService";
 
 // BASIC SELECTORS
 export const getAnnotationHierarchy = (state: State) => state.selection.annotationHierarchy;
@@ -173,7 +174,7 @@ export const getLoadingQueryOrSource = createSelector(
     }
 );
 
-export const getPythonConversion = createSelector(
+export const getPythonSnippet = createSelector(
     [
         getPlatformDependentServices,
         getAnnotationHierarchy,
@@ -181,9 +182,21 @@ export const getPythonConversion = createSelector(
         getOpenFileFolders,
         getSortColumn,
         getSelectedDataSources,
+        // Not read below: a source's type is settled while it loads, so this is
+        // what tells the memoized result to recompute once the answer exists.
+        getIsLoadingSource,
     ],
-    (platformDependentServices, hierarchy, filters, openFolders, sortColumn, sources) => {
-        return SearchParams.convertToPython(
+    (
+        platformDependentServices,
+        hierarchy,
+        filters,
+        openFolders,
+        sortColumn,
+        sources
+    ): PythonicDataAccessSnippet => {
+        const sourceType =
+            sources?.[0] && platformDependentServices.databaseService.getResolvedType(sources[0]);
+        const code = SearchParams.convertToPython(
             {
                 hierarchy,
                 filters,
@@ -192,8 +205,10 @@ export const getPythonConversion = createSelector(
                 sources,
             },
             platformDependentServices.executionEnvService.getOS(),
-            sources?.[0] && platformDependentServices.databaseService.getResolvedType(sources[0])
+            sourceType
         );
+        const dependencies = ['"pandas>=1.5"', ...(sourceType === "delta" ? ['"deltalake"'] : [])];
+        return { code, setup: `pip install ${dependencies.join(" ")}` };
     }
 );
 

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -191,7 +191,8 @@ export const getPythonConversion = createSelector(
                 sortColumn,
                 sources,
             },
-            platformDependentServices.executionEnvService.getOS()
+            platformDependentServices.executionEnvService.getOS(),
+            sources?.[0] && platformDependentServices.databaseService.getResolvedType(sources[0])
         );
     }
 );

--- a/packages/core/state/selection/test/logics.test.ts
+++ b/packages/core/state/selection/test/logics.test.ts
@@ -723,7 +723,7 @@ describe("Selection logics", () => {
                     hierarchy: [],
                     filters: [],
                     openFolders: [],
-                    sources: [{ name: dataSourceName, type: "csv", uri }],
+                    sources: [{ name: dataSourceName, uri }],
                 },
             };
         };
@@ -982,12 +982,9 @@ describe("Selection logics", () => {
             // Arrange
             const hierarchy = ["Cell Line"];
             const filters = [new FileFilter("Cell Line", "AICS-13")];
-            const sources: DataSource[] = [
-                { id: "Source", name: "Source", type: "csv", uri: "fake-uri.test" },
-            ];
+            const sources: DataSource[] = [{ id: "Source", name: "Source", uri: "fake-uri.test" }];
             const provenanceSource: Source = {
                 name: "Provenance",
-                type: "csv",
                 uri: "prov-uri.test",
             };
             const selectedQuery = mockQuery("Selected", {
@@ -1033,7 +1030,7 @@ describe("Selection logics", () => {
         });
 
         it("parses sources from a non-cached datasetDescriptionSource", async () => {
-            const mdSource: Source = { name: "README.md", type: "md", uri: "README.md" };
+            const mdSource: Source = { name: "README.md", uri: "README.md" };
             const selectedQuery = mockQuery("Selected", {
                 sources: [mdSource],
             });
@@ -1083,7 +1080,7 @@ describe("Selection logics", () => {
         });
 
         it("parses sources from a cached datasetDescriptionSource", async () => {
-            const mdSource: Source = { name: "README.md", type: "md", uri: "README" };
+            const mdSource: Source = { name: "README.md", uri: "README.md" };
             const selectedQuery = mockQuery("Selected", {
                 sources: [mdSource],
             });
@@ -1133,15 +1130,13 @@ describe("Selection logics", () => {
         it("overrides markdown if provenance/column description sources are provided manually", async () => {
             const provSourceFromUser: Source = {
                 name: "some-other-prov-source",
-                type: "csv",
                 uri: "some-other-prov-url.csv",
             };
             const columnDescriptionsFromUser: Source = {
                 name: "some-other-metadata-source",
-                type: "csv",
                 uri: "some-other-metadata-url.csv",
             };
-            const mdSource: Source = { name: "README.md", type: "md", uri: "README" };
+            const mdSource: Source = { name: "README.md", uri: "README.md" };
             const selectedQuery = mockQuery("Selected", {
                 sources: [mdSource],
                 provenanceSource: provSourceFromUser,

--- a/packages/core/state/selection/test/reducer.test.ts
+++ b/packages/core/state/selection/test/reducer.test.ts
@@ -64,7 +64,6 @@ describe("Selection reducer", () => {
                 {
                     name: "My Tiffs",
                     version: 2,
-                    type: "csv",
                     id: "13123019",
                     uri: "",
                 },

--- a/packages/core/state/selection/test/selectors.test.ts
+++ b/packages/core/state/selection/test/selectors.test.ts
@@ -12,6 +12,45 @@ import ExcludeFilter from "../../../entity/FileFilter/ExcludeFilter";
 import IncludeFilter from "../../../entity/FileFilter/IncludeFilter";
 
 describe("Selection selectors", () => {
+    describe("getPythonSnippet", () => {
+        const stateForSourceType = (uri: string, type?: string) =>
+            mergeState(initialState, {
+                interaction: {
+                    platformDependentServices: {
+                        databaseService: { getResolvedType: () => type },
+                        executionEnvService: { getOS: () => "Darwin" },
+                    },
+                },
+                selection: {
+                    dataSources: [{ name: "source", uri }],
+                },
+            });
+
+        it("installs only pandas for a source pandas can read on its own", () => {
+            // Arrange
+            const state = stateForSourceType("https://example.com/a.csv", "csv");
+
+            // Act
+            const { setup } = selection.selectors.getPythonSnippet(state);
+
+            // Assert
+            expect(setup).to.equal('pip install "pandas>=1.5"');
+        });
+
+        it("adds deltalake and pandas for a Delta source", () => {
+            // Arrange
+            // The snippet reads the table into a dataframe and queries it with
+            // pandas, so deltalake alone would leave `import pandas as pd` failing.
+            const state = stateForSourceType("s3://bucket/table", "delta");
+
+            // Act
+            const { setup } = selection.selectors.getPythonSnippet(state);
+
+            // Assert
+            expect(setup).to.equal('pip install "pandas>=1.5" "deltalake"');
+        });
+    });
+
     describe("getGroupedByFilterName", () => {
         it("leaves display value blank for any/none filters regardless of type", () => {
             // arrange

--- a/packages/web/benchmark/src/index.ts
+++ b/packages/web/benchmark/src/index.ts
@@ -135,7 +135,7 @@ async function main() {
         const warmup = config.testCases[0][0];
         const warmupFile = localFiles[warmup.label];
         await service.prepareDataSources(
-            [{ name: "__bff_warmup__", type: "parquet", uri: warmupFile ?? warmup.url }],
+            [{ name: "__bff_warmup__", uri: warmupFile ?? warmup.url }],
             /* skipNormalization */ true
         );
         await service.execute('DROP VIEW IF EXISTS "__bff_warmup__"');

--- a/packages/web/src/components/OpenSourceDatasets/index.tsx
+++ b/packages/web/src/components/OpenSourceDatasets/index.tsx
@@ -9,7 +9,7 @@ import Modal from "../../../../core/components/Modal";
 import { metadata, selection } from "../../../../core/state";
 import SearchParams, {
     SearchParamsComponents,
-    getNameAndTypeFromSourceUrl,
+    getNameFromSourceUrl,
     Source,
 } from "../../../../core/entity/SearchParams";
 
@@ -58,7 +58,7 @@ export default function OpenSourceDatasets() {
         openDatasetInApp(
             datasetDetails.name,
             {
-                ...getNameAndTypeFromSourceUrl(dataSourceURL),
+                name: getNameFromSourceUrl(dataSourceURL),
                 uri: dataSourceURL,
             },
             url

--- a/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
@@ -8,7 +8,11 @@ import SQLBuilder from "../../../../core/entity/SQLBuilder";
 import { HIDDEN_UID_ANNOTATION } from "../../../../core/constants";
 import DataSourcePreparationError from "../../../../core/errors/DataSourcePreparationError";
 import { DatabaseService } from "../../../../core/services";
-import { CancellablePromise, initializeDuckDB } from "../../../../core/services/DatabaseService";
+import {
+    CancellablePromise,
+    initializeDuckDB,
+    SourceWithType,
+} from "../../../../core/services/DatabaseService";
 
 declare const self: DedicatedWorkerGlobalScope & typeof globalThis;
 let databaseService: DatabaseServiceWebWorker | null = null;
@@ -235,7 +239,7 @@ export default class DatabaseServiceWebWorker extends DatabaseService {
 
     // public wrapper so that the worker can access the function
     public async prepareDataSourceWorker(
-        dataSource: Source,
+        dataSource: SourceWithType,
         skipNormalization: boolean
     ): Promise<void> {
         await this.prepareDataSource(dataSource, skipNormalization);

--- a/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/duckdb-worker.worker.ts
@@ -8,11 +8,8 @@ import SQLBuilder from "../../../../core/entity/SQLBuilder";
 import { HIDDEN_UID_ANNOTATION } from "../../../../core/constants";
 import DataSourcePreparationError from "../../../../core/errors/DataSourcePreparationError";
 import { DatabaseService } from "../../../../core/services";
-import {
-    CancellablePromise,
-    initializeDuckDB,
-    SourceWithType,
-} from "../../../../core/services/DatabaseService";
+import { CancellablePromise, initializeDuckDB } from "../../../../core/services/DatabaseService";
+import { SourceWithType } from "../../../../core/entity/SearchParams";
 
 declare const self: DedicatedWorkerGlobalScope & typeof globalThis;
 let databaseService: DatabaseServiceWebWorker | null = null;

--- a/packages/web/src/services/DatabaseServiceWeb/index.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/index.ts
@@ -13,7 +13,7 @@ import {
     WorkerResType,
 } from "./types";
 import { DatabaseService } from "../../../../core/services";
-import { CancellablePromise } from "../../../../core/services/DatabaseService";
+import { CancellablePromise, SourceWithType } from "../../../../core/services/DatabaseService";
 
 export default class DatabaseServiceWeb extends DatabaseService {
     // Initialize with AICS FMS data source name to pretend it always exists
@@ -186,7 +186,7 @@ export default class DatabaseServiceWeb extends DatabaseService {
     }
 
     protected async prepareDataSource(
-        dataSource: Source,
+        dataSource: SourceWithType,
         skipNormalization: boolean
     ): Promise<void> {
         const { name, type, uri } = dataSource;

--- a/packages/web/src/services/DatabaseServiceWeb/index.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/index.ts
@@ -13,7 +13,8 @@ import {
     WorkerResType,
 } from "./types";
 import { DatabaseService } from "../../../../core/services";
-import { CancellablePromise, SourceWithType } from "../../../../core/services/DatabaseService";
+import { CancellablePromise } from "../../../../core/services/DatabaseService";
+import { SourceWithType } from "../../../../core/entity/SearchParams";
 
 export default class DatabaseServiceWeb extends DatabaseService {
     // Initialize with AICS FMS data source name to pretend it always exists

--- a/packages/web/src/services/DatabaseServiceWeb/types.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/types.ts
@@ -1,5 +1,4 @@
-import { Source, TABULAR_SOURCE_TYPES } from "../../../../core/entity/SearchParams";
-import { SourceType } from "../../../../core/services/DatabaseService";
+import { Source, SourceType, TABULAR_SOURCE_TYPES } from "../../../../core/entity/SearchParams";
 
 export enum WorkerMsgType {
     ADD_SOURCE = "add datasource",

--- a/packages/web/src/services/DatabaseServiceWeb/types.ts
+++ b/packages/web/src/services/DatabaseServiceWeb/types.ts
@@ -1,8 +1,5 @@
-import {
-    ACCEPTED_SOURCE_TYPES,
-    Source,
-    TABULAR_SOURCE_TYPES,
-} from "../../../../core/entity/SearchParams";
+import { Source, TABULAR_SOURCE_TYPES } from "../../../../core/entity/SearchParams";
+import { SourceType } from "../../../../core/services/DatabaseService";
 
 export enum WorkerMsgType {
     ADD_SOURCE = "add datasource",
@@ -74,7 +71,7 @@ export type WorkerReqPayload<T extends WorkerMsgType> = {
     };
     [WorkerMsgType.ADD_SOURCE]: {
         name: string;
-        type: typeof ACCEPTED_SOURCE_TYPES[number];
+        type: SourceType;
         uri: string | File;
         skipNormalization?: boolean;
     };


### PR DESCRIPTION
## Context
This adds support for detecting Delta Lake type files.

## Changes
Type resolution for files (csv, json, parquet, delta) now happens as lazily as possible. This type is largely just needed by the `DatabaseService` to perform various actions. A similar follow-up for removing `name` may be possible later, however this was necessary now because detecting if a file is a Delta Lake requires a network call.

## Testing
Tested with various deltalake files using the next PR - deltalake files were detected as expected and resolutions triggered once in the network tab
