### PR TITLE
Avoid rendering empty sections

### DIFF
--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -109,12 +109,17 @@ function unwrapNestedMetadata(values: UnwrappedMetadataValue): MetadataValue {
 
     // Recursive case: values is an array of nested metadata objects
     if (!isEmpty(nested)) {
-        return nested.map((nestedValue) =>
-            Object.entries(nestedValue).reduce((acc, [key, value]) => {
-                const unwrappedValue = unwrapNestedMetadata(value);
-                if (isEmpty(unwrappedValue)) return acc;
-                return { ...acc, [key]: unwrappedValue };
-            }, {} as NestedMetadataValue)
+        return (
+            nested
+                .map((nestedValue) =>
+                    Object.entries(nestedValue).reduce((acc, [key, value]) => {
+                        const unwrappedValue = unwrapNestedMetadata(value);
+                        if (isEmpty(unwrappedValue)) return acc;
+                        return { ...acc, [key]: unwrappedValue };
+                    }, {} as NestedMetadataValue)
+                )
+                // Prevent entries that are wholly empty (i.e., `{}`) from rendering
+                .filter((unwrappedValue) => !isEmpty(unwrappedValue))
         );
     }
 

--- a/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
+++ b/packages/core/services/FileService/DatabaseFileService/test/DatabaseFileService.test.ts
@@ -63,6 +63,44 @@ describe("DatabaseFileService", () => {
             });
         });
 
+        it("omits a nested column whose sub-fields are all empty", async () => {
+            const rowsWithEmptyStruct = [
+                {
+                    [HIDDEN_UID_ANNOTATION]: "1",
+                    "File Name": "file",
+                    "Empty Category": { "Processing Date": null, "Analysis Scope": null },
+                    "Partly Empty Category": { "Processing Date": "2017-02-27", Notes: null },
+                    "Empty Entries": [{ Name: null }, { Name: "kept" }, { Name: "  " }],
+                },
+            ];
+            class MockStructDatabaseService extends DatabaseServiceNoop {
+                protected readonly existingDataSources = new Set(["parquet_source"]);
+                public query(): { promise: Promise<any> } {
+                    return { promise: Promise.resolve(rowsWithEmptyStruct) };
+                }
+                public async fetchAnnotations(): Promise<[]> {
+                    return [];
+                }
+            }
+            const databaseFileService = new DatabaseFileService({
+                dataSourceNames: ["parquet_source"],
+                databaseService: new MockStructDatabaseService(),
+                downloadService: new FileDownloadServiceNoop(),
+            });
+
+            const [file] = await databaseFileService.getFiles({
+                from: 0,
+                limit: 1,
+                fileSet: new FileSet(),
+            });
+
+            expect(Object.fromEntries(file.metadata)).to.deep.equal({
+                "File Name": ["file"],
+                "Partly Empty Category": [{ "Processing Date": ["2017-02-27"] }],
+                "Empty Entries": [{ Name: ["kept"] }],
+            });
+        });
+
         it("sorts parquets by hidden_bff_uid when offset is used", async () => {
             // Arrange
             const parquetFiles = [


### PR DESCRIPTION
## Context
It is possible for the database to return a nested object that is essentially empty (ex. "Sample": { "Processing Date": [], "Color": null } would have become "Sample": {} which would cause an empty section (see screenshot).

## Changes
Filter out sections that are wholly empty

### Before
<img width="417" height="81" alt="Screenshot 2026-09-01 at 12 58 06 PM" src="https://github.com/user-attachments/assets/78dd1b9e-1105-4d12-8101-27252cc1d0da" />


