### PR TITLE
Stop inappropriately applying a flatten when the nested root is scalar

### DIFF
--- a/packages/core/entity/SQLBuilder/index.ts
+++ b/packages/core/entity/SQLBuilder/index.ts
@@ -187,7 +187,7 @@ export default class SQLBuilder {
         // Keep lambda variable names deterministic so generated SQL strings remain stable in tests.
         const lambdaVars = ["x", "y", "z", "w", "v", "u", "t", "s"];
         let nextLambdaVarIdx = 0;
-        let flattenLayers = 0;
+        let transformLayers = 0;
         const rootColumnExpr = `"${path[0]}"`;
         const isRootArray = pathIsArray[0];
 
@@ -202,6 +202,7 @@ export default class SQLBuilder {
                 // Root column: either list_transform("Root", var -> ...) for STRUCT[]
                 // or plain dot access for a scalar root struct.
                 if (isRootArray) {
+                    transformLayers++;
                     const lambdaVar = nextLambdaVar();
                     const innerExpr = buildFrom(1, lambdaVar);
                     return `list_transform(${rootColumnExpr}, ${lambdaVar} -> ${innerExpr})`;
@@ -215,10 +216,10 @@ export default class SQLBuilder {
                 return leafTransform(segmentExpr);
             }
 
-            // Intermediate array segment: add another transform layer and remember to
-            // flatten once after the recursive expression is built.
+            // Intermediate array segment: add another transform layer, which adds one more
+            // list level to unwrap once the recursive expression is built.
             if (pathIsArray[pathIndex]) {
-                flattenLayers++;
+                transformLayers++;
                 const lambdaVar = nextLambdaVar();
                 const innerExpr = buildFrom(pathIndex + 1, lambdaVar);
                 return `list_transform(${segmentExpr}, ${lambdaVar} -> ${innerExpr})`;
@@ -230,8 +231,8 @@ export default class SQLBuilder {
 
         let expr = buildFrom(0, "");
 
-        // Each intermediate array boundary adds one nested list layer to flatten.
-        for (let i = 0; i < flattenLayers; i++) {
+        // Each list_transform wraps the result in one more list layer.
+        for (let i = 1; i < transformLayers; i++) {
             expr = `flatten(${expr})`;
         }
 

--- a/packages/core/entity/SQLBuilder/test/SQLBuilder.test.ts
+++ b/packages/core/entity/SQLBuilder/test/SQLBuilder.test.ts
@@ -21,6 +21,15 @@ describe("SQLBuilder", () => {
             );
         });
 
+        it("does not flatten when a scalar root has a single array segment", () => {
+            expect(
+                SQLBuilder.buildNestedAccessExpression(
+                    ["Conditions", "Reagents", "Concentration"],
+                    [false, true, false]
+                )
+            ).to.equal(`list_transform("Conditions"."Reagents", x -> x."Concentration")`);
+        });
+
         // Rare case: a singular (non-array) struct at the root collapses to plain dot access.
         it("uses plain dot access when the root segment is a scalar struct", () => {
             expect(SQLBuilder.buildNestedAccessExpression(["Well", "Unit"], [false])).to.equal(


### PR DESCRIPTION
## Context
Noticed this console log when rendering a nested parquet:
```
app.2539f658fa269dd67564.js:2 Error in web worker:  Binder Error: No function matches the given name and argument types 'flatten(VARCHAR[])'. You might need to add explicit type casts.
	Candidate functions:
	flatten(T[][]) -> T[]


LINE 5:             WHERE (len(flatten(list_transform("Specimen & Experimental Conditions...
```

- after tracing it down, found that this is because the root is scalar and BFF is trying to apply a flatten to it (which is impossible)

## Changes
Stop applying flatten to scalar roots

## Testing
Ran the original nested parquet alongside a few others I have laying around and the error no longer reproduces - query values appear as expected as well.
