### PR TITLE
(Small) Attach descriptions for nested metadata

### DIFF
--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -1540,6 +1540,8 @@ export default abstract class DatabaseService {
                     // One flag per path segment (length === path.length)
                     const pathIsArray = [rootIsArray, ...field.isArray];
                     const fullPath = [columnName, ...fieldParts];
+                    const fullName = fullPath.join(".");
+                    const explicitFieldType = annotationNameToTypeMap[fullName];
                     // Create a NESTED (parent) annotation for each intermediate struct level
                     for (let depth = 1; depth < fullPath.length - 1; depth++) {
                         const ancestorPath = fullPath.slice(0, depth + 1);
@@ -1549,7 +1551,7 @@ export default abstract class DatabaseService {
                             annotations.push(
                                 new Annotation({
                                     annotationName: ancestorPath,
-                                    description: annotationNameToDescriptionMap[columnName] || "",
+                                    description: annotationNameToDescriptionMap[ancestorName] || "",
                                     type: AnnotationType.NESTED,
                                     pathIsArray: pathIsArray.slice(0, depth + 1),
                                 })
@@ -1559,8 +1561,12 @@ export default abstract class DatabaseService {
                     annotations.push(
                         new Annotation({
                             annotationName: fullPath,
-                            description: annotationNameToDescriptionMap[columnName] || "",
-                            type: DatabaseService.columnTypeToAnnotationType(field.type),
+                            description: annotationNameToDescriptionMap[fullName] || "",
+                            // A leaf is never NESTED itself, so ignore that override if declared
+                            type:
+                                explicitFieldType && explicitFieldType !== AnnotationType.NESTED
+                                    ? explicitFieldType
+                                    : DatabaseService.columnTypeToAnnotationType(field.type),
                             pathIsArray,
                         })
                     );


### PR DESCRIPTION
## Context
Descriptions were not rendering for nested parquets consistently. This was due to this mapping in the changeset not properly checking for the annotation based on the full ancestry path.

## Changes
Checks for presence of description based on full ancestry rather than leaf name.

## Testing
Used the following description CSV alongside other CSVs (such as those in the Data Source page).
[Uploading aics_bff_primary_images_slim_rembi_fully_nested_metadata_descriptor.csv…]()

