### PR TITLE
(Very small) Consider any filter incompatible with hierarchy filters of same name

### DIFF
--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -194,11 +194,7 @@ const useDirectoryHierarchy = (
                         // and also have filters applied for that field (e.g., barcode=1234, barcode=1357),
                         // then at the barcode=1234 group we should remove the barcode=1357 filter
                         const nonHierarchyFilters = selectedFileFilters.filter(
-                            (f) =>
-                                !(
-                                    take(hierarchy, depth + 1).includes(f.name) &&
-                                    f.type === FilterType.DEFAULT
-                                )
+                            (f) => !take(hierarchy, depth + 1).includes(f.name)
                         );
                         const filters = uniqWith(
                             [...hierarchyFilters, ...nonHierarchyFilters],


### PR DESCRIPTION
Small change to avoid letting filters like fuzzy/any/none filters override hierarchy filters when querying for files in a file set. Without this change the wider fuzzy search query for example is selected over the narrower equality filter from the hierarchy group.

**Before**
Note the "Lumenoid Condition" mismatch between the group and the actual value for the file
<img width="1728" height="724" alt="Screenshot 2026-09-01 at 12 01 43 PM" src="https://github.com/user-attachments/assets/2863e16f-10f3-4c2a-b8ed-b8d22cc4f89a" />

**After**
Note that only the groups themselves are filtered by the fuzzy filter rather than the files themselves since the group filter is narrower
<img width="1728" height="771" alt="Screenshot 2026-09-01 at 12 02 02 PM" src="https://github.com/user-attachments/assets/ecfff74b-ed6d-4bc3-893d-89abdd82ab22" />

