### PR TITLE
Change the number range picker default to overall max+1

### DIFF
--- a/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
+++ b/packages/core/components/AnnotationFilterForm/test/AnnotationFilterForm.test.tsx
@@ -307,9 +307,9 @@ describe("<AnnotationFilterForm />", () => {
             const minInput = await findByTestId("rangemin");
             const maxInput = await findByTestId("rangemax");
 
-            // Values are naturally sorted so rangemin gets the overall min and rangemax the max
+            // Values are naturally sorted so rangemin gets the overall min and rangemax the default max (overall max + 1)
             expect((minInput as HTMLInputElement).value).to.equal("-12");
-            expect((maxInput as HTMLInputElement).value).to.equal("10000000000");
+            expect((maxInput as HTMLInputElement).value).to.equal("10000000001");
         });
     });
 

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -45,6 +45,10 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
     const overallMax = React.useMemo(() => {
         return items.at(-1)?.value?.toString() ?? "";
     }, [items]);
+    // On component load, default to slightly more than max so that values aren't excluded
+    const defaultMax = React.useMemo(() => {
+        return overallMax ? (Number(overallMax) + 1).toString() : "";
+    }, [overallMax]);
     const overallMinDisplay = items[0]?.displayValue?.toString() ?? overallMin;
     const overallMaxDisplay = items.at(-1)?.displayValue?.toString() ?? overallMax;
 
@@ -52,15 +56,15 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
         extractValuesFromRangeOperatorFilterString(currentRange?.value).minValue ?? overallMin
     );
     const [searchMaxValue, setSearchMaxValue] = React.useState(
-        extractValuesFromRangeOperatorFilterString(currentRange?.value).maxValue ?? overallMax
+        extractValuesFromRangeOperatorFilterString(currentRange?.value).maxValue ?? defaultMax
     );
 
     // Instead of removing filter completely, reset to min and max and submit
     function onResetSearch() {
         setSearchMinValue(overallMin);
-        setSearchMaxValue(overallMax);
-        if (overallMin && overallMax) {
-            onSearch(`RANGE(${overallMin},${overallMax})`);
+        setSearchMaxValue(defaultMax);
+        if (overallMin && defaultMax) {
+            onSearch(`RANGE(${overallMin},${defaultMax})`);
         }
     }
 
@@ -70,7 +74,7 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
             maxValue: oldMaxValue,
         } = extractValuesFromRangeOperatorFilterString(currentRange?.value);
         const newMinValue = searchMinValue || oldMinValue || overallMin;
-        const newMaxValue = searchMaxValue || oldMaxValue || (Number(overallMax) + 1).toString(); // Ensure that actual max is not excluded
+        const newMaxValue = searchMaxValue || oldMaxValue || defaultMax; // Ensure that actual max is not excluded
         if (newMinValue && newMaxValue) {
             onSearch(`RANGE(${newMinValue},${newMaxValue})`);
         }
@@ -131,7 +135,6 @@ export default function NumberRangePicker(props: NumberRangePickerProps) {
                         label="Max (exclusive)"
                         onChange={onMaxChange}
                         min={Number(overallMin)}
-                        max={Number(overallMax)}
                     />
                     <div className={styles.resetButtonContainer}>
                         <TertiaryButton

--- a/packages/core/components/NumberRangePicker/index.tsx
+++ b/packages/core/components/NumberRangePicker/index.tsx
@@ -39,16 +39,10 @@ interface NumberRangePickerProps {
 export default function NumberRangePicker(props: NumberRangePickerProps) {
     const { errorMessage, items, loading, onSearch, currentRange, units } = props;
 
-    const overallMin = React.useMemo(() => {
-        return items[0]?.value?.toString() ?? "";
-    }, [items]);
-    const overallMax = React.useMemo(() => {
-        return items.at(-1)?.value?.toString() ?? "";
-    }, [items]);
+    const overallMin = items[0]?.value?.toString() ?? "";
+    const overallMax = items.at(-1)?.value?.toString() ?? "";
     // On component load, default to slightly more than max so that values aren't excluded
-    const defaultMax = React.useMemo(() => {
-        return overallMax ? (Number(overallMax) + 1).toString() : "";
-    }, [overallMax]);
+    const defaultMax = overallMax ? (Number(overallMax) + 1).toString() : "";
     const overallMinDisplay = items[0]?.displayValue?.toString() ?? overallMin;
     const overallMaxDisplay = items.at(-1)?.displayValue?.toString() ?? overallMax;
 

--- a/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
+++ b/packages/core/components/NumberRangePicker/test/NumberRangePicker.test.tsx
@@ -8,7 +8,7 @@ import NumberRangePicker, { ListItem } from "..";
 import FileFilter from "../../../entity/FileFilter";
 
 describe("<NumberRangePicker />", () => {
-    it("renders input fields for min and max values initialized to overall min/max", () => {
+    it("renders input fields for min and max values initialized to overall min and overall max + 1", () => {
         // Arrange
         const items: ListItem[] = ["0", "20"].map((val) => ({
             displayValue: val,
@@ -26,7 +26,7 @@ describe("<NumberRangePicker />", () => {
 
         // Should initialize to min and max item provided, respectively
         expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("0");
-        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("20");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("21");
     });
 
     it("initializes to values passed through props if provided", () => {
@@ -69,7 +69,7 @@ describe("<NumberRangePicker />", () => {
 
         // Should reset to min and max values
         expect(screen.getByTestId<HTMLInputElement>("rangemin").value).to.equal("0");
-        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("20");
+        expect(screen.getByTestId<HTMLInputElement>("rangemax").value).to.equal("21");
     });
 
     it("displays available min and max of items", () => {


### PR DESCRIPTION
## Context
The numeric range filter's maximum field was defaulting to the overall maximum, which meant that values were getting excluded when that default filter was applied.
closes #816 

## Changes
Keeps the filter behavior the same (inclusive min, exclusive max) but changes the default max value to overall maximum + 1 when the modal opens/resets. For example, if full range of values is [100, 101, 102, 103], then when the modal opens the fields will auto-populate with min (inclusive) = 100 and max (exclusive) = 104

Initially considered doing some step-size inference to account for the magnitude of the values (e.g., 0.001 for small values, 1 for integers), but it wasn't worth the effort vs impact trade-off for just a default field value. Also, + 1 was actually already the fallback behavior when the max field is empty, so it keeps the UI self-consistent 

## Testing
Manual testing + updated unit tests

## Note
We may eventually move towards inclusive/inclusive range filters (see #931), in which case this would just be a temporary fix for this component 