### PR TITLE
Avoid error when annotations are loading

### DIFF
--- a/packages/core/components/FileDetails/MetadataList/Row.tsx
+++ b/packages/core/components/FileDetails/MetadataList/Row.tsx
@@ -36,6 +36,7 @@ export default function Row(props: Props) {
     const annotationNameToAnnotationMap = useSelector(
         metadata.selectors.getAnnotationNameToAnnotationMap
     );
+    const areAnnotationsLoaded = useSelector(metadata.selectors.areAnnotationsLoaded);
 
     const [isTextValueCollapsed, setIsTextValueCollapsed] = React.useState(true);
 
@@ -58,7 +59,7 @@ export default function Row(props: Props) {
 
     const pathLabel = path.join(" : ");
     React.useEffect(() => {
-        if (!annotation) {
+        if (!annotation && areAnnotationsLoaded) {
             dispatch(
                 interaction.actions.processError(
                     `<Row />-${pathLabel}`,
@@ -66,7 +67,7 @@ export default function Row(props: Props) {
                 )
             );
         }
-    }, [annotation, pathLabel, dispatch]);
+    }, [annotation, areAnnotationsLoaded, pathLabel, dispatch]);
 
     if (!annotation || text === null) {
         // Don't render anything for this metadata field (e.g. if it's still loading or if there is no value to show)

--- a/packages/core/components/FileDetails/MetadataList/test/MetadataList.test.tsx
+++ b/packages/core/components/FileDetails/MetadataList/test/MetadataList.test.tsx
@@ -144,6 +144,58 @@ describe("<MetadataList />", () => {
             );
         });
 
+        it("does not report a missing annotation while annotations are loading", () => {
+            // Arrange
+            const fileWithUnknownField = () =>
+                new FileDetail(
+                    {
+                        file_path: "path/to/MyFile.txt",
+                        file_id: "abc123",
+                        file_name: "MyFile.txt",
+                        file_size: 7,
+                        uploaded: "01/01/01",
+                        annotations: [{ name: "Unknown Field", values: ["some value"] }],
+                    },
+                    Environment.TEST
+                );
+
+            function renderWith(annotations: Annotation[]) {
+                const { store, actions } = configureMockStore({
+                    state: mergeState(initialState, {
+                        metadata: {
+                            annotations,
+                        },
+                        interaction: {
+                            platformDependentServices: {
+                                executionEnvService: new ExecutionEnvServiceNoop(),
+                            },
+                        },
+                    }),
+                });
+                render(
+                    <Provider store={store}>
+                        <MetadataList isLoading={false} file={fileWithUnknownField()} />
+                    </Provider>
+                );
+                return actions;
+            }
+
+            const isMissingMetadataError = (action: any) =>
+                JSON.stringify(action?.payload ?? "").includes(
+                    "Unable to find column metadata for field"
+                );
+
+            // (sanity-check) check if error is present first
+            let actions = renderWith(TOP_LEVEL_FILE_ANNOTATIONS);
+            expect(actions.list.filter(isMissingMetadataError)).to.not.be.empty;
+
+            // Act
+            actions = renderWith([]);
+
+            // Assert
+            expect(actions.list.filter(isMissingMetadataError)).to.be.empty;
+        });
+
         it("has loading message when file is downloading", async () => {
             // Arrange
             class FakeExecutionEnvService extends ExecutionEnvServiceNoop {

--- a/packages/core/components/FileDetails/MetadataList/test/MetadataList.test.tsx
+++ b/packages/core/components/FileDetails/MetadataList/test/MetadataList.test.tsx
@@ -144,58 +144,6 @@ describe("<MetadataList />", () => {
             );
         });
 
-        it("does not report a missing annotation while annotations are loading", () => {
-            // Arrange
-            const fileWithUnknownField = () =>
-                new FileDetail(
-                    {
-                        file_path: "path/to/MyFile.txt",
-                        file_id: "abc123",
-                        file_name: "MyFile.txt",
-                        file_size: 7,
-                        uploaded: "01/01/01",
-                        annotations: [{ name: "Unknown Field", values: ["some value"] }],
-                    },
-                    Environment.TEST
-                );
-
-            function renderWith(annotations: Annotation[]) {
-                const { store, actions } = configureMockStore({
-                    state: mergeState(initialState, {
-                        metadata: {
-                            annotations,
-                        },
-                        interaction: {
-                            platformDependentServices: {
-                                executionEnvService: new ExecutionEnvServiceNoop(),
-                            },
-                        },
-                    }),
-                });
-                render(
-                    <Provider store={store}>
-                        <MetadataList isLoading={false} file={fileWithUnknownField()} />
-                    </Provider>
-                );
-                return actions;
-            }
-
-            const isMissingMetadataError = (action: any) =>
-                JSON.stringify(action?.payload ?? "").includes(
-                    "Unable to find column metadata for field"
-                );
-
-            // (sanity-check) check if error is present first
-            let actions = renderWith(TOP_LEVEL_FILE_ANNOTATIONS);
-            expect(actions.list.filter(isMissingMetadataError)).to.not.be.empty;
-
-            // Act
-            actions = renderWith([]);
-
-            // Assert
-            expect(actions.list.filter(isMissingMetadataError)).to.be.empty;
-        });
-
         it("has loading message when file is downloading", async () => {
             // Arrange
             class FakeExecutionEnvService extends ExecutionEnvServiceNoop {

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -722,11 +722,12 @@ const refresh = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const { getState } = deps;
         const sources = selection.selectors.getSelectedDataSources(getState());
-        const hierarchy = selection.selectors.getAnnotationHierarchy(getState());
-        const annotationService = interactionSelectors.getAnnotationService(getState());
         const isStale = () => selection.selectors.getSelectedDataSources(getState()) !== sources;
 
         try {
+            const hierarchy = selection.selectors.getAnnotationHierarchy(getState());
+            const annotationService = interactionSelectors.getAnnotationService(getState());
+
             // Refresh list of annotations & which annotations are available
             const [annotations, availableAnnotations] = await Promise.all([
                 annotationService.fetchAnnotations(),

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -720,24 +720,26 @@ const showContextMenu = createLogic({
  */
 const refresh = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
-        try {
-            const { getState } = deps;
-            const hierarchy = selection.selectors.getAnnotationHierarchy(getState());
-            const sources = selection.selectors.getSelectedDataSources(getState());
-            const annotationService = interactionSelectors.getAnnotationService(getState());
+        const { getState } = deps;
+        const sources = selection.selectors.getSelectedDataSources(getState());
+        const hierarchy = selection.selectors.getAnnotationHierarchy(getState());
+        const annotationService = interactionSelectors.getAnnotationService(getState());
+        const isStale = () => selection.selectors.getSelectedDataSources(getState()) !== sources;
 
+        try {
             // Refresh list of annotations & which annotations are available
             const [annotations, availableAnnotations] = await Promise.all([
                 annotationService.fetchAnnotations(),
                 annotationService.fetchAvailableAnnotationsForHierarchy(hierarchy),
             ]);
             // A late response would overwrite the newer source's schema with this one's.
-            if (selection.selectors.getSelectedDataSources(getState()) !== sources) return;
+            if (isStale()) return;
             dispatch(metadata.actions.receiveAnnotations(annotations));
             dispatch(selection.actions.setAvailableAnnotations(availableAnnotations) as AnyAction);
         } catch (err) {
+            if (isStale()) return;
             console.error(`Error encountered while refreshing: ${err}`);
-            const annotations = metadata.selectors.getAnnotations(deps.getState());
+            const annotations = metadata.selectors.getAnnotations(getState());
             dispatch(
                 selection.actions.setAvailableAnnotations(
                     annotations.map((a) => a.name)

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -723,6 +723,7 @@ const refresh = createLogic({
         try {
             const { getState } = deps;
             const hierarchy = selection.selectors.getAnnotationHierarchy(getState());
+            const sources = selection.selectors.getSelectedDataSources(getState());
             const annotationService = interactionSelectors.getAnnotationService(getState());
 
             // Refresh list of annotations & which annotations are available
@@ -730,6 +731,8 @@ const refresh = createLogic({
                 annotationService.fetchAnnotations(),
                 annotationService.fetchAvailableAnnotationsForHierarchy(hierarchy),
             ]);
+            // A late response would overwrite the newer source's schema with this one's.
+            if (selection.selectors.getSelectedDataSources(getState()) !== sources) return;
             dispatch(metadata.actions.receiveAnnotations(annotations));
             dispatch(selection.actions.setAvailableAnnotations(availableAnnotations) as AnyAction);
         } catch (err) {

--- a/packages/core/state/interaction/test/logics.test.ts
+++ b/packages/core/state/interaction/test/logics.test.ts
@@ -40,7 +40,11 @@ import FileSet from "../../../entity/FileSet";
 import FileSelection from "../../../entity/FileSelection";
 import NumericRange from "../../../entity/NumericRange";
 import { RECEIVE_ANNOTATIONS } from "../../metadata/actions";
-import { SET_AVAILABLE_ANNOTATIONS } from "../../selection/actions";
+import {
+    changeDataSources,
+    CHANGE_DATA_SOURCES,
+    SET_AVAILABLE_ANNOTATIONS,
+} from "../../selection/actions";
 import FileDownloadService, {
     DownloadResolution,
     FileInfo,
@@ -1199,6 +1203,42 @@ describe("Interaction logics", () => {
                     payload: [expectedAnnotation.displayName],
                 })
             ).to.be.true;
+        });
+
+        it("drops a response that arrives after the data source changed", async () => {
+            // Arrange: a fetch resolved by hand, so the response lands after the source swap
+            let resolveFetch: (annotations: Annotation[]) => void = () => undefined;
+            sandbox.stub(interaction.selectors, "getAnnotationService").returns({
+                fetchAnnotations: () =>
+                    new Promise((resolve) => {
+                        resolveFetch = resolve;
+                    }),
+                fetchAvailableAnnotationsForHierarchy: () => Promise.resolve([]),
+            } as any);
+
+            const reducer = (state: any, action: any) =>
+                action.type === CHANGE_DATA_SOURCES
+                    ? { ...state, selection: { ...state.selection, dataSources: action.payload } }
+                    : state;
+
+            const { actions, store, logicMiddleware } = configureMockStore({
+                state: mergeState(initialState, {
+                    selection: { dataSources: [{ name: "source-a", type: "parquet" }] },
+                }),
+                reducer,
+                logics: interactionLogics,
+            });
+
+            // Act
+            store.dispatch(refresh());
+            await Promise.resolve(); // let the logic reach its await
+            store.dispatch(changeDataSources([{ name: "source-b", type: "parquet" }]) as any);
+            resolveFetch(annotations);
+            await logicMiddleware.whenComplete();
+
+            // Assert: source A's schema must not land on top of source B
+            expect(actions.includesMatch({ type: RECEIVE_ANNOTATIONS })).to.be.false;
+            expect(actions.includesMatch({ type: SET_AVAILABLE_ANNOTATIONS })).to.be.false;
         });
     });
 

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -41,6 +41,8 @@ const requestAnnotations = createLogic({
         const sources = selection.selectors.getSelectedDataSources(getState());
         const annotationService = interaction.selectors.getAnnotationService(getState());
         const applicationVersion = interaction.selectors.getApplicationVersion(getState());
+        const isStale = () => selection.selectors.getSelectedDataSources(getState()) !== sources;
+
         if (annotationService instanceof HttpAnnotationService) {
             if (applicationVersion) {
                 annotationService.setApplicationVersion(applicationVersion);
@@ -51,14 +53,17 @@ const requestAnnotations = createLogic({
         try {
             const annotations = await annotationService.fetchAnnotations();
             // A late response would overwrite the newer source's schema with this one's.
-            if (selection.selectors.getSelectedDataSources(getState()) !== sources) return;
+            if (isStale()) return;
             dispatch(receiveAnnotations(annotations));
         } catch (err) {
+            if (isStale()) return;
             console.error("Failed to fetch annotations", err);
             dispatch(
                 interaction.actions.processError(
                     "requestAnnotations",
-                    `Failed to load column metadata for ${sources}. ${err}`
+                    `Failed to load column metadata for ${sources
+                        .map((source) => source.name)
+                        .join(", ")}. ${err}`
                 )
             );
         } finally {

--- a/packages/core/state/metadata/logics.ts
+++ b/packages/core/state/metadata/logics.ts
@@ -38,6 +38,7 @@ import HttpAnnotationService from "../../services/AnnotationService/HttpAnnotati
 const requestAnnotations = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const { getState, httpClient } = deps;
+        const sources = selection.selectors.getSelectedDataSources(getState());
         const annotationService = interaction.selectors.getAnnotationService(getState());
         const applicationVersion = interaction.selectors.getApplicationVersion(getState());
         if (annotationService instanceof HttpAnnotationService) {
@@ -49,9 +50,17 @@ const requestAnnotations = createLogic({
 
         try {
             const annotations = await annotationService.fetchAnnotations();
+            // A late response would overwrite the newer source's schema with this one's.
+            if (selection.selectors.getSelectedDataSources(getState()) !== sources) return;
             dispatch(receiveAnnotations(annotations));
         } catch (err) {
             console.error("Failed to fetch annotations", err);
+            dispatch(
+                interaction.actions.processError(
+                    "requestAnnotations",
+                    `Failed to load column metadata for ${sources}. ${err}`
+                )
+            );
         } finally {
             done();
         }

--- a/packages/core/state/metadata/reducer.ts
+++ b/packages/core/state/metadata/reducer.ts
@@ -1,5 +1,6 @@
 import { makeReducer } from "@aics/redux-utils";
 
+import { CHANGE_DATA_SOURCES } from "../selection/actions";
 import Annotation from "../../entity/Annotation";
 import { EdgeDefinition } from "../../entity/Graph";
 import { DataSource } from "../../services/DataSourceService";
@@ -33,6 +34,10 @@ export default makeReducer<MetadataStateBranch>(
         [RECEIVE_ANNOTATIONS]: (state, action) => ({
             ...state,
             annotations: action.payload,
+        }),
+        [CHANGE_DATA_SOURCES]: (state) => ({
+            ...state,
+            annotations: [],
         }),
         [RECEIVE_DATA_SOURCES]: (state, action) => ({
             ...state,

--- a/packages/core/state/metadata/test/logics.test.ts
+++ b/packages/core/state/metadata/test/logics.test.ts
@@ -16,6 +16,8 @@ import {
 import metadataLogics from "../logics";
 import { initialState, interaction } from "../../";
 import {
+    changeDataSources,
+    CHANGE_DATA_SOURCES,
     SET_COLUMNS,
     SET_FILE_FILTERS,
     SET_HAS_USER_SELECTED_COLUMNS,
@@ -59,6 +61,50 @@ describe("Metadata logics", () => {
 
             // assert
             expect(actions.includesMatch({ type: RECEIVE_ANNOTATIONS })).to.be.true;
+        });
+
+        it("drops a response that arrives after the data source changed", async () => {
+            // Arrange: a fetch resolved by hand, so the response lands after the source swap
+            let resolveFetch: (annotations: Annotation[]) => void = () => undefined;
+            class SlowDatabaseService extends DatabaseServiceNoop {
+                public fetchAnnotations(): Promise<Annotation[]> {
+                    return new Promise((resolve) => {
+                        resolveFetch = resolve;
+                    });
+                }
+            }
+
+            const reducer = (state: any, action: any) =>
+                action.type === CHANGE_DATA_SOURCES
+                    ? { ...state, selection: { ...state.selection, dataSources: action.payload } }
+                    : state;
+
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state: mergeState(initialState, {
+                    selection: { dataSources: [{ name: "source-a", type: "parquet" }] },
+                    interaction: {
+                        platformDependentServices: { databaseService: new SlowDatabaseService() },
+                    },
+                }),
+                reducer,
+                logics: metadataLogics,
+            });
+
+            // Act
+            store.dispatch(requestAnnotations());
+            await Promise.resolve(); // let the logic reach its await
+            store.dispatch(changeDataSources([{ name: "source-b", type: "parquet" }]) as any);
+            resolveFetch([
+                new Annotation({
+                    annotationName: "Only On Source A",
+                    description: "",
+                    type: AnnotationType.STRING,
+                }),
+            ]);
+            await logicMiddleware.whenComplete();
+
+            // Assert: source A's schema must not land on top of source B
+            expect(actions.includesMatch({ type: RECEIVE_ANNOTATIONS })).to.be.false;
         });
     });
 

--- a/packages/core/state/metadata/test/reducer.test.ts
+++ b/packages/core/state/metadata/test/reducer.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+
+import { receiveAnnotations } from "../actions";
+import reducer, { initialState } from "../reducer";
+import { changeDataSources } from "../../selection/actions";
+import Annotation from "../../../entity/Annotation";
+import { AnnotationType } from "../../../entity/AnnotationFormatter";
+
+describe("Metadata reducer", () => {
+    const annotation = new Annotation({
+        annotationName: "Cell Line",
+        description: "",
+        type: AnnotationType.STRING,
+    });
+
+    describe("CHANGE_DATA_SOURCES", () => {
+        it("clears annotations so they cannot be read as the new source's schema", () => {
+            const loaded = reducer(initialState, receiveAnnotations([annotation]));
+            expect(loaded.annotations).to.have.lengthOf(1);
+
+            const state = reducer(loaded, changeDataSources([]));
+            expect(state.annotations).to.be.empty;
+        });
+    });
+
+    describe("RECEIVE_ANNOTATIONS", () => {
+        it("populates annotations for the new source", () => {
+            // Arrange
+            // (sanity-check) check if annotations are empty first
+            expect(initialState.annotations).to.be.empty;
+
+            // Act
+            const state = reducer(initialState, receiveAnnotations([annotation]));
+
+            // Assert
+            expect(state.annotations).to.deep.equal([annotation]);
+        });
+    });
+});


### PR DESCRIPTION
## Context
The error seen below occurs when switching data sources (or sometimes on refreshing). Due to this being a race between the renderer and the db query it isn't seen consistently, but the steps to reproduce are below the screenshot
<img width="748" height="553" alt="Screenshot 2026-09-01 at 2 21 03 PM" src="https://github.com/user-attachments/assets/19b90e73-87e7-4119-8194-327db6edbcfd" />

### How to reproduce

- Set up two queries on parquets with different schemas (the more different the better)
- Select a file so the details pane is populated, then switch to the other query. changeQueryLogic dispatches changeDataSources in its first batch (files start loading immediately), but requestAnnotations only fires later so the file is compared against the old schema thereby rendering an error.
- Watch the error notifications: Unable to find column metadata for field "<Section> : <Field>"

Or you can hard-reload with a local query source already selected. Annotations start as [], so if the file details pane paints first, every top-level field in every section errors at once. Throttling the network in devtools makes this reliable.

## Changes
Clear annotations when data sources change and in the component check if the annotations are loaded before considering anything an error.

## Testing
Tested using steps above across several data sources (downloading any of the data sources from the data source page works with this too)
