### PR TITLE
Bundle multi-file web downloads into a single zipped download

### DIFF
--- a/packages/core/services/FileDownloadService/index.ts
+++ b/packages/core/services/FileDownloadService/index.ts
@@ -58,6 +58,15 @@ export default abstract class FileDownloadService extends HttpServiceBase {
     ): Promise<DownloadResult>;
 
     /**
+     * Download multiple files bundled together as a single ZIP archive.
+     */
+    downloadFilesAsZip?(
+        files: FileInfo[],
+        downloadRequestId: string,
+        onProgress?: (bytesDownloaded: number) => void
+    ): Promise<DownloadResult>;
+
+    /**
      * Retrieves the file system's default download location.
      */
     abstract getDefaultDownloadDirectory(): Promise<string>;

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -319,7 +319,72 @@ const downloadFilesLogic = createLogic({
         const totalBytesToDownload = sumBy(filesToDownload, "size") || 0;
         const totalBytesDisplay = getBytesDisplay(totalBytesToDownload, someFilesHaveUnknownSize);
 
-        // TODO: Download these into a zip using new streamsaver zipped code
+        if (filesToDownload.length > 1 && fileDownloadService.downloadFilesAsZip) {
+            let isCancelled = false;
+            const downloadRequestId = uniqueId();
+            const fileIds = filesToDownload.map((file) => file.id);
+
+            const onCancel = () => {
+                isCancelled = true;
+                dispatch(cancelFileDownload(downloadRequestId));
+            };
+
+            let totalBytesDownloaded = 0;
+            const throttledProgressDispatcher = throttle((progressMsg: string) => {
+                if (isCancelled) return;
+                dispatch(
+                    processProgress(
+                        downloadRequestId,
+                        totalBytesToDownload ? totalBytesDownloaded / totalBytesToDownload : 0,
+                        progressMsg,
+                        onCancel,
+                        fileIds
+                    )
+                );
+            }, 1000);
+
+            const onProgress = (transferredBytes: number) => {
+                totalBytesDownloaded += transferredBytes;
+
+                const updatedBytesDisplay = numberFormatter.displayValue(
+                    totalBytesDownloaded,
+                    "bytes"
+                );
+                const progressMsg = `Downloading ${filesToDownload.length} files as ZIP. <br/> ${updatedBytesDisplay} out of ${totalBytesDisplay} set to download`;
+                throttledProgressDispatcher(progressMsg);
+            };
+
+            try {
+                const msg = `Downloading ${filesToDownload.length} files as ZIP. <br/> ${totalBytesDisplay} set to download`;
+                dispatch(processStart(downloadRequestId, msg, onCancel, fileIds));
+
+                const result = await fileDownloadService.downloadFilesAsZip(
+                    filesToDownload,
+                    downloadRequestId,
+                    onProgress
+                );
+
+                if (result.resolution === DownloadResolution.CANCELLED) {
+                    onCancel();
+                } else {
+                    dispatch(
+                        processSuccess(
+                            downloadRequestId,
+                            result.msg || "Download completed successfully."
+                        )
+                    );
+                }
+            } catch (err) {
+                const errorMsg = `File download failed. Details:<br/>${
+                    err instanceof Error ? err.message : err
+                }`;
+                dispatch(processError(downloadRequestId, errorMsg));
+            }
+
+            done();
+            return;
+        }
+
         await Promise.allSettled(
             filesToDownload.map(async (file) => {
                 let isCancelled = false;

--- a/packages/web/src/entity/StreamedZipDownloader/index.ts
+++ b/packages/web/src/entity/StreamedZipDownloader/index.ts
@@ -97,6 +97,7 @@ export default class StreamedZipDownloader {
     public async end() {
         if (this.isCancelled) return;
         await this.taskQueue.drain();
+        if (this.isCancelled) return;
         this.zip.end();
         await this.finalizeWriter("close");
     }
@@ -105,7 +106,9 @@ export default class StreamedZipDownloader {
         if (this.isCancelled) return;
         this.isCancelled = true;
         await this.taskQueue.cancel();
-        this.zip.terminate();
+        if (!this.writerFinalized) {
+            this.zip.terminate();
+        }
         await this.finalizeWriter("abort");
     }
 

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -13,8 +13,6 @@ import Zarr from "../entity/Zarr";
 
 export default class FileDownloadServiceWeb extends FileDownloadService {
     isFileSystemAccessible = false;
-    private nextDownloadAt = 0;
-    private readonly DOWNLOAD_STAGGER_MS = 100;
 
     // TODO: Test this in unit tests
     public static isLocalPath(filePath: string): boolean {
@@ -24,8 +22,24 @@ export default class FileDownloadServiceWeb extends FileDownloadService {
 
     private static async fetchFileStream(path: string): Promise<ReadableStream<Uint8Array>> {
         const res = await fetch(path);
-        if (!res.ok || !res.body) throw new Error(`Failed to get .zarr file at ${path}`);
+        if (!res.ok || !res.body) throw new Error(`Failed to get file at ${path}`);
         return res.body;
+    }
+
+    /**
+     * Pick a unique name for a file's entry within a zip archive; selections can
+     * contain identically named files from different directories
+     */
+    private static toUniqueEntryName(name: string, usedEntryNames: Set<string>): string {
+        let entryName = name;
+        for (let attempt = 2; usedEntryNames.has(entryName); attempt += 1) {
+            const extensionIndex = name.lastIndexOf(".");
+            const base = extensionIndex > 0 ? name.slice(0, extensionIndex) : name;
+            const extension = extensionIndex > 0 ? name.slice(extensionIndex) : "";
+            entryName = `${base} (${attempt})${extension}`;
+        }
+        usedEntryNames.add(entryName);
+        return entryName;
     }
 
     public download(
@@ -39,6 +53,122 @@ export default class FileDownloadServiceWeb extends FileDownloadService {
         }
 
         return this.downloadFile(fileInfo);
+    }
+
+    /**
+     * Download multiple files as a single streamed ZIP archive. Browsers only allow one
+     * download per user gesture (additional ones are blocked behind Chrome's "download
+     * multiple files" permission prompt), so a multi-file selection must be bundled
+     * into one download.
+     */
+    public async downloadFilesAsZip(
+        files: FileInfo[],
+        downloadRequestId: string,
+        onProgress?: (transferredBytes: number) => void
+    ): Promise<DownloadResult> {
+        let totalBytesDownloaded = 0;
+        const downloader = new StreamedZipDownloader(
+            "biofile-finder-download",
+            (transferredBytes) => {
+                totalBytesDownloaded += transferredBytes;
+                onProgress?.(transferredBytes);
+            }
+        );
+
+        // Register cancellation token for this request
+        this.activeRequestMap[downloadRequestId] = {
+            cancel: () => {
+                void downloader.cancel();
+            },
+        };
+
+        const usedEntryNames = new Set<string>();
+        try {
+            for (const file of files) {
+                if (downloader.isCancelled) break;
+                const entryName = FileDownloadServiceWeb.toUniqueEntryName(
+                    file.name,
+                    usedEntryNames
+                );
+                if (isMultiObjectFile(file.path)) {
+                    if (FileDownloadServiceWeb.isLocalPath(file.path)) {
+                        this.downloadLocalDirectory(file); // throws with explanatory message
+                    }
+                    // Nest the directory's contents under its own folder within the zip
+                    for await (const relativeInnerPath of this.getRelativePathsInDirectory(
+                        file.path
+                    )) {
+                        await downloader.addFile(`${entryName}/${relativeInnerPath}`, () =>
+                            FileDownloadServiceWeb.fetchFileStream(
+                                `${file.path}/${relativeInnerPath}`
+                            )
+                        );
+                    }
+                } else {
+                    await downloader.addFile(entryName, () => this.getFileStream(file));
+                }
+            }
+            await downloader.end();
+        } catch (error) {
+            console.error("Failed to download files as zip", error);
+            await downloader.cancel();
+            throw error;
+        } finally {
+            // Cleanup after download finishes
+            delete this.activeRequestMap[downloadRequestId];
+        }
+
+        if (downloader.isCancelled) {
+            return {
+                downloadRequestId,
+                msg: "Download was cancelled.",
+                resolution: DownloadResolution.CANCELLED,
+            };
+        }
+
+        // Consider it a failure if we didn't download the amount of bytes we were expected to
+        const allSizesKnown = files.every((file) => file.size !== undefined);
+        const expectedBytes = files.reduce((sum, file) => sum + (file.size || 0), 0);
+        if (allSizesKnown && expectedBytes !== totalBytesDownloaded) {
+            const numberFormatter = annotationFormatterFactory(AnnotationType.NUMBER);
+            const expectedBytesWithUnits = numberFormatter.displayValue(expectedBytes, "bytes");
+            const totalBytesDownloadedWithUnits = numberFormatter.displayValue(
+                totalBytesDownloaded,
+                "bytes"
+            );
+            throw new Error(
+                `Expected to download ${expectedBytesWithUnits}, instead downloaded ${totalBytesDownloadedWithUnits} (${expectedBytes} vs ${totalBytesDownloaded}). This may indicate that some files either failed to download, couldn't be found, or were skipped.`
+            );
+        }
+
+        return {
+            downloadRequestId,
+            msg: `Successfully downloaded ${files.length} files as a ZIP file to your default downloads folder.`,
+            resolution: DownloadResolution.SUCCESS,
+        };
+    }
+
+    /**
+     * Resolve a single (non-directory) file to a readable stream of its contents
+     */
+    private async getFileStream(fileInfo: FileInfo): Promise<ReadableStream<Uint8Array>> {
+        const data = fileInfo.data || fileInfo.path;
+
+        if (data instanceof Uint8Array) {
+            const dataBlob = new Uint8Array(data.byteLength);
+            dataBlob.set(data);
+            return new Blob([dataBlob]).stream();
+        }
+        if (data instanceof Blob) {
+            return data.stream();
+        }
+        if (typeof data === "string") {
+            // See if the data is a URL that needs to be formatted
+            // this would be the case for S3 protocol URLs for example
+            const url = (await this.s3StorageService.formatAsHttpResource(data)) || data;
+            return FileDownloadServiceWeb.fetchFileStream(url);
+        }
+        throw new Error("Unsupported data type for download");
     }
 
     private downloadDirectory(
@@ -153,13 +283,6 @@ Please navigate to this directory manually, or upload files to a remote address 
             const a = document.createElement("a");
             a.href = downloadUrl;
             a.download = fileInfo.name;
-            // Stagger concurrent downloads
-            const now = Date.now();
-            const delay = Math.max(0, this.nextDownloadAt - now);
-            this.nextDownloadAt = Math.max(now, this.nextDownloadAt) + this.DOWNLOAD_STAGGER_MS;
-            if (delay > 0) {
-                await new Promise<void>((resolve) => setTimeout(resolve, delay));
-            }
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);

--- a/packages/web/src/services/FileDownloadServiceWeb.ts
+++ b/packages/web/src/services/FileDownloadServiceWeb.ts
@@ -98,6 +98,7 @@ export default class FileDownloadServiceWeb extends FileDownloadService {
                     for await (const relativeInnerPath of this.getRelativePathsInDirectory(
                         file.path
                     )) {
+                        if (downloader.isCancelled) break;
                         await downloader.addFile(`${entryName}/${relativeInnerPath}`, () =>
                             FileDownloadServiceWeb.fetchFileStream(
                                 `${file.path}/${relativeInnerPath}`
@@ -217,6 +218,7 @@ Please navigate to this directory manually, or upload files to a remote address 
 
         try {
             for await (const relativeInnerPath of this.getRelativePathsInDirectory(fileInfo.path)) {
+                if (downloader.isCancelled) break;
                 await downloader.addFile(relativeInnerPath, () =>
                     FileDownloadServiceWeb.fetchFileStream(`${fileInfo.path}/${relativeInnerPath}`)
                 );

--- a/packages/web/src/services/test/FileDownloadServiceWeb.test.ts
+++ b/packages/web/src/services/test/FileDownloadServiceWeb.test.ts
@@ -274,6 +274,146 @@ describe("FileDownloadServiceWeb", () => {
         });
     });
 
+    describe("downloadFilesAsZip", () => {
+        type WriterStub = {
+            write: (chunk: Uint8Array) => Promise<void>;
+            close: () => Promise<void>;
+        };
+
+        let originalCreateWriteStream: typeof streamSaver.createWriteStream;
+
+        beforeEach(() => {
+            originalCreateWriteStream = streamSaver.createWriteStream;
+            const writer: WriterStub = {
+                write: async () => undefined,
+                close: async () => undefined,
+            };
+
+            (streamSaver as {
+                createWriteStream: typeof streamSaver.createWriteStream;
+            }).createWriteStream = () =>
+                ({
+                    getWriter: () => (writer as unknown) as WritableStreamDefaultWriter<Uint8Array>,
+                } as WritableStream<Uint8Array>);
+        });
+
+        afterEach(() => {
+            (streamSaver as {
+                createWriteStream: typeof streamSaver.createWriteStream;
+            }).createWriteStream = originalCreateWriteStream;
+        });
+
+        it("bundles every file into a single zip, deduplicating entry names", async () => {
+            const service = new FileDownloadServiceWeb();
+            const files: FileInfo[] = [
+                {
+                    id: "id-1",
+                    name: "image.tiff",
+                    path: "https://example.org/a/image.tiff",
+                },
+                {
+                    id: "id-2",
+                    name: "image.tiff",
+                    path: "https://example.org/b/image.tiff",
+                },
+                {
+                    id: "id-3",
+                    name: "notes.txt",
+                    path: "https://example.org/notes.txt",
+                },
+            ];
+
+            const addFileStub = sinon.stub(StreamedZipDownloader.prototype, "addFile").resolves();
+            const endStub = sinon.stub(StreamedZipDownloader.prototype, "end").resolves();
+            const cancelStub = sinon.stub(StreamedZipDownloader.prototype, "cancel").resolves();
+
+            const result = await service.downloadFilesAsZip(files, "request-zip-1");
+
+            expect(addFileStub.callCount).to.equal(3);
+            expect(addFileStub.getCall(0).args[0]).to.equal("image.tiff");
+            expect(addFileStub.getCall(1).args[0]).to.equal("image (2).tiff");
+            expect(addFileStub.getCall(2).args[0]).to.equal("notes.txt");
+            expect(endStub.calledOnce).to.equal(true);
+            expect(cancelStub.called).to.equal(false);
+            expect(result.resolution).to.equal(DownloadResolution.SUCCESS);
+            expect(result.downloadRequestId).to.equal("request-zip-1");
+            expect(
+                ((service as unknown) as { activeRequestMap: Record<string, unknown> })
+                    .activeRequestMap["request-zip-1"]
+            ).to.equal(undefined);
+        });
+
+        it("nests multi-object (directory) files under their own folder in the zip", async () => {
+            const service = new FileDownloadServiceWeb();
+            const files: FileInfo[] = [
+                {
+                    id: "id-1",
+                    name: "dataset.zarr",
+                    path: "https://example.org/dataset.zarr",
+                },
+                {
+                    id: "id-2",
+                    name: "notes.txt",
+                    path: "https://example.org/notes.txt",
+                },
+            ];
+
+            const addFileStub = sinon.stub(StreamedZipDownloader.prototype, "addFile").resolves();
+            sinon.stub(StreamedZipDownloader.prototype, "end").resolves();
+            sinon.stub(StreamedZipDownloader.prototype, "cancel").resolves();
+
+            const pathsGenerator = (async function* () {
+                yield "0/zarr.json";
+                yield "0/c/0/0";
+            })();
+            sinon
+                .stub(
+                    (service as unknown) as {
+                        getRelativePathsInDirectory: (path: string) => AsyncGenerator<string>;
+                    },
+                    "getRelativePathsInDirectory"
+                )
+                .returns(pathsGenerator);
+
+            const result = await service.downloadFilesAsZip(files, "request-zip-2");
+
+            expect(addFileStub.callCount).to.equal(3);
+            expect(addFileStub.getCall(0).args[0]).to.equal("dataset.zarr/0/zarr.json");
+            expect(addFileStub.getCall(1).args[0]).to.equal("dataset.zarr/0/c/0/0");
+            expect(addFileStub.getCall(2).args[0]).to.equal("notes.txt");
+            expect(result.resolution).to.equal(DownloadResolution.SUCCESS);
+        });
+
+        it("throws when fewer bytes than expected were downloaded", async () => {
+            const service = new FileDownloadServiceWeb();
+            const files: FileInfo[] = [
+                {
+                    id: "id-1",
+                    name: "image.tiff",
+                    path: "https://example.org/image.tiff",
+                    size: 1024,
+                },
+                {
+                    id: "id-2",
+                    name: "notes.txt",
+                    path: "https://example.org/notes.txt",
+                    size: 512,
+                },
+            ];
+
+            sinon.stub(StreamedZipDownloader.prototype, "addFile").resolves();
+            sinon.stub(StreamedZipDownloader.prototype, "end").resolves();
+            sinon.stub(StreamedZipDownloader.prototype, "cancel").resolves();
+
+            try {
+                await service.downloadFilesAsZip(files, "request-zip-3");
+                throw new Error("Expected size mismatch to throw");
+            } catch (error) {
+                expect((error as Error).message).to.contain("1536 vs 0");
+            }
+        });
+    });
+
     describe("getDefaultDownloadDirectory", () => {
         it("throws because web implementation is not supported", async () => {
             const service = new FileDownloadServiceWeb();


### PR DESCRIPTION
Resolves #920

## Problem

Multi-file selections on web (chrome) only downloaded the first file. The rest were blocked behind Chrome's "download multiple files" permission prompt. The click stagger from #894/#901 didn't (and couldn't) fix this; it only appeared fixed on machines where the automatic-downloads permission had already been granted (like mine...)

## Solution

Zip Downloads! 

## Testing
Added unit tests for `downloadFilesAsZip`

- [x] Manual check multi-select download on web produces one ZIP
- [x] Cancel works
- [x] single file isnt zipped
- [x] desktop downloads seperate files 
- [x] multifile zip with zarrs works 

🤖 Generated with [Claude Code](https://claude.com/claude-code)