### PR TITLE
De-duplicate indexes on reselection

### DIFF
--- a/packages/core/entity/FileSelection/index.ts
+++ b/packages/core/entity/FileSelection/index.ts
@@ -238,16 +238,23 @@ export default class FileSelection {
         const { fileSet, sortOrder, indexToFocus = indexRange.max } = params;
 
         // if `indexRange` contains already selected file rows, compact
-        const compacted = reject(this.selections, (existingSelectionItem) => {
+        const overlapping = this.selections.filter((existingSelectionItem) => {
             return (
                 fileSet.equals(existingSelectionItem.fileSet) &&
-                indexRange.contains(existingSelectionItem.selection)
+                (indexRange.intersects(existingSelectionItem.selection) ||
+                    indexRange.abuts(existingSelectionItem.selection))
             );
         });
+        const compacted = reject(this.selections, (existingSelectionItem) =>
+            overlapping.includes(existingSelectionItem)
+        );
 
         const item: SelectionItem = {
             fileSet,
-            selection: indexRange,
+            selection: overlapping.reduce(
+                (range, existingSelectionItem) => range.union(existingSelectionItem.selection),
+                indexRange
+            ),
             sortOrder,
         };
 

--- a/packages/core/entity/FileSelection/test/FileSelection.test.ts
+++ b/packages/core/entity/FileSelection/test/FileSelection.test.ts
@@ -79,6 +79,43 @@ describe("FileSelection", () => {
             ).to.equal(true);
         });
 
+        it("does not double count file rows that are already selected", () => {
+            // Arrange
+            const fileSet = new FileSet();
+            const selection = new FileSelection().select({
+                fileSet,
+                index: new NumericRange(5, 14),
+                sortOrder: 0,
+            });
+
+            // Act: re-select a file row within the existing selection
+            const nextSelection = selection.select({ fileSet, index: 13, sortOrder: 0 });
+
+            // Assert
+            expect(nextSelection.count()).to.equal(10);
+            expect(nextSelection.getFocusedItemIndices().indexAcrossAllSelections).to.equal(8);
+        });
+
+        it("combines a new selection with a selection it abuts", () => {
+            // Arrange
+            const fileSet = new FileSet();
+            const selection = new FileSelection().select({
+                fileSet,
+                index: new NumericRange(5, 14),
+                sortOrder: 0,
+            });
+
+            // Act: extend the existing selection by one file row
+            const nextSelection = selection.select({ fileSet, index: 4, sortOrder: 0 });
+
+            // Assert
+            expect(nextSelection.count()).to.equal(11);
+            expect(nextSelection.getFocusedItemIndices().indexAcrossAllSelections).to.equal(0);
+            [4, 5, 14].forEach((idx) => {
+                expect(nextSelection.isSelected(fileSet, idx)).to.equal(true);
+            });
+        });
+
         it("makes the new selection focused", () => {
             // Arrange
             const selection = new FileSelection();


### PR DESCRIPTION
## Context
Lyndsay found a bug (resolves #874)
>If you select multiple files, then hold SHIFT+ Up arrow key to "page" through selected files, the counter total number math becomes wrong. So, 9/10 ends up being 9/11.

## Description
Essentially, the index range did account for duplicates when they are wholly subsets not partial subsets so when Lyndsay did the action above a partial range was added in duplicate.

## Testing
Seems fine locally, unit tests added to cover this

## Before
https://www.awesomescreenshot.com/video/56216061?key=5ac80b03c73bf6c7aa1f7efd3799aac2

## After

https://github.com/user-attachments/assets/799116e4-a9e1-4623-ac02-66b6c00323a0

